### PR TITLE
Salvage scheduleActivationRetry from #23 (fixes #24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin/

--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -18,6 +18,9 @@ object Constants {
     // UsageStats query window (DT-02)
     const val USAGE_STATS_WINDOW_MS = 5000L
 
+    // Retry delay when UsageStats hasn't caught up with the foreground app yet (DT-06a)
+    const val ACTIVATION_RETRY_MS = 1000L
+
     // Debug log buffer size (UI-10)
     const val DEBUG_LOG_BUFFER_SIZE = 200
 

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -35,7 +35,10 @@ class OverlayServiceLogic(
 
     private var deactivateRunnable: Runnable? = null
     // DT-06a: Retry runnable for UsageStats lag — fires if foreground not detected on first check.
+    // activationRetryPending gates re-scheduling: it stays true while the runnable is executing
+    // so that evaluateForeground() inside the runnable cannot queue a second retry.
     private var activationRetryRunnable: Runnable? = null
+    private var activationRetryPending = false
 
     // ── Camera callback delegation ──────────────────────────────────────────
 
@@ -49,6 +52,7 @@ class OverlayServiceLogic(
         cameraState.setCameraAvailable(cameraId)
         // DT-04/DT-05: Only schedule deactivation when ALL cameras have been released
         if (cameraState.areAllCamerasAvailable()) {
+            cancelActivationRetry()
             scheduleDeactivation()
         }
     }
@@ -125,14 +129,19 @@ class OverlayServiceLogic(
         }
     }
 
-    // DT-06a: Retry activation after UsageStats lag.
+    // DT-06a: Retry activation after UsageStats lag — one shot per camera-open event.
     private fun scheduleActivationRetry() {
-        if (activationRetryRunnable != null) return  // already scheduled
-        activationRetryRunnable = Runnable {
+        if (activationRetryPending) return  // already scheduled or currently executing
+        activationRetryPending = true
+        val runnable = Runnable {
             activationRetryRunnable = null
+            // activationRetryPending stays true while evaluateForeground() runs, so any
+            // scheduleActivationRetry() call inside cannot queue a second retry.
             evaluateForeground()
+            activationRetryPending = false
         }
-        handler.postDelayed(activationRetryRunnable!!, Constants.ACTIVATION_RETRY_MS)
+        activationRetryRunnable = runnable
+        handler.postDelayed(runnable, Constants.ACTIVATION_RETRY_MS)
     }
 
     private fun cancelActivationRetry() {
@@ -140,6 +149,7 @@ class OverlayServiceLogic(
             handler.removeCallbacks(it)
             activationRetryRunnable = null
         }
+        activationRetryPending = false
     }
 
     /** Called from onDestroy to clean up mutable state. */

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -34,6 +34,8 @@ class OverlayServiceLogic(
         private set
 
     private var deactivateRunnable: Runnable? = null
+    // DT-06a: Retry runnable for UsageStats lag — fires if foreground not detected on first check.
+    private var activationRetryRunnable: Runnable? = null
 
     // ── Camera callback delegation ──────────────────────────────────────────
 
@@ -55,6 +57,7 @@ class OverlayServiceLogic(
 
     /**
      * DT-02/DT-03: Check if Pixel Camera is the foreground app and show/hide overlay.
+     * DT-06a: If the foreground event hasn't appeared in UsageStats yet (lag), schedule a retry.
      */
     fun evaluateForeground() {
         if (!hasUsageStatsPermission()) {
@@ -63,12 +66,17 @@ class OverlayServiceLogic(
                 isOverlayActive = false
                 onUsageAccessLost()
             }
+            cancelActivationRetry()
             return
         }
 
         val pkg = foregroundDetector.getForegroundPackage()
         if (ForegroundDetector.isPixelCameraPackage(pkg) && !isOverlayActive) {
+            cancelActivationRetry()
             showOverlay()
+        } else if (!isOverlayActive && cameraState.anyCameraUnavailable()) {
+            // UsageStats may not have caught up yet; schedule a retry (DT-06a).
+            scheduleActivationRetry()
         }
     }
 
@@ -117,9 +125,27 @@ class OverlayServiceLogic(
         }
     }
 
+    // DT-06a: Retry activation after UsageStats lag.
+    private fun scheduleActivationRetry() {
+        if (activationRetryRunnable != null) return  // already scheduled
+        activationRetryRunnable = Runnable {
+            activationRetryRunnable = null
+            evaluateForeground()
+        }
+        handler.postDelayed(activationRetryRunnable!!, Constants.ACTIVATION_RETRY_MS)
+    }
+
+    private fun cancelActivationRetry() {
+        activationRetryRunnable?.let {
+            handler.removeCallbacks(it)
+            activationRetryRunnable = null
+        }
+    }
+
     /** Called from onDestroy to clean up mutable state. */
     fun reset() {
         cancelPendingDeactivation()
+        cancelActivationRetry()
         isOverlayActive = false
     }
 }

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -353,6 +353,29 @@ class OverlayServiceLogicTest {
     }
 
     /**
+     * When the retry fires but UsageStats still has not caught up, no second retry must be
+     * scheduled — the retry is strictly one-shot per camera-open event.
+     *
+     * Without the activationRetryPending flag, scheduleActivationRetry() re-schedules on every
+     * evaluateForeground() call triggered by the runnable, creating a 1 Hz polling loop.
+     */
+    @Test
+    fun `DT-06a retry does not re-schedule when foreground still not detected after firing`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        // Fire the retry runnable
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+        runnableCaptor.firstValue.run()
+
+        // Foreground still not detected — must NOT schedule a second postDelayed
+        verify(handler, times(1)).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
+        assertFalse("Overlay must not be active when foreground was never detected", logic.isOverlayActive)
+    }
+
+    /**
      * When usage-stats permission is revoked, any pending retry should be cancelled so the
      * retry cannot fire and attempt to show the overlay without permission.
      */

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -259,4 +259,116 @@ class OverlayServiceLogicTest {
         verify(sessionTracker, never()).startSession()
         assertFalse("Media observer should not be registered when device is unlocked", mediaObserverRegistered)
     }
+
+    // ── DT-06a: UsageStats lag retry ────────────────────────────────────────
+
+    /**
+     * When the camera becomes unavailable but UsageStats hasn't caught up yet (foreground
+     * package is not Pixel Camera), evaluateForeground() should schedule a retry runnable
+     * via handler.postDelayed with ACTIVATION_RETRY_MS.
+     */
+    @Test
+    fun `DT-06a retry scheduled when camera unavailable but foreground not yet detected`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        verify(handler).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
+        assertFalse("Overlay should not be active yet", logic.isOverlayActive)
+    }
+
+    /**
+     * A second evaluateForeground() call while a retry is already pending must not schedule
+     * a second handler.postDelayed — the existing retry is reused (idempotent scheduling).
+     */
+    @Test
+    fun `DT-06a retry is not double-scheduled on repeated evaluateForeground calls`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        logic.evaluateForeground()
+        logic.evaluateForeground()
+
+        verify(handler, times(1)).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
+    }
+
+    /**
+     * When the retry fires and UsageStats now returns Pixel Camera as the foreground app,
+     * the overlay is shown.
+     */
+    @Test
+    fun `DT-06a overlay shows when retry fires and UsageStats has caught up`() {
+        // First call: foreground not yet detected → retry scheduled
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+
+        // UsageStats has now caught up
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        assertTrue("Overlay should be active after retry succeeds", logic.isOverlayActive)
+        verify(overlayManager).show()
+    }
+
+    /**
+     * When evaluateForeground() succeeds immediately (Pixel Camera is already in the foreground),
+     * no retry should be scheduled.
+     */
+    @Test
+    fun `DT-06a no retry scheduled when Pixel Camera is already in foreground`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        verify(handler, never()).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
+        assertTrue(logic.isOverlayActive)
+    }
+
+    /**
+     * If the camera becomes available again before the retry fires, the pending retry should
+     * be cancelled on reset() so it cannot trigger a stale activation.
+     */
+    @Test
+    fun `DT-06a pending retry is cancelled on reset`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+
+        logic.reset()
+
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+        assertFalse(logic.isOverlayActive)
+    }
+
+    /**
+     * When usage-stats permission is revoked, any pending retry should be cancelled so the
+     * retry cannot fire and attempt to show the overlay without permission.
+     */
+    @Test
+    fun `DT-06a pending retry cancelled when usage stats permission is revoked`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+
+        // Revoke permission; evaluateForeground should cancel the retry
+        usageStatsPermission = false
+        logic.evaluateForeground()
+
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+    }
 }

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -394,4 +394,22 @@ class OverlayServiceLogicTest {
 
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
     }
+
+    /**
+     * If the camera is released while a retry is pending (e.g. a non-Pixel-Camera app
+     * briefly opened the camera), the retry should be cancelled so it doesn't fire stale.
+     */
+    @Test
+    fun `DT-06a pending retry cancelled when camera released before retry fires`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        logic.onCameraUnavailable("0")
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+
+        // Camera released — all cameras now available
+        logic.onCameraAvailable("0")
+
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+    }
 }


### PR DESCRIPTION
Add ACTIVATION_RETRY_MS (1 s) to Constants and implement
scheduleActivationRetry / cancelActivationRetry in OverlayServiceLogic
(DT-06a). When evaluateForeground() sees a camera in use but UsageStats
hasn't yet reported Pixel Camera as the foreground app, a single retry is
scheduled; it is cancelled as soon as the foreground is confirmed, the
permission is revoked, the camera is released, or the service is destroyed.
Eight new unit tests in OverlayServiceLogicTest cover scheduling,
idempotence, retry success, no-retry-on-immediate-success, and cancellation
on reset/permission-revoke/camera-released.

https://claude.ai/code/session_01Ht9uzQDgfouMkzGR7WJooX