### PR TITLE
Fix #12: re-extract OverlayServiceLogic and add unit tests

### DIFF
--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -1,5 +1,6 @@
 package com.gb4pc.service
 
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.Service
@@ -39,9 +40,7 @@ class OverlayService : Service() {
     private lateinit var overlayManager: OverlayManager
     private lateinit var cameraState: CameraState
     private lateinit var handler: Handler
-
-    private var deactivateRunnable: Runnable? = null
-    private var isOverlayActive = false
+    private lateinit var logic: OverlayServiceLogic
 
     // H7: Track registration state to avoid re-registering on each onStartCommand
     private var callbackRegistered = false
@@ -55,19 +54,12 @@ class OverlayService : Service() {
     private val cameraCallback = object : CameraManager.AvailabilityCallback() {
         override fun onCameraUnavailable(cameraId: String) {
             DebugLog.log("Camera $cameraId unavailable")
-            cameraState.setCameraUnavailable(cameraId)
-            cancelPendingDeactivation()
-            evaluateForeground()
+            logic.onCameraUnavailable(cameraId)
         }
 
         override fun onCameraAvailable(cameraId: String) {
             DebugLog.log("Camera $cameraId available")
-            cameraState.setCameraAvailable(cameraId)
-
-            // DT-04/DT-05: Only deactivate if ALL cameras available, with debounce
-            if (cameraState.areAllCamerasAvailable()) {
-                scheduleDeactivation()
-            }
+            logic.onCameraAvailable(cameraId)
         }
     }
 
@@ -80,6 +72,32 @@ class OverlayService : Service() {
         prefsManager = PrefsManager(this)
         overlayManager = OverlayManager(this, prefsManager)
         cameraState = CameraState()
+        val km = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+        logic = OverlayServiceLogic(
+            hasUsageStatsPermission = { PermissionHelper.hasUsageStatsPermission(this) },
+            hasOverlayPermission = { PermissionHelper.hasOverlayPermission(this) },
+            overlayManager = overlayManager,
+            cameraState = cameraState,
+            foregroundDetector = foregroundDetector,
+            sessionTracker = SessionTracker.instance,
+            handler = handler,
+            onUsageAccessLost = {
+                postPermissionNotification(
+                    Constants.NOTIFICATION_PERMISSION_ID,
+                    getString(R.string.notification_usage_access_lost)
+                )
+            },
+            onOverlayPermissionLost = {
+                postPermissionNotification(
+                    Constants.NOTIFICATION_PERMISSION_ID,
+                    getString(R.string.notification_overlay_lost)
+                )
+            },
+            isKeyguardLocked = { km.isKeyguardLocked },
+            onRegisterMediaObserver = ::registerMediaObserver,
+            onUnregisterMediaObserver = ::unregisterMediaObserver,
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -106,7 +124,7 @@ class OverlayService : Service() {
 
     override fun onDestroy() {
         DebugLog.log("Service destroyed")
-        cancelPendingDeactivation()
+        logic.reset()
         if (callbackRegistered) {
             cameraManager.unregisterAvailabilityCallback(cameraCallback)
             callbackRegistered = false
@@ -115,7 +133,6 @@ class OverlayService : Service() {
         unregisterMediaObserver()
         overlayManager.hide()
         cameraState.reset()
-        isOverlayActive = false
         super.onDestroy()
     }
 
@@ -166,7 +183,7 @@ class OverlayService : Service() {
     // H3: When screen turns off while overlay is active but session not started, start session
     private fun onScreenOff() {
         DebugLog.log("Screen off received")
-        if (isOverlayActive && !SessionTracker.instance.isSessionActive) {
+        if (logic.isOverlayActive && !SessionTracker.instance.isSessionActive) {
             SessionTracker.instance.startSession()
             registerMediaObserver()
             DebugLog.log("Secure camera session started on screen off")
@@ -181,59 +198,6 @@ class OverlayService : Service() {
             unregisterMediaObserver()
             DebugLog.log("Secure camera session ended on device unlock")
         }
-    }
-
-    /**
-     * DT-02/DT-03: Check if Pixel Camera is the foreground app.
-     */
-    private fun evaluateForeground() {
-        if (!PermissionHelper.hasUsageStatsPermission(this)) {
-            DebugLog.log("Usage stats permission missing — hiding overlay (PM-03)")
-            if (isOverlayActive) {
-                overlayManager.hide()
-                isOverlayActive = false
-                postPermissionNotification(
-                    Constants.NOTIFICATION_PERMISSION_ID,
-                    getString(R.string.notification_usage_access_lost)
-                )
-            }
-            return
-        }
-
-        val foregroundPackage = foregroundDetector.getForegroundPackage()
-        DebugLog.log("Foreground app: $foregroundPackage")
-
-        if (ForegroundDetector.isPixelCameraPackage(foregroundPackage)) {
-            if (!isOverlayActive) {
-                showOverlay()
-            }
-        } else {
-            // Not Pixel Camera — do nothing (DT-03, EC-07)
-            // The overlay will be hidden via the deactivation path when camera is released
-        }
-    }
-
-    private fun showOverlay() {
-        if (!PermissionHelper.hasOverlayPermission(this)) {
-            DebugLog.log("Overlay permission missing (PM-04)")
-            postPermissionNotification(
-                Constants.NOTIFICATION_PERMISSION_ID,
-                getString(R.string.notification_overlay_lost)
-            )
-            return
-        }
-        DebugLog.log("Showing overlay")
-        overlayManager.show()
-        isOverlayActive = true
-
-        // SF-01: Start secure session if device is locked at the moment overlay activates
-        val km = getSystemService(Context.KEYGUARD_SERVICE) as android.app.KeyguardManager
-        if (km.isKeyguardLocked) {
-            SessionTracker.instance.startSession()
-            registerMediaObserver()
-            DebugLog.log("Secure camera session started (device already locked)")
-        }
-        // H3: If device is not locked now, onScreenOff() will start the session when it locks
     }
 
     // H4: Register ContentObserver on session start (SF-03)
@@ -317,34 +281,6 @@ class OverlayService : Service() {
             }
         }
         return null
-    }
-
-    /**
-     * DT-04: Schedule overlay deactivation with debounce delay.
-     */
-    private fun scheduleDeactivation() {
-        cancelPendingDeactivation()
-        deactivateRunnable = Runnable {
-            if (cameraState.areAllCamerasAvailable()) {
-                DebugLog.log("Deactivating overlay (all cameras available)")
-                overlayManager.hide()
-                isOverlayActive = false
-                // SF-01: End secure session on overlay deactivation
-                if (SessionTracker.instance.isSessionActive) {
-                    SessionTracker.instance.endSession()
-                    unregisterMediaObserver()
-                    DebugLog.log("Secure camera session ended")
-                }
-            }
-        }
-        handler.postDelayed(deactivateRunnable!!, Constants.CAMERA_DEBOUNCE_MS)
-    }
-
-    private fun cancelPendingDeactivation() {
-        deactivateRunnable?.let {
-            handler.removeCallbacks(it)
-            deactivateRunnable = null
-        }
     }
 
     private fun buildNotification(): Notification {

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -1,0 +1,125 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.Constants
+import com.gb4pc.overlay.OverlayManager
+import com.gb4pc.viewer.SessionTracker
+
+/**
+ * Core overlay activation / deactivation logic extracted for unit-testability.
+ *
+ * All Android-framework side-effects are accessed only through constructor lambdas,
+ * so this class can be exercised in plain JVM unit tests without Robolectric.
+ *
+ * Wired to [OverlayService] via constructor injection in onCreate().
+ */
+class OverlayServiceLogic(
+    private val hasUsageStatsPermission: () -> Boolean,
+    private val hasOverlayPermission: () -> Boolean,
+    private val overlayManager: OverlayManager,
+    private val cameraState: CameraState,
+    private val foregroundDetector: ForegroundDetector,
+    private val sessionTracker: SessionTracker,
+    private val handler: Handler,
+    private val debounceMs: Long = Constants.CAMERA_DEBOUNCE_MS,
+    /** Called when usage-stats permission is lost while the overlay is active (PM-03). */
+    private val onUsageAccessLost: () -> Unit,
+    /** Called when the overlay DRAW_OVERLAYS permission is missing on showOverlay() (PM-04). */
+    private val onOverlayPermissionLost: () -> Unit,
+    private val isKeyguardLocked: () -> Boolean,
+    private val onRegisterMediaObserver: () -> Unit,
+    private val onUnregisterMediaObserver: () -> Unit,
+) {
+    var isOverlayActive: Boolean = false
+        private set
+
+    private var deactivateRunnable: Runnable? = null
+
+    // ── Camera callback delegation ──────────────────────────────────────────
+
+    fun onCameraUnavailable(cameraId: String) {
+        cameraState.setCameraUnavailable(cameraId)
+        cancelPendingDeactivation()
+        evaluateForeground()
+    }
+
+    fun onCameraAvailable(cameraId: String) {
+        cameraState.setCameraAvailable(cameraId)
+        // DT-04/DT-05: Only schedule deactivation when ALL cameras have been released
+        if (cameraState.areAllCamerasAvailable()) {
+            scheduleDeactivation()
+        }
+    }
+
+    // ── Core logic ──────────────────────────────────────────────────────────
+
+    /**
+     * DT-02/DT-03: Check if Pixel Camera is the foreground app and show/hide overlay.
+     */
+    fun evaluateForeground() {
+        if (!hasUsageStatsPermission()) {
+            if (isOverlayActive) {
+                overlayManager.hide()
+                isOverlayActive = false
+                onUsageAccessLost()
+            }
+            return
+        }
+
+        val pkg = foregroundDetector.getForegroundPackage()
+        if (ForegroundDetector.isPixelCameraPackage(pkg) && !isOverlayActive) {
+            showOverlay()
+        }
+    }
+
+    /**
+     * PM-04 / SF-01: Show the overlay, guarding against missing permissions.
+     * Starts a secure session if the device is already locked at activation time.
+     */
+    fun showOverlay() {
+        if (!hasOverlayPermission()) {
+            onOverlayPermissionLost()
+            return
+        }
+        overlayManager.show()
+        isOverlayActive = true
+
+        // SF-01: If device is locked at activation time, begin a secure session immediately.
+        // H3: If unlocked, onScreenOff() will start the session when the screen locks.
+        if (isKeyguardLocked()) {
+            sessionTracker.startSession()
+            onRegisterMediaObserver()
+        }
+    }
+
+    /**
+     * DT-04: Schedule overlay deactivation with a debounce delay.
+     */
+    fun scheduleDeactivation() {
+        cancelPendingDeactivation()
+        deactivateRunnable = Runnable {
+            if (cameraState.areAllCamerasAvailable()) {
+                overlayManager.hide()
+                isOverlayActive = false
+                if (sessionTracker.isSessionActive) {
+                    sessionTracker.endSession()
+                    onUnregisterMediaObserver()
+                }
+            }
+        }
+        handler.postDelayed(deactivateRunnable!!, debounceMs)
+    }
+
+    fun cancelPendingDeactivation() {
+        deactivateRunnable?.let {
+            handler.removeCallbacks(it)
+            deactivateRunnable = null
+        }
+    }
+
+    /** Called from onDestroy to clean up mutable state. */
+    fun reset() {
+        cancelPendingDeactivation()
+        isOverlayActive = false
+    }
+}

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -1,0 +1,262 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.Constants
+import com.gb4pc.overlay.OverlayManager
+import com.gb4pc.viewer.SessionTracker
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+/**
+ * Unit tests for [OverlayServiceLogic] covering the five scenarios originally exercised by
+ * the now-deleted OverlayServiceLogicTest and called out in issue #12.
+ *
+ * All Android-framework dependencies are replaced by mocks or simple lambda flags, so these
+ * tests run on the plain JVM without Robolectric.
+ */
+class OverlayServiceLogicTest {
+
+    // ── Mocked collaborators ────────────────────────────────────────────────
+    private lateinit var overlayManager: OverlayManager
+    private lateinit var foregroundDetector: ForegroundDetector
+    private lateinit var sessionTracker: SessionTracker
+    private lateinit var handler: Handler
+
+    // CameraState is used as a real object — it has no Android deps
+    private lateinit var cameraState: CameraState
+
+    // ── Lambda state flags ──────────────────────────────────────────────────
+    private var usageStatsPermission = true
+    private var overlayPermission = true
+    private var keyguardLocked = false
+
+    private var usageAccessLostCount = 0
+    private var overlayLostCount = 0
+    private var mediaObserverRegistered = false
+
+    // ── Subject under test ──────────────────────────────────────────────────
+    private lateinit var logic: OverlayServiceLogic
+
+    @Before
+    fun setUp() {
+        overlayManager = mock()
+        foregroundDetector = mock()
+        sessionTracker = mock()
+        handler = mock()
+        cameraState = CameraState()
+
+        usageStatsPermission = true
+        overlayPermission = true
+        keyguardLocked = false
+        usageAccessLostCount = 0
+        overlayLostCount = 0
+        mediaObserverRegistered = false
+
+        logic = OverlayServiceLogic(
+            hasUsageStatsPermission = { usageStatsPermission },
+            hasOverlayPermission = { overlayPermission },
+            overlayManager = overlayManager,
+            cameraState = cameraState,
+            foregroundDetector = foregroundDetector,
+            sessionTracker = sessionTracker,
+            handler = handler,
+            debounceMs = 0L, // keep handler calls synchronous-looking in tests
+            onUsageAccessLost = { usageAccessLostCount++ },
+            onOverlayPermissionLost = { overlayLostCount++ },
+            isKeyguardLocked = { keyguardLocked },
+            onRegisterMediaObserver = { mediaObserverRegistered = true },
+            onUnregisterMediaObserver = { mediaObserverRegistered = false },
+        )
+    }
+
+    // ── DT-05: multi-camera ─────────────────────────────────────────────────
+
+    /**
+     * A second onCameraUnavailable for a different camera while the overlay is active must
+     * not prematurely deactivate it.  Only once the LAST tracked camera becomes available
+     * should a deactivation be scheduled.
+     */
+    @Test
+    fun `DT-05 second camera unavailable does not schedule deactivation`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        // Camera 0 in use → overlay activates
+        logic.onCameraUnavailable("0")
+        assertTrue("Overlay should be active after camera 0 unavailable", logic.isOverlayActive)
+
+        // Camera 1 also in use — no deactivation should be scheduled
+        logic.onCameraUnavailable("1")
+        assertTrue("Overlay should remain active while camera 1 is also in use", logic.isOverlayActive)
+        verify(handler, never()).postDelayed(any(), any())
+
+        // Camera 0 released but camera 1 still in use → still no deactivation
+        logic.onCameraAvailable("0")
+        verify(handler, never()).postDelayed(any(), any())
+        assertTrue("Overlay should still be active while camera 1 is in use", logic.isOverlayActive)
+
+        // Camera 1 released — all cameras available → deactivation scheduled
+        logic.onCameraAvailable("1")
+        verify(handler, times(1)).postDelayed(any(), eq(0L))
+    }
+
+    @Test
+    fun `DT-05 deactivation runnable hides overlay only when all cameras available`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        logic.onCameraUnavailable("0")
+        assertTrue(logic.isOverlayActive)
+
+        logic.onCameraAvailable("0")
+
+        // Capture and run the deactivation runnable
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(0L))
+        runnableCaptor.firstValue.run()
+
+        assertFalse("Overlay should be hidden after deactivation runnable executes", logic.isOverlayActive)
+        verify(overlayManager).hide()
+    }
+
+    // ── Idempotent activation ───────────────────────────────────────────────
+
+    /**
+     * Calling evaluateForeground() multiple times while Pixel Camera is already the foreground
+     * app must not show the overlay more than once.
+     */
+    @Test
+    fun `idempotent - evaluateForeground multiple times shows overlay exactly once`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        logic.evaluateForeground()
+        logic.evaluateForeground()
+        logic.evaluateForeground()
+
+        verify(overlayManager, times(1)).show()
+        assertTrue(logic.isOverlayActive)
+    }
+
+    /**
+     * Calling evaluateForeground() again while the overlay is already active must not
+     * register a duplicate media observer.
+     */
+    @Test
+    fun `idempotent - evaluateForeground does not re-register media observer when already active`() {
+        keyguardLocked = true
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        logic.evaluateForeground()
+        assertTrue(mediaObserverRegistered)
+
+        // Call again — observer must not be registered a second time
+        var registrationCount = 0
+        val logic2 = OverlayServiceLogic(
+            hasUsageStatsPermission = { true },
+            hasOverlayPermission = { true },
+            overlayManager = overlayManager,
+            cameraState = cameraState,
+            foregroundDetector = foregroundDetector,
+            sessionTracker = sessionTracker,
+            handler = handler,
+            debounceMs = 0L,
+            onUsageAccessLost = {},
+            onOverlayPermissionLost = {},
+            isKeyguardLocked = { keyguardLocked },
+            onRegisterMediaObserver = { registrationCount++ },
+            onUnregisterMediaObserver = {},
+        )
+        logic2.evaluateForeground()
+        logic2.evaluateForeground()
+        logic2.evaluateForeground()
+
+        assertEquals("Media observer should be registered exactly once", 1, registrationCount)
+    }
+
+    // ── Usage-stats permission revocation ───────────────────────────────────
+
+    /**
+     * If hasUsageStatsPermission returns false during evaluateForeground while the overlay is
+     * active, the overlay is hidden and the usage-access-lost notification is fired.
+     */
+    @Test
+    fun `usage stats revoked while overlay active hides overlay and fires notification`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+
+        // Revoke permission and evaluate again
+        usageStatsPermission = false
+        logic.evaluateForeground()
+
+        verify(overlayManager).hide()
+        assertFalse("Overlay should be inactive after permission revocation", logic.isOverlayActive)
+        assertEquals("Usage-access-lost notification should fire once", 1, usageAccessLostCount)
+    }
+
+    /**
+     * If the overlay is not active when usage-stats permission is missing, no notification
+     * is fired and hide() is not called.
+     */
+    @Test
+    fun `usage stats missing when overlay inactive does not fire notification`() {
+        usageStatsPermission = false
+        logic.evaluateForeground()
+
+        assertEquals(0, usageAccessLostCount)
+        verify(overlayManager, never()).hide()
+        assertFalse(logic.isOverlayActive)
+    }
+
+    // ── Overlay permission loss ─────────────────────────────────────────────
+
+    /**
+     * If hasOverlayPermission returns false, the overlay-lost notification fires without
+     * changing isOverlayActive (it remains false / unchanged).
+     */
+    @Test
+    fun `showOverlay with missing overlay permission fires notification and leaves isOverlayActive false`() {
+        overlayPermission = false
+        logic.showOverlay()
+
+        assertEquals("Overlay-lost notification should fire once", 1, overlayLostCount)
+        assertFalse("isOverlayActive must remain false", logic.isOverlayActive)
+        verify(overlayManager, never()).show()
+    }
+
+    @Test
+    fun `showOverlay with missing overlay permission does not start session`() {
+        overlayPermission = false
+        keyguardLocked = true
+        logic.showOverlay()
+
+        verify(sessionTracker, never()).startSession()
+        assertFalse(mediaObserverRegistered)
+    }
+
+    // ── Session gating on keyguard state ────────────────────────────────────
+
+    /**
+     * showOverlay() starts a secure session only when isKeyguardLocked is true;
+     * when the screen is unlocked at activation time no session is started.
+     */
+    @Test
+    fun `showOverlay starts session when device is locked at activation time`() {
+        keyguardLocked = true
+        logic.showOverlay()
+
+        assertTrue(logic.isOverlayActive)
+        verify(sessionTracker).startSession()
+        assertTrue("Media observer should be registered when session starts", mediaObserverRegistered)
+    }
+
+    @Test
+    fun `showOverlay does not start session when device is unlocked at activation time`() {
+        keyguardLocked = false
+        logic.showOverlay()
+
+        assertTrue(logic.isOverlayActive)
+        verify(sessionTracker, never()).startSession()
+        assertFalse("Media observer should not be registered when device is unlocked", mediaObserverRegistered)
+    }
+}


### PR DESCRIPTION
Re-introduces OverlayServiceLogic as a properly-wired class that holds
the camera-callback, evaluateForeground, showOverlay, and
scheduleDeactivation logic extracted from OverlayService.  All
Android-framework side-effects are accessed via constructor lambdas so
the class is exercisable on the plain JVM.

OverlayServiceLogicTest covers the five scenarios called out in the issue:
- DT-05 multi-camera: second onCameraUnavailable does not prematurely
  schedule deactivation; only when the last tracked camera is released
  does scheduleDeactivation() run.
- Idempotent activation: evaluateForeground() multiple times with Pixel
  Camera in foreground calls overlayManager.show() exactly once and
  does not re-register the media observer.
- Usage-stats permission revocation: overlay is hidden and the
  usage-access-lost notification fires; no notification when overlay
  was already inactive.
- Overlay permission loss: notification fires and isOverlayActive
  remains false; no session is started.
- Session gating on keyguard state: showOverlay() starts a session and
  registers the media observer only when isKeyguardLocked is true.

https://claude.ai/code/session_01Rd6GKntfPmNN4o2J7i7qby