### PR TITLE
Add agent guidance for code reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+If participating in a PR or review, read `./agents/code_review.md`.

--- a/agents/code_review.md
+++ b/agents/code_review.md
@@ -1,0 +1,5 @@
+## Code reviews must be conversational, and slightly competitive, between **at least two parties**.
+
+- A *Reviewer* agent (or even its managing agent) must not make code changes itself, but should communicate discoveries clearly enough to convince a code author of the need to change the PR.
+- An *Author* agent should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
+- This slightly competitive interaction between at least two parties is important to the SDLC, because it reduces the presence of untested ideas in our code.


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` pointing agents to review guidance
- Adds `agents/code_review.md` documenting that code reviews must be conversational and slightly competitive between at least two parties — reviewers must not self-implement fixes, and authors must engage critically rather than auto-accepting review comments
- Adds `.kotlin/` to `.gitignore`

https://claude.ai/code/session_01PmpXByJByaWqFY35Xh7FZP