### PR TITLE
Implement #34 & #35: debounce config + X/Y text inputs

### DIFF
--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -13,7 +13,7 @@ object Constants {
     const val MAX_SIZE_PERCENT = 30.0f
 
     // Camera debounce delay (DT-04)
-    const val CAMERA_DEBOUNCE_MS = 500L
+    const val CAMERA_DEBOUNCE_MS = 50L
 
     // UsageStats query window (DT-02)
     const val USAGE_STATS_WINDOW_MS = 5000L
@@ -35,6 +35,7 @@ object Constants {
     const val PREF_GALLERY_PACKAGE = "gallery_package"
     const val PREF_OVERLAY_POSITIONS = "overlay_positions"
     const val PREF_SETUP_COMPLETED = "setup_completed"
+    const val PREF_CAMERA_DEBOUNCE_MS = "camera_debounce_ms"
 
     // Secure viewer
     const val SESSION_TIMESTAMP_TOLERANCE_MS = 2000L

--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -14,7 +14,8 @@ object Constants {
 
     // Camera debounce delay (DT-04)
     const val CAMERA_DEBOUNCE_MS = 50L
-    const val MAX_CAMERA_DEBOUNCE_MS = 5000L
+    const val MIN_CAMERA_DEBOUNCE_MS = 10L
+    const val MAX_CAMERA_DEBOUNCE_MS = 1000L
 
     // UsageStats query window (DT-02)
     const val USAGE_STATS_WINDOW_MS = 5000L

--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -14,6 +14,7 @@ object Constants {
 
     // Camera debounce delay (DT-04)
     const val CAMERA_DEBOUNCE_MS = 50L
+    const val MAX_CAMERA_DEBOUNCE_MS = 5000L
 
     // UsageStats query window (DT-02)
     const val USAGE_STATS_WINDOW_MS = 5000L

--- a/app/src/main/java/com/gb4pc/data/PrefsManager.kt
+++ b/app/src/main/java/com/gb4pc/data/PrefsManager.kt
@@ -24,6 +24,10 @@ class PrefsManager(context: Context) {
         get() = prefs.getBoolean(Constants.PREF_SETUP_COMPLETED, false)
         set(value) = prefs.edit().putBoolean(Constants.PREF_SETUP_COMPLETED, value).apply()
 
+    var cameraDebounceMs: Long
+        get() = prefs.getLong(Constants.PREF_CAMERA_DEBOUNCE_MS, Constants.CAMERA_DEBOUNCE_MS)
+        set(value) = prefs.edit().putLong(Constants.PREF_CAMERA_DEBOUNCE_MS, value).apply()
+
     /**
      * Returns the overlay position for the given aspect ratio.
      * Falls back to the closest stored ratio (PS-04), then to defaults.

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -82,6 +82,7 @@ class OverlayService : Service() {
             foregroundDetector = foregroundDetector,
             sessionTracker = SessionTracker.instance,
             handler = handler,
+            debounceMs = prefsManager.cameraDebounceMs,
             onUsageAccessLost = {
                 postPermissionNotification(
                     Constants.NOTIFICATION_PERMISSION_ID,

--- a/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
@@ -55,6 +55,7 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
     var sizePercent by remember { mutableFloatStateOf(currentPosition.sizePercent) }
     var xText by remember { mutableStateOf("%.2f".format(currentPosition.xPercent)) }
     var yText by remember { mutableStateOf("%.2f".format(currentPosition.yPercent)) }
+    var sizeText by remember { mutableStateOf("%.2f".format(currentPosition.sizePercent)) }
     var debounceText by remember { mutableStateOf(prefsManager.cameraDebounceMs.toString()) }
     var showResetDialog by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
@@ -79,9 +80,16 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
         savePosition()
     }
 
+    fun commitSizeText() {
+        val parsed = sizeText.toFloatOrNull()
+        sizePercent = (parsed ?: sizePercent).coerceIn(Constants.MIN_SIZE_PERCENT, Constants.MAX_SIZE_PERCENT)
+        sizeText = "%.2f".format(sizePercent)
+        savePosition()
+    }
+
     fun commitDebounceText() {
         val parsed = debounceText.toLongOrNull()
-        if (parsed != null && parsed >= 0) {
+        if (parsed != null && parsed >= Constants.MIN_CAMERA_DEBOUNCE_MS) {
             val clamped = parsed.coerceAtMost(Constants.MAX_CAMERA_DEBOUNCE_MS)
             prefsManager.cameraDebounceMs = clamped
             debounceText = clamped.toString()
@@ -195,14 +203,43 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            Text(
-                text = stringResource(R.string.advanced_size),
-                style = MaterialTheme.typography.labelLarge
-            )
-            Text(text = "%.2f%%".format(sizePercent), style = MaterialTheme.typography.bodySmall)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 4.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.advanced_size),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = sizeText,
+                    onValueChange = { text ->
+                        sizeText = text
+                        val parsed = text.toFloatOrNull()
+                        if (parsed != null) {
+                            sizePercent = parsed.coerceIn(Constants.MIN_SIZE_PERCENT, Constants.MAX_SIZE_PERCENT)
+                        }
+                    },
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = {
+                        commitSizeText()
+                        focusManager.clearFocus()
+                    }),
+                    singleLine = true,
+                    modifier = Modifier.width(96.dp)
+                )
+            }
             Slider(
                 value = sizePercent,
-                onValueChange = { sizePercent = it },
+                onValueChange = {
+                    sizePercent = it
+                    sizeText = "%.2f".format(it)
+                },
                 onValueChangeFinished = { savePosition() },
                 valueRange = Constants.MIN_SIZE_PERCENT..Constants.MAX_SIZE_PERCENT,
                 modifier = Modifier.padding(bottom = 16.dp)
@@ -298,6 +335,7 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         sizePercent = defaultPos.sizePercent
                         xText = "%.2f".format(defaultPos.xPercent)
                         yText = "%.2f".format(defaultPos.yPercent)
+                        sizeText = "%.2f".format(defaultPos.sizePercent)
                         showResetDialog = false
                     }) {
                         Text("Reset")

--- a/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
@@ -57,11 +57,37 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
     var yText by remember { mutableStateOf("%.2f".format(currentPosition.yPercent)) }
     var debounceText by remember { mutableStateOf(prefsManager.cameraDebounceMs.toString()) }
     var showResetDialog by remember { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
 
     // Save on change (UI-11)
     fun savePosition() {
         val pos = OverlayPosition(xPercent, yPercent, sizePercent)
         prefsManager.saveOverlayPosition(aspectRatio, pos)
+    }
+
+    fun commitXText() {
+        val parsed = xText.toFloatOrNull()
+        xPercent = (parsed ?: xPercent).coerceIn(0f, 100f)
+        xText = "%.2f".format(xPercent)
+        savePosition()
+    }
+
+    fun commitYText() {
+        val parsed = yText.toFloatOrNull()
+        yPercent = (parsed ?: yPercent).coerceIn(0f, 100f)
+        yText = "%.2f".format(yPercent)
+        savePosition()
+    }
+
+    fun commitDebounceText() {
+        val parsed = debounceText.toLongOrNull()
+        if (parsed != null && parsed >= 0) {
+            val clamped = parsed.coerceAtMost(Constants.MAX_CAMERA_DEBOUNCE_MS)
+            prefsManager.cameraDebounceMs = clamped
+            debounceText = clamped.toString()
+        } else {
+            debounceText = prefsManager.cameraDebounceMs.toString()
+        }
     }
 
     // M2 fix: live-updating debug log entries via DebugLog listener
@@ -84,9 +110,7 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 .padding(16.dp)
                 .fillMaxWidth()
         ) {
-            val focusManager = LocalFocusManager.current
-
-            // UI-10.1: Position sliders with text inputs (M4 fix: persist only on onValueChangeFinished)
+            // UI-10.1: Position sliders with text inputs (M4 fix: persist only on commit/onValueChangeFinished)
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(bottom = 4.dp)
@@ -103,7 +127,6 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         val parsed = text.toFloatOrNull()
                         if (parsed != null) {
                             xPercent = parsed.coerceIn(0f, 100f)
-                            savePosition()
                         }
                     },
                     suffix = { Text("%") },
@@ -111,7 +134,10 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         keyboardType = KeyboardType.Decimal,
                         imeAction = ImeAction.Done
                     ),
-                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                    keyboardActions = KeyboardActions(onDone = {
+                        commitXText()
+                        focusManager.clearFocus()
+                    }),
                     singleLine = true,
                     modifier = Modifier.width(96.dp)
                 )
@@ -143,7 +169,6 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         val parsed = text.toFloatOrNull()
                         if (parsed != null) {
                             yPercent = parsed.coerceIn(0f, 100f)
-                            savePosition()
                         }
                     },
                     suffix = { Text("%") },
@@ -151,7 +176,10 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         keyboardType = KeyboardType.Decimal,
                         imeAction = ImeAction.Done
                     ),
-                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                    keyboardActions = KeyboardActions(onDone = {
+                        commitYText()
+                        focusManager.clearFocus()
+                    }),
                     singleLine = true,
                     modifier = Modifier.width(96.dp)
                 )
@@ -187,21 +215,23 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
             )
             OutlinedTextField(
                 value = debounceText,
-                onValueChange = { text ->
-                    debounceText = text
-                    val parsed = text.toLongOrNull()
-                    if (parsed != null && parsed > 0) {
-                        prefsManager.cameraDebounceMs = parsed
-                    }
-                },
+                onValueChange = { debounceText = it },
                 suffix = { Text("ms") },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                keyboardActions = KeyboardActions(onDone = {
+                    commitDebounceText()
+                    focusManager.clearFocus()
+                }),
                 singleLine = true,
-                modifier = Modifier.padding(bottom = 24.dp).width(128.dp)
+                modifier = Modifier.width(128.dp)
+            )
+            Text(
+                text = stringResource(R.string.advanced_camera_debounce_restart),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(bottom = 24.dp)
             )
 
             // UI-10.2: Reset to defaults

--- a/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
@@ -5,13 +5,19 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.gb4pc.Constants
 import com.gb4pc.R
@@ -47,6 +53,9 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
     var xPercent by remember { mutableFloatStateOf(currentPosition.xPercent) }
     var yPercent by remember { mutableFloatStateOf(currentPosition.yPercent) }
     var sizePercent by remember { mutableFloatStateOf(currentPosition.sizePercent) }
+    var xText by remember { mutableStateOf("%.2f".format(currentPosition.xPercent)) }
+    var yText by remember { mutableStateOf("%.2f".format(currentPosition.yPercent)) }
+    var debounceText by remember { mutableStateOf(prefsManager.cameraDebounceMs.toString()) }
     var showResetDialog by remember { mutableStateOf(false) }
 
     // Save on change (UI-11)
@@ -75,28 +84,84 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 .padding(16.dp)
                 .fillMaxWidth()
         ) {
-            // UI-10.1: Position sliders (M4 fix: persist only on onValueChangeFinished)
-            Text(
-                text = stringResource(R.string.advanced_x_position),
-                style = MaterialTheme.typography.labelLarge
-            )
-            Text(text = "%.2f%%".format(xPercent), style = MaterialTheme.typography.bodySmall)
+            val focusManager = LocalFocusManager.current
+
+            // UI-10.1: Position sliders with text inputs (M4 fix: persist only on onValueChangeFinished)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 4.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.advanced_x_position),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = xText,
+                    onValueChange = { text ->
+                        xText = text
+                        val parsed = text.toFloatOrNull()
+                        if (parsed != null) {
+                            xPercent = parsed.coerceIn(0f, 100f)
+                            savePosition()
+                        }
+                    },
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                    singleLine = true,
+                    modifier = Modifier.width(96.dp)
+                )
+            }
             Slider(
                 value = xPercent,
-                onValueChange = { xPercent = it },
+                onValueChange = {
+                    xPercent = it
+                    xText = "%.2f".format(it)
+                },
                 onValueChangeFinished = { savePosition() },
                 valueRange = 0f..100f,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            Text(
-                text = stringResource(R.string.advanced_y_position),
-                style = MaterialTheme.typography.labelLarge
-            )
-            Text(text = "%.2f%%".format(yPercent), style = MaterialTheme.typography.bodySmall)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 4.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.advanced_y_position),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                OutlinedTextField(
+                    value = yText,
+                    onValueChange = { text ->
+                        yText = text
+                        val parsed = text.toFloatOrNull()
+                        if (parsed != null) {
+                            yPercent = parsed.coerceIn(0f, 100f)
+                            savePosition()
+                        }
+                    },
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                    singleLine = true,
+                    modifier = Modifier.width(96.dp)
+                )
+            }
             Slider(
                 value = yPercent,
-                onValueChange = { yPercent = it },
+                onValueChange = {
+                    yPercent = it
+                    yText = "%.2f".format(it)
+                },
                 onValueChangeFinished = { savePosition() },
                 valueRange = 0f..100f,
                 modifier = Modifier.padding(bottom = 16.dp)
@@ -113,6 +178,30 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 onValueChangeFinished = { savePosition() },
                 valueRange = Constants.MIN_SIZE_PERCENT..Constants.MAX_SIZE_PERCENT,
                 modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = stringResource(R.string.advanced_camera_debounce_ms),
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+            OutlinedTextField(
+                value = debounceText,
+                onValueChange = { text ->
+                    debounceText = text
+                    val parsed = text.toLongOrNull()
+                    if (parsed != null && parsed > 0) {
+                        prefsManager.cameraDebounceMs = parsed
+                    }
+                },
+                suffix = { Text("ms") },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                singleLine = true,
+                modifier = Modifier.padding(bottom = 24.dp).width(128.dp)
             )
 
             // UI-10.2: Reset to defaults
@@ -177,6 +266,8 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                         xPercent = defaultPos.xPercent
                         yPercent = defaultPos.yPercent
                         sizePercent = defaultPos.sizePercent
+                        xText = "%.2f".format(defaultPos.xPercent)
+                        yText = "%.2f".format(defaultPos.yPercent)
                         showResetDialog = false
                     }) {
                         Text("Reset")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="advanced_x_position">X position</string>
     <string name="advanced_y_position">Y position</string>
     <string name="advanced_size">Size</string>
-    <string name="advanced_camera_debounce_ms">Camera close detection interval (ms, 0–5000)</string>
+    <string name="advanced_camera_debounce_ms">Camera close detection interval (ms, 10–1000)</string>
     <string name="advanced_camera_debounce_restart">Takes effect when the service is restarted.</string>
     <string name="advanced_reset">Reset to Defaults</string>
     <string name="advanced_reset_confirm_title">Reset Position?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,8 @@
     <string name="advanced_x_position">X position</string>
     <string name="advanced_y_position">Y position</string>
     <string name="advanced_size">Size</string>
-    <string name="advanced_camera_debounce_ms">Camera close detection interval (ms)</string>
+    <string name="advanced_camera_debounce_ms">Camera close detection interval (ms, 0–5000)</string>
+    <string name="advanced_camera_debounce_restart">Takes effect when the service is restarted.</string>
     <string name="advanced_reset">Reset to Defaults</string>
     <string name="advanced_reset_confirm_title">Reset Position?</string>
     <string name="advanced_reset_confirm_message">This will restore the default overlay position for the current display aspect ratio.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="advanced_x_position">X position</string>
     <string name="advanced_y_position">Y position</string>
     <string name="advanced_size">Size</string>
+    <string name="advanced_camera_debounce_ms">Camera close detection interval (ms)</string>
     <string name="advanced_reset">Reset to Defaults</string>
     <string name="advanced_reset_confirm_title">Reset Position?</string>
     <string name="advanced_reset_confirm_message">This will restore the default overlay position for the current display aspect ratio.</string>


### PR DESCRIPTION
- Lower CAMERA_DEBOUNCE_MS default from 500ms to 50ms (#34)
- Add PREF_CAMERA_DEBOUNCE_MS preference; PrefsManager exposes
  cameraDebounceMs with the 50ms default as fallback
- OverlayService passes prefsManager.cameraDebounceMs to
  OverlayServiceLogic so the live value is used at service start
- Advanced Settings: numeric text field for camera close detection
  interval (ms), no slider (#34)
- Advanced Settings: OutlinedTextField beside each position label
  for X and Y, two-way synced with their sliders (#35)

https://claude.ai/code/session_01ECHfLGnE1PKXZCDXaa6Zx3