### PR TITLE
Fix issues #32, #33, #38, #39

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,14 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.APP_GALLERY" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="image/*" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -73,14 +73,43 @@ class OverlayManager(
         } catch (_: Exception) {}
     }
 
+    fun showLatestPhotoThumbnail(photoUri: String) {
+        val targetView = overlayView ?: return
+        val uri = android.net.Uri.parse(photoUri)
+        Thread {
+            try {
+                val bitmap = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    context.contentResolver.loadThumbnail(uri, android.util.Size(200, 200), null)
+                } else {
+                    context.contentResolver.openInputStream(uri)?.use { stream ->
+                        val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = 4 }
+                        android.graphics.BitmapFactory.decodeStream(stream, null, opts)
+                    }
+                }
+                bitmap?.let { bmp ->
+                    android.os.Handler(android.os.Looper.getMainLooper()).post {
+                        targetView.setImageBitmap(bmp)
+                    }
+                }
+            } catch (e: Exception) {
+                DebugLog.log("Failed to load thumbnail: ${e.message}")
+            }
+        }.start()
+    }
+
     private fun createOverlayView(): ImageView {
         val imageView = ImageView(context)
         imageView.scaleType = ImageView.ScaleType.FIT_CENTER
         imageView.clipToOutline = true
-
+        imageView.outlineProvider = object : android.view.ViewOutlineProvider() {
+            override fun getOutline(view: android.view.View, outline: android.graphics.Outline) {
+                if (view.width == 0 || view.height == 0) return
+                val radius = view.width * 0.30f
+                outline.setRoundRect(0, 0, view.width, view.height, radius)
+            }
+        }
         updateIconDrawable(imageView)
         imageView.setOnClickListener { handleTap() }
-
         return imageView
     }
 
@@ -192,6 +221,9 @@ class OverlayManager(
     }
 
     private fun createLayoutParams(): WindowManager.LayoutParams {
+        @Suppress("DEPRECATION")
+        val showWhenLockedFlag = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+
         // M8: On API 30+ use currentWindowMetrics for correct bounds in split-screen;
         // fall back to displayMetrics on older API.
         val (displayWidth, displayHeight) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -222,7 +254,8 @@ class OverlayManager(
             sizePx,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                showWhenLockedFlag,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -50,6 +50,8 @@ class OverlayService : Service() {
 
     // H4: ContentObserver registered at session start, unregistered at session end
     private var mediaObserver: ContentObserver? = null
+    private var thumbnailObserver: ContentObserver? = null
+    private var overlayActiveTimestamp: Long = 0L
 
     private val cameraCallback = object : CameraManager.AvailabilityCallback() {
         override fun onCameraUnavailable(cameraId: String) {
@@ -98,6 +100,8 @@ class OverlayService : Service() {
             isKeyguardLocked = { km.isKeyguardLocked },
             onRegisterMediaObserver = ::registerMediaObserver,
             onUnregisterMediaObserver = ::unregisterMediaObserver,
+            onRegisterThumbnailObserver = ::registerThumbnailObserver,
+            onUnregisterThumbnailObserver = ::unregisterThumbnailObserver,
             onOverlayStateChanged = { active -> isOverlayActive = active },
         )
     }
@@ -133,6 +137,7 @@ class OverlayService : Service() {
             callbackRegistered = false
         }
         unregisterScreenEventReceiver()
+        unregisterThumbnailObserver()
         unregisterMediaObserver()
         overlayManager.hide()
         cameraState.reset()
@@ -234,6 +239,36 @@ class OverlayService : Service() {
             contentResolver.unregisterContentObserver(it)
             mediaObserver = null
             DebugLog.log("ContentObserver unregistered")
+        }
+    }
+
+    private fun registerThumbnailObserver() {
+        if (thumbnailObserver != null) return
+        overlayActiveTimestamp = System.currentTimeMillis()
+        val startMs = overlayActiveTimestamp
+        thumbnailObserver = object : ContentObserver(handler) {
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                val item = queryLatestMedia(startMs)
+                if (item != null) {
+                    overlayManager.showLatestPhotoThumbnail(item.uri)
+                    DebugLog.log("Thumbnail updated: ${item.uri}")
+                }
+            }
+        }
+        contentResolver.registerContentObserver(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true, thumbnailObserver!!
+        )
+        contentResolver.registerContentObserver(
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true, thumbnailObserver!!
+        )
+        DebugLog.log("Thumbnail observer registered")
+    }
+
+    private fun unregisterThumbnailObserver() {
+        thumbnailObserver?.let {
+            contentResolver.unregisterContentObserver(it)
+            thumbnailObserver = null
+            DebugLog.log("Thumbnail observer unregistered")
         }
     }
 

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -29,6 +29,8 @@ class OverlayServiceLogic(
     private val isKeyguardLocked: () -> Boolean,
     private val onRegisterMediaObserver: () -> Unit,
     private val onUnregisterMediaObserver: () -> Unit,
+    private val onRegisterThumbnailObserver: () -> Unit = {},
+    private val onUnregisterThumbnailObserver: () -> Unit = {},
     /** Called whenever the overlay visibility changes; default no-op. Used by tests and UI. */
     private val onOverlayStateChanged: (Boolean) -> Unit = {},
 ) {
@@ -99,6 +101,7 @@ class OverlayServiceLogic(
         overlayManager.show()
         isOverlayActive = true
         onOverlayStateChanged(true)
+        onRegisterThumbnailObserver()   // always register thumbnail observer on activation
 
         // SF-01: If device is locked at activation time, begin a secure session immediately.
         // H3: If unlocked, onScreenOff() will start the session when the screen locks.
@@ -118,6 +121,7 @@ class OverlayServiceLogic(
                 overlayManager.hide()
                 isOverlayActive = false
                 onOverlayStateChanged(false)
+                onUnregisterThumbnailObserver()   // unregister thumbnail observer on deactivation
                 if (sessionTracker.isSessionActive) {
                     sessionTracker.endSession()
                     onUnregisterMediaObserver()
@@ -161,6 +165,7 @@ class OverlayServiceLogic(
     fun reset() {
         cancelPendingDeactivation()
         cancelActivationRetry()
+        onUnregisterThumbnailObserver()
         isOverlayActive = false
     }
 }

--- a/app/src/main/java/com/gb4pc/ui/picker/AppListFilter.kt
+++ b/app/src/main/java/com/gb4pc/ui/picker/AppListFilter.kt
@@ -32,7 +32,7 @@ object AppListFilter {
      * Returns the set of package names that are plausibly photo-related, built from
      * the union of two PackageManager queries:
      *   1. Apps declaring CATEGORY_APP_GALLERY
-     *   2. Apps that can handle ACTION_VIEW with image/* MIME type
+     *   2. Apps that can handle ACTION_VIEW for image MIME types
      */
     fun buildPhotoRelatedPackages(context: Context): Set<String> {
         val pm = context.packageManager

--- a/app/src/main/java/com/gb4pc/ui/picker/AppListFilter.kt
+++ b/app/src/main/java/com/gb4pc/ui/picker/AppListFilter.kt
@@ -1,5 +1,7 @@
 package com.gb4pc.ui.picker
 
+import android.content.Context
+import android.content.Intent
 import com.gb4pc.Constants
 
 /**
@@ -24,5 +26,25 @@ object AppListFilter {
                     app.packageName.contains(query, ignoreCase = true)
             }
             .sortedBy { it.label.lowercase() }
+    }
+
+    /**
+     * Returns the set of package names that are plausibly photo-related, built from
+     * the union of two PackageManager queries:
+     *   1. Apps declaring CATEGORY_APP_GALLERY
+     *   2. Apps that can handle ACTION_VIEW with image/* MIME type
+     */
+    fun buildPhotoRelatedPackages(context: Context): Set<String> {
+        val pm = context.packageManager
+        val packages = mutableSetOf<String>()
+        runCatching {
+            val galleryIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_APP_GALLERY)
+            pm.queryIntentActivities(galleryIntent, 0).forEach { packages.add(it.activityInfo.packageName) }
+        }
+        runCatching {
+            val imageIntent = Intent(Intent.ACTION_VIEW).apply { type = "image/*" }
+            pm.queryIntentActivities(imageIntent, 0).forEach { packages.add(it.activityInfo.packageName) }
+        }
+        return packages
     }
 }

--- a/app/src/main/java/com/gb4pc/ui/picker/PickerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/picker/PickerActivity.kt
@@ -80,25 +80,33 @@ fun PickerScreen(
 ) {
     val context = LocalContext.current
     var searchQuery by remember { mutableStateOf("") }
+    var showAll by remember { mutableStateOf(false) }
 
-    // Load all launchable apps off the main thread
     var allApps by remember { mutableStateOf(emptyList<AppInfo>()) }
+    var photoRelatedPackages by remember { mutableStateOf(emptySet<String>()) }
+
     LaunchedEffect(Unit) {
-        allApps = withContext(Dispatchers.IO) {
+        val (apps, photoPackages) = withContext(Dispatchers.IO) {
             val pm = context.packageManager
             val mainIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
             val resolveInfos = pm.queryIntentActivities(mainIntent, PackageManager.MATCH_ALL)
-            resolveInfos.map { ri ->
+            val loadedApps = resolveInfos.map { ri ->
                 AppInfo(
                     label = ri.loadLabel(pm).toString(),
                     packageName = ri.activityInfo.packageName
                 )
             }.distinctBy { it.packageName }
+            val loadedPhotoPackages = AppListFilter.buildPhotoRelatedPackages(context)
+            loadedApps to loadedPhotoPackages
         }
+        allApps = apps
+        photoRelatedPackages = photoPackages
+        if (photoPackages.isEmpty()) showAll = true
     }
 
-    val filteredApps = remember(allApps, searchQuery) {
-        AppListFilter.filter(allApps, searchQuery, context.packageName)
+    val filteredApps = remember(allApps, photoRelatedPackages, searchQuery, showAll) {
+        val baseList = if (showAll) allApps else allApps.filter { it.packageName in photoRelatedPackages }
+        AppListFilter.filter(baseList, searchQuery, context.packageName)
     }
 
     Scaffold(
@@ -107,7 +115,6 @@ fun PickerScreen(
         }
     ) { padding ->
         Column(modifier = Modifier.padding(padding)) {
-            // UI-06: Search bar
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
@@ -118,10 +125,31 @@ fun PickerScreen(
                 singleLine = true
             )
 
-            // UI-05: App list
             LazyColumn {
+                if (!showAll) {
+                    item {
+                        Text(
+                            text = stringResource(R.string.picker_filtered_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                        )
+                    }
+                }
                 items(filteredApps, key = { it.packageName }) { app ->
                     AppRow(app = app, onClick = { onAppSelected(app.packageName) })
+                }
+                if (!showAll) {
+                    item {
+                        TextButton(
+                            onClick = { showAll = true },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Text(stringResource(R.string.picker_show_all))
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <!-- App Picker -->
     <string name="picker_title">Choose Gallery App</string>
     <string name="picker_search_hint">Search apps…</string>
+    <string name="picker_show_all">Show all apps</string>
+    <string name="picker_filtered_hint">Showing photo-related apps</string>
 
     <!-- Advanced Settings -->
     <string name="advanced_title">Advanced Settings</string>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#32 — Overlay not visible on lock screen**: Add `FLAG_SHOW_WHEN_LOCKED` to the overlay's `WindowManager.LayoutParams` so `TYPE_APPLICATION_OVERLAY` windows appear over the keyguard. Extracted to a local `val` so `@Suppress("DEPRECATION")` is correctly scoped to the declaration.
- **#33 — Show gallery icon then switch to latest photo thumbnail**: Register a separate thumbnail `ContentObserver` whenever the overlay becomes active (not just during lock-screen sessions). On each new photo, load a 200×200 thumbnail on a background thread and swap it onto the overlay button. Captures the view reference before launching the thread to prevent stale-reference races. Unregisters cleanly on overlay hide, deactivation, and `reset()`.
- **#38 — Filter app picker to photo-related apps by default**: Add `CATEGORY_APP_GALLERY` and `ACTION_VIEW/image/*` to the `<queries>` manifest block (required for API 30+ package visibility). Build the filtered set from the union of both `PackageManager` queries, wrapped in `runCatching`. Default picker view shows only photo-related apps with a "Showing photo-related apps" hint and a "Show all apps" fallback button; auto-falls back to the full list if the filtered set is empty.
- **#39 — Change overlay button shape from Circle to Squircle**: Set a custom `ViewOutlineProvider` on the overlay `ImageView` that clips to a rounded rectangle with 30% corner radius. Guards against zero-dimension layout passes in `getOutline()`.

## Test plan

- [ ] **#32**: Lock device → open camera from lock screen → confirm overlay button is visible
- [ ] **#33**: Open camera from home screen → take a photo → confirm overlay button switches from gallery icon to photo thumbnail; close camera → reopen → confirm icon resets to gallery icon
- [ ] **#38**: Open gallery app picker → confirm only photo-related apps shown with hint text; tap "Show all apps" → confirm full list appears
- [ ] **#38**: On a device where `CATEGORY_APP_GALLERY`/`image/*` queries return nothing → confirm picker automatically shows all apps
- [ ] **#39**: Open camera → confirm overlay button has rounded-square (squircle) shape instead of circle
- [ ] Run unit tests: `./gradlew :app:testDebugUnitTest` — all existing tests should pass unchanged (new `OverlayServiceLogic` params have default no-op values)

https://claude.ai/code/session_01PziNi8BtG2pisr3DB5hzt3
EOF
)