### PR TITLE
Automate version sync: git tag is single source of truth for versionName

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --no-daemon
-
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest --no-daemon
+      - name: Build and test
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: ./gradlew assembleDebug testDebugUnitTest -PversionName=dev.${{ github.run_number }} --no-daemon
 
       - name: Upload test results
         if: always()
@@ -126,7 +125,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build app, test, and mock Pixel Camera APKs
-        run: ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug --no-daemon
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: >
+          ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug
+          -PversionName=dev.${{ github.run_number }} --no-daemon
 
       - name: Start emulator
         run: |
@@ -241,7 +244,9 @@ jobs:
           path: app/build/outputs/androidTest-results/
           retention-days: 14
 
-  # Produce a release build on every merge to main (continuous delivery)
+  # Produce a signed release APK on every merge to main for easy sideloading.
+  # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.
+  # Runs after build (unit tests must pass) but independently of e2e-tests.
   release-build:
     if: github.event_name == 'push'
     needs: build
@@ -272,12 +277,27 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build release APK
-        run: ./gradlew assembleRelease --no-daemon
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+
+      - name: Build signed release APK
+        env:
+          KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: ./gradlew assembleRelease -PversionName=dev.${{ github.run_number }} --no-daemon
+
+      - name: Rename APK
+        run: |
+          mv app/build/outputs/apk/release/*.apk \
+             app/build/outputs/apk/release/gb4pc-dev.${{ github.run_number }}.apk
 
       - name: Upload release APK
         uses: actions/upload-artifact@v7
         with:
-          name: release-apk
-          path: app/build/outputs/apk/release/*.apk
+          name: gb4pc-dev.${{ github.run_number }}
+          path: app/build/outputs/apk/release/gb4pc-dev.${{ github.run_number }}.apk
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,54 +7,15 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build and test
-        env:
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: ./gradlew assembleDebug testDebugUnitTest -PversionName=dev.${{ github.run_number }} --no-daemon
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-results
-          path: app/build/reports/tests/
-          retention-days: 14
-
-  # End-to-end tests on an emulator using a minimal mock Pixel Camera stub.
+  # Gate for PRs and merges: compiles, runs unit tests, then E2E tests on an emulator.
+  # Unit tests run first so a fast failure skips the slower emulator phase.
+  # On success the single debug build is reused for both test suites.
   #
-  # The real Pixel Camera APK refuses to start on non-Pixel emulators (PairIP
-  # device-compatibility check). The e2e-mock-camera module has the same
-  # applicationId ("com.google.android.GoogleCamera") and opens the camera
-  # hardware on resume, so GB4PC's CameraManager callback and UsageStats-based
-  # foreground detection are exercised identically to the real app.
+  # E2E background: the real Pixel Camera APK refuses to start on non-Pixel emulators
+  # (PairIP device-compatibility check). The e2e-mock-camera module has the same
+  # applicationId ("com.google.android.GoogleCamera") and opens the camera hardware
+  # on resume, so GB4PC's CameraManager callback and UsageStats-based foreground
+  # detection are exercised identically to the real app.
   #
   # We manage the emulator lifecycle ourselves rather than using
   # reactivecircus/android-emulator-runner@v2 because the runner action
@@ -62,7 +23,7 @@ jobs:
   # sys.boot_completed=1, before system services accept binder connections on
   # the slow API-35 emulator — causing exit code 224 (Broken Pipe) before our
   # script ever starts. The explicit steps below poll for true service readiness.
-  e2e-tests:
+  build-and-test:
     # ubuntu-latest has KVM hardware acceleration (available since April 2024).
     runs-on: ubuntu-latest
 
@@ -124,12 +85,20 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build app, test, and mock Pixel Camera APKs
+      - name: Build and run unit tests
         env:
           BUILD_NUMBER: ${{ github.run_number }}
         run: >
           ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug
-          -PversionName=dev.${{ github.run_number }} --no-daemon
+          testDebugUnitTest -PversionName=dev.${{ github.run_number }} --no-daemon
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-results
+          path: app/build/reports/tests/
+          retention-days: 14
 
       - name: Start emulator
         run: |
@@ -244,12 +213,12 @@ jobs:
           path: app/build/outputs/androidTest-results/
           retention-days: 14
 
-  # Produce a signed release APK on every merge to main for easy sideloading.
+  # Produce a signed release-config APK on every merge to main for easy sideloading.
   # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.
-  # Runs after build (unit tests must pass) but independently of e2e-tests.
-  release-build:
+  # Waits for the full test suite (unit + E2E) before producing an artifact.
+  dev-build:
     if: github.event_name == 'push'
-    needs: build
+    needs: build-and-test
     runs-on: ubuntu-latest
 
     steps:
@@ -281,7 +250,7 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
 
-      - name: Build signed release APK
+      - name: Build signed release-config APK
         env:
           KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -295,7 +264,7 @@ jobs:
           mv app/build/outputs/apk/release/*.apk \
              app/build/outputs/apk/release/gb4pc-dev.${{ github.run_number }}.apk
 
-      - name: Upload release APK
+      - name: Upload dev APK
         uses: actions/upload-artifact@v7
         with:
           name: gb4pc-dev.${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          BUILD_NUMBER: ${{ github.run_number }}
         run: ./gradlew assembleRelease -PversionName=${{ steps.version.outputs.version }} --no-daemon
 
       - name: Rename APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --no-daemon
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          REF="${{ github.event.inputs.tag_name || github.ref_name }}"
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${REF}" >> "$GITHUB_OUTPUT"
+
       - name: Decode keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
@@ -54,14 +61,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew assembleRelease --no-daemon
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          REF="${{ github.event.inputs.tag_name || github.ref_name }}"
-          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
-          echo "tag_name=${REF}" >> "$GITHUB_OUTPUT"
+        run: ./gradlew assembleRelease -PversionName=${{ steps.version.outputs.version }} --no-daemon
 
       - name: Rename APK
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest --no-daemon
-
       - name: Extract version from tag
         id: version
         run: |
           REF="${{ github.event.inputs.tag_name || github.ref_name }}"
           echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
           echo "tag_name=${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Run unit tests
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: ./gradlew testDebugUnitTest -PversionName=${{ steps.version.outputs.version }} --no-daemon
 
       - name: Decode keystore
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  build-and-release:
+  tagged-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,9 +10,10 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
-// Versioning: semver versionName + yyyyMMdd time-based versionCode.
-// GitHub releases must be tagged v{versionName} (e.g. v0.0.1).
-// CI may override the build number via the BUILD_NUMBER env var.
+// Versioning: git tag is the single source of truth for versionName.
+// To release: run scripts/tag-release.sh <version> (e.g. 1.2.3).
+// CI extracts the version from the tag and injects it via -PversionName=X.Y.Z.
+// Dev builds (no property) show "dev". versionCode uses yyyyMMdd date or BUILD_NUMBER env var.
 // BUILD_NUMBER must be a valid integer; a malformed value fails the build loudly.
 val envBuildNumber: String? = System.getenv("BUILD_NUMBER")
 val buildNumber: Int = when {
@@ -31,7 +32,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = buildNumber
-        versionName = "0.0.2"
+        versionName = findProperty("versionName") as String? ?: "dev"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Exclude E2E tests from the standard instrumented-test run.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,8 @@ plugins {
 // Versioning: git tag is the single source of truth for versionName.
 // To release: run scripts/tag-release.sh <version> (e.g. 1.2.3).
 // CI extracts the version from the tag and injects it via -PversionName=X.Y.Z.
-// Dev builds (no property) show "dev". versionCode uses yyyyMMdd date or BUILD_NUMBER env var.
+// Dev builds (no property) show "dev". versionCode uses yyyyMMdd date locally or
+// github.run_number (via BUILD_NUMBER env var) in CI — monotonically increasing, no collisions.
 // BUILD_NUMBER must be a valid integer; a malformed value fails the build loudly.
 val envBuildNumber: String? = System.getenv("BUILD_NUMBER")
 val buildNumber: Int = when {

--- a/app/src/test/java/com/gb4pc/ReleaseVersionTest.kt
+++ b/app/src/test/java/com/gb4pc/ReleaseVersionTest.kt
@@ -14,50 +14,48 @@ import java.time.format.DateTimeParseException
  * validate the build that produced this APK, not future builds.
  *
  * Verifies:
- *  1. versionName follows semver (MAJOR.MINOR.PATCH, no leading zeros).
- *  2. versionCode is a valid yyyyMMdd build date (UTC) within a sane range.
+ *  1. versionName is either semver (MAJOR.MINOR.PATCH) for tagged releases, or
+ *     dev.N for CI/pre-release builds (where N is github.run_number).
+ *  2. versionCode is either a valid yyyyMMdd build date (local dev builds) or a
+ *     positive CI run number (github.run_number in CI builds).
  */
 class ReleaseVersionTest {
 
     @Test
-    fun `versionName follows semver MAJOR dot MINOR dot PATCH without leading zeros`() {
+    fun `versionName is semver or dev build label`() {
         val versionName = BuildConfig.VERSION_NAME
-        // Strict semver: no leading zeros per spec item 2.
         val semver = Regex("""^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$""")
+        val devLabel = Regex("""^dev\.\d+$""")
         assertTrue(
-            "versionName '$versionName' must follow semver MAJOR.MINOR.PATCH (no leading zeros)",
-            semver.matches(versionName)
+            "versionName '$versionName' must be semver (X.Y.Z) or a dev label (dev.N)",
+            semver.matches(versionName) || devLabel.matches(versionName)
         )
     }
 
     @Test
-    fun `versionCode is a valid yyyyMMdd build date`() {
+    fun `versionCode is a valid yyyyMMdd date or positive CI run number`() {
         val code = BuildConfig.VERSION_CODE
         val str = code.toString()
-        assertEquals(
-            "versionCode must be exactly 8 digits (yyyyMMdd format), was '$str'",
-            8, str.length
-        )
-        try {
-            LocalDate.parse(str, DateTimeFormatter.ofPattern("yyyyMMdd"))
-        } catch (e: DateTimeParseException) {
-            fail("versionCode '$code' is not a valid yyyyMMdd date: ${e.message}")
+        assertTrue("versionCode must be positive, was $code", code > 0)
+        if (str.length == 8) {
+            // Local dev build: validate as yyyyMMdd within sane range.
+            val buildDate = try {
+                LocalDate.parse(str, DateTimeFormatter.ofPattern("yyyyMMdd"))
+            } catch (e: DateTimeParseException) {
+                fail("8-digit versionCode '$code' is not a valid yyyyMMdd date: ${e.message}")
+                return
+            }
+            val projectEpoch = LocalDate.of(2024, 1, 1)
+            val tomorrow = LocalDate.now(ZoneOffset.UTC).plusDays(1)
+            assertTrue(
+                "versionCode date '$buildDate' is before project epoch ($projectEpoch)",
+                !buildDate.isBefore(projectEpoch)
+            )
+            assertFalse(
+                "versionCode date '$buildDate' should not be in the future",
+                buildDate.isAfter(tomorrow)
+            )
         }
-    }
-
-    @Test
-    fun `versionCode build date is within sane bounds`() {
-        val code = BuildConfig.VERSION_CODE
-        val buildDate = LocalDate.parse(code.toString(), DateTimeFormatter.ofPattern("yyyyMMdd"))
-        val projectEpoch = LocalDate.of(2024, 1, 1)
-        val tomorrow = LocalDate.now(ZoneOffset.UTC).plusDays(1)
-        assertTrue(
-            "versionCode build date '$buildDate' is before project epoch ($projectEpoch)",
-            !buildDate.isBefore(projectEpoch)
-        )
-        assertFalse(
-            "versionCode build date '$buildDate' should not be in the future",
-            buildDate.isAfter(tomorrow)
-        )
+        // else: CI build — github.run_number is any positive integer, already checked above.
     }
 }

--- a/app/src/test/java/com/gb4pc/ReleaseVersionTest.kt
+++ b/app/src/test/java/com/gb4pc/ReleaseVersionTest.kt
@@ -25,7 +25,7 @@ class ReleaseVersionTest {
     fun `versionName is semver or dev build label`() {
         val versionName = BuildConfig.VERSION_NAME
         val semver = Regex("""^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$""")
-        val devLabel = Regex("""^dev\.\d+$""")
+        val devLabel = Regex("""^dev(\.\d+)?$""")
         assertTrue(
             "versionName '$versionName' must be semver (X.Y.Z) or a dev label (dev.N)",
             semver.matches(versionName) || devLabel.matches(versionName)

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/tag-release.sh <version>  (e.g. ./scripts/tag-release.sh 1.2.3)
+# Creates an annotated git tag and pushes it to origin, which triggers the release workflow.
+# The tag is the single source of truth for versionName — no file edits required.
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+    echo "Error: version argument required." >&2
+    echo "Usage: $0 <version>  (e.g. $0 1.2.3)" >&2
+    exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must be semver X.Y.Z, got: '$VERSION'" >&2
+    exit 1
+fi
+
+TAG="v${VERSION}"
+
+if git rev-parse "$TAG" &>/dev/null; then
+    echo "Error: tag $TAG already exists." >&2
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is dirty — commit or stash changes before releasing." >&2
+    exit 1
+fi
+
+echo "Tagging $TAG on $(git rev-parse --short HEAD) …"
+git tag -a "$TAG" -m "Release $TAG"
+git push origin "$TAG"
+echo "Done. The release workflow will build and publish $TAG."

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -18,7 +18,7 @@ fi
 
 TAG="v${VERSION}"
 
-if git rev-parse "$TAG" &>/dev/null; then
+if git rev-parse "refs/tags/$TAG" &>/dev/null; then
     echo "Error: tag $TAG already exists." >&2
     exit 1
 fi


### PR DESCRIPTION
## What this does

Makes the **git tag** the single source of truth for `versionName`, so the version baked into the APK, the APK filename, and the GitHub Release name are always identical. Eliminates the previous manual step of editing `versionName` in `build.gradle.kts` before tagging.

Also enables **signed release APKs on every CI build** (not just tagged releases), making it easy to sideload any pre-release build.

## How it works

### `versionName` — injected from outside, never hardcoded

`app/build.gradle.kts` reads `versionName` from a Gradle project property (`-PversionName=…`). CI always supplies it; local builds without the property get `"dev"` as a fallback.

| Build | `versionName` | `versionCode` | APK filename |
|---|---|---|---|
| Local dev | `dev` | `yyyyMMdd` (date) | `app-release.apk` |
| CI merge to main | `dev.<run_number>` | `github.run_number` | `gb4pc-dev.<run_number>.apk` |
| Tagged release | `X.Y.Z` (from tag) | `github.run_number` | `gb4pc-X.Y.Z.apk` |

### `versionCode` — `github.run_number` in CI

`github.run_number` is a monotonically-increasing integer scoped to the repository. It fits easily in Android's int32 `versionCode` limit, never collides (even two releases on the same day get different values), and makes APK version ordering unambiguous for sideloading.

### `scripts/tag-release.sh` — one command to release

```
./scripts/tag-release.sh 1.2.3
```

Validates semver format, checks for a clean working tree, creates an annotated `v1.2.3` tag, and pushes it. The release workflow picks up from there — no file edits required.

### Workflow structure

Three jobs serve distinct purposes; none is redundant:

| Job | Trigger | Output | Signed |
|---|---|---|---|
| `build` (unit tests) | PRs + pushes | test report | — |
| `release-build` | push to main | `gb4pc-dev.N.apk` artifact | yes |
| `release.yml` | `v*` tag | GitHub Release + APK | yes |

`release-build` and the release workflow both produce signed APKs but differ in trigger, naming, and destination (Actions artifact vs. GitHub Release). The `release-build` job provides installable builds for every merge, so you don't have to tag just to test a sideloaded build.

## Files changed

- `app/build.gradle.kts` — `versionName` reads from `-PversionName` Gradle property
- `app/src/test/java/com/gb4pc/ReleaseVersionTest.kt` — updated to accept `dev.N` labels and `github.run_number` as versionCode
- `.github/workflows/build.yml` — version + build number injected everywhere; `release-build` job now signs and names APKs
- `.github/workflows/release.yml` — version extracted before unit tests so it can be passed to both; `BUILD_NUMBER=github.run_number` added
- `scripts/tag-release.sh` — new release helper

https://claude.ai/code/session_01GGycetahvWiq2FMpZDYT3g