### PR TITLE
Sign release APK using keystore secrets in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,16 @@ jobs:
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --no-daemon
 
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+
       - name: Build release APK
+        env:
+          KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew assembleRelease --no-daemon
 
       - name: Extract version from tag


### PR DESCRIPTION
Decodes KEYSTORE_BASE64 into a temp file and passes the four keystore
env vars to assembleRelease so the workflow produces a properly signed
APK. The signing plumbing in app/build.gradle.kts already supports this.

https://claude.ai/code/session_014vDsfMtjrnaMtC9CjtHVRF