### PR TITLE
Fix crash on Android 16: remove LIMIT from ContentProvider sort order

### DIFF
--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -307,7 +307,7 @@ class OverlayService : Service() {
         isVideo: Boolean
     ): MediaItem? {
         val selection = "${MediaStore.MediaColumns.DATE_ADDED} >= ?"
-        val sortOrder = "${MediaStore.MediaColumns.DATE_ADDED} DESC LIMIT 1"
+        val sortOrder = "${MediaStore.MediaColumns.DATE_ADDED} DESC"
         contentResolver.query(contentUri, projection, selection, selectionArgs, sortOrder)?.use { cursor ->
             if (cursor.moveToFirst()) {
                 val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))


### PR DESCRIPTION
Android 16 rejects LIMIT in the sortOrder string with
IllegalArgumentException. Since queryMediaStore already only reads the
first row via moveToFirst(), dropping LIMIT 1 is safe and correct.

Fixes crash reported against 20260420 build.

https://claude.ai/code/session_01Pfte26HasStNJn7VRH6Qop