### PR TITLE
Add agent orchestration guidelines; split code_review.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local.properties
 e2e/pixel-camera.apk
 e2e/pixel-camera.apkm
 .kotlin/
+.claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 # Instructions for agents
 
-- If participating in a PR or review, read `./agents/code_review.md`.
+- If addressing a GitHub issue or PR without a specific assigned role, read `./agents/dev_orchestration.md`.
+- If participating in a PR or review (as author, reviewer, or manager), read `./agents/pr_participation.md`.
+- If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for agents
 
 - If addressing a GitHub issue or PR without a specific assigned role, read `./agents/dev_orchestration.md`.
-- If participating in a PR or review (as author, reviewer, or manager), read `./agents/pr_participation.md`.
+- If participating in a PR or review (as Author, Reviewer, or Orchestrator), read `./agents/pr_participation.md`.
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -25,7 +25,7 @@ The Orchestrator is not a code reviewer or a programmer.
 ## Assigning a programmer
 
 - Create a Sonnet sub-agent unless the user requested otherwise
-- Inform the programmer of its role as an expert software developer resolving the issue
+- Inform the agent of its role as an expert software developer resolving the issue
 - Inform the programmer of its responsibility to commit its work to a branch and open a PR (if one doesn't speedy exist)
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -26,14 +26,14 @@ The Orchestrator is not a code reviewer or a programmer.
 
 - Create a Sonnet sub-agent unless the user requested otherwise
 - Inform the agent of its role as an expert software developer resolving the issue
-- Inform the programmer of its responsibility to commit its work to a branch and open a PR (if one doesn't speedy exist)
+- Inform the agent of its responsibility to commit its work to a branch and open a PR (if one doesn't already exist)
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user
 
 ## Assigning a reviewer
 
 - Create a Sonnet sub-agent unless the user requested otherwise
-- Inform the reviewer of its role as an expert software reviewer who ensures high quality code and adherence to development plans
+- Inform the agent of its role as an expert software reviewer who ensures high quality code and adherence to development plans
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -22,11 +22,26 @@ The Orchestrator is not a code reviewer or a programmer.
 - Dispatch and communicate with subagents
 - Relay subagent results to the user
 
+## Assigning a programmer
+
+- Create a Sonnet sub-agent unless the user requested otherwise
+- Inform the programmer of its role as an expert software developer resolving the issue
+- Inform the programmer of its responsibility to commit its work to a branch and open a PR (if one doesn't speedy exist)
+- Pass the issue number to the subagent
+- Relay any relevant instruction from the user
+
+## Assigning a reviewer
+
+- Create a Sonnet sub-agent unless the user requested otherwise
+- Inform the reviewer of its role as an expert software reviewer who ensures high quality code and adherence to development plans
+- Pass the issue number to the subagent
+- Relay any relevant instruction from the user
+
 ## Delegation rules
 
 - **One subagent per ticket.** Each issue or PR gets its own independent subagent.
 - **Dispatch in parallel** for independent issues.
-- **Do not pre-diagnose.** Pass the issue number to the subagent. Include along with any relevant instruction from the user. Do not include your own analysis of the root cause.
+- **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - **If a system hook or event signals uncommitted work, a test failure, or an error**, dispatch a cleanup subagent with the hook output as context — do not act directly.
 - **If no PR was opened**, then the programmer did not finish, even if it claimed otherwise. Assign another to finish the job.
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -2,19 +2,22 @@
 
 ## When you are the orchestrator
 
-If you are addressing a GitHub issue or PR but have not been given a specific role (programmer, code author, reviewer, etc.), then you are the **orchestrator only**.
+If you are addressing a GitHub issue or PR but have not been given a specific role (programmer, code author, reviewer, etc.), then you are the **orchestrator**.
 
 ## What orchestrators may and may not do
+
+The Orchestrator is not a code reviewer or a programmer.
 
 **May not:**
 - Read source files (Read, Bash cat/grep, etc.)
 - Edit or write files
 - Diagnose bugs or evaluate code
 - Make git commits or push changes
+- Create PRs
 - Apply fixes when an agent leaves work incomplete — dispatch another agent instead
 
 **May:**
-- Read issues and PRs via GitHub MCP tools
+- Read issues, PRs, and the comments on either via GitHub MCP tools
 - Read project instructions (AGENTS.md and the files it references)
 - Dispatch and communicate with subagents
 - Relay subagent results to the user
@@ -22,22 +25,13 @@ If you are addressing a GitHub issue or PR but have not been given a specific ro
 ## Delegation rules
 
 - **One subagent per ticket.** Each issue or PR gets its own independent subagent.
-- **Dispatch in parallel** when tickets are independent (different files, no shared state).
-- **Do not pre-diagnose.** Pass the issue title, body, and any referenced issue numbers to the subagent and let it explore the codebase. Do not include your own analysis of the root cause.
+- **Dispatch in parallel** for independent issues.
+- **Do not pre-diagnose.** Pass the issue number to the subagent. Include along with any relevant instruction from the user. Do not include your own analysis of the root cause.
 - **If a system hook or event signals uncommitted work, a test failure, or an error**, dispatch a cleanup subagent with the hook output as context — do not act directly.
+- **If no PR was opened**, then the programmer did not finish, even if it claimed otherwise. Assign another to finish the job.
 
-## PR creation
+## When to abort
 
-Before creating PRs, read `./agents/pr_creation.md`.
-
-## Template prompt (copy and adapt)
-
-```
-Implement any open issues.
-
-Read AGENTS.md first. You are the orchestrator: dispatch one subagent per issue to
-plan, code, and test. Dispatch independent subagents in parallel. Once all subagents
-complete, create PRs following pr_creation.md.
-
-Your subagents are expert programmers and will handle only one ticket each.
-```
+- **After three rounds** of the programmer / reviewer loop not reaching consensus (unless the user gave a different threshold)
+- **If the programmer gives up** or claims the issue cannot be solved as stated
+- **If the reviewer** agrees the PR may be merged

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -1,0 +1,43 @@
+# Development orchestration
+
+## When you are the orchestrator
+
+If you are addressing a GitHub issue or PR but have not been given a specific role (programmer, code author, reviewer, etc.), then you are the **orchestrator only**.
+
+## What orchestrators may and may not do
+
+**May not:**
+- Read source files (Read, Bash cat/grep, etc.)
+- Edit or write files
+- Diagnose bugs or evaluate code
+- Make git commits or push changes
+- Apply fixes when an agent leaves work incomplete — dispatch another agent instead
+
+**May:**
+- Read issues and PRs via GitHub MCP tools
+- Read project instructions (AGENTS.md and the files it references)
+- Dispatch and communicate with subagents
+- Relay subagent results to the user
+
+## Delegation rules
+
+- **One subagent per ticket.** Each issue or PR gets its own independent subagent.
+- **Dispatch in parallel** when tickets are independent (different files, no shared state).
+- **Do not pre-diagnose.** Pass the issue title, body, and any referenced issue numbers to the subagent and let it explore the codebase. Do not include your own analysis of the root cause.
+- **If a system hook or event signals uncommitted work, a test failure, or an error**, dispatch a cleanup subagent with the hook output as context — do not act directly.
+
+## PR creation
+
+Before creating PRs, read `./agents/pr_creation.md`.
+
+## Template prompt (copy and adapt)
+
+```
+Implement any open issues.
+
+Read AGENTS.md first. You are the orchestrator: dispatch one subagent per issue to
+plan, code, and test. Dispatch independent subagents in parallel. Once all subagents
+complete, create PRs following pr_creation.md.
+
+Your subagents are expert programmers and will handle only one ticket each.
+```

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -1,12 +1,12 @@
 # Development orchestration
 
-## When you are the orchestrator
+## When you are the Orchestrator
 
-If you are addressing a GitHub issue or PR but have not been given a specific role (programmer, code author, reviewer, etc.), then you are the **orchestrator**.
+If you are addressing a GitHub issue or PR but have not been given a specific role (Programmer, Author, Reviewer, etc.), then you are the **Orchestrator**.
 
-## What orchestrators may and may not do
+## What Orchestrators may and may not do
 
-The Orchestrator is not a code reviewer or a programmer.
+The Orchestrator is not a Reviewer or a Programmer.
 
 **May not:**
 - Read source files (Read, Bash cat/grep, etc.)
@@ -22,7 +22,7 @@ The Orchestrator is not a code reviewer or a programmer.
 - Dispatch and communicate with subagents
 - Relay subagent results to the user
 
-## Assigning a programmer
+## Assigning a Programmer
 
 - Create a Sonnet sub-agent unless the user requested otherwise
 - Inform the agent of its role as an expert software developer resolving the issue
@@ -30,7 +30,7 @@ The Orchestrator is not a code reviewer or a programmer.
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user
 
-## Assigning a reviewer
+## Assigning a Reviewer
 
 - Create a Sonnet sub-agent unless the user requested otherwise
 - Inform the agent of its role as an expert software reviewer who ensures high quality code and adherence to development plans
@@ -43,10 +43,10 @@ The Orchestrator is not a code reviewer or a programmer.
 - **Dispatch in parallel** for independent issues.
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - **If a system hook or event signals uncommitted work, a test failure, or an error**, dispatch a cleanup subagent with the hook output as context — do not act directly.
-- **If no PR was opened**, then the programmer did not finish, even if it claimed otherwise. Assign another to finish the job.
+- **If no PR was opened**, then the Programmer did not finish, even if it claimed otherwise. Assign another to finish the job.
 
 ## When to abort
 
-- **After three rounds** of the programmer / reviewer loop not reaching consensus (unless the user gave a different threshold)
-- **If the programmer gives up** or claims the issue cannot be solved as stated
-- **If the reviewer** agrees the PR may be merged
+- **After three rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)
+- **If the Programmer gives up** or claims the issue cannot be solved as stated
+- **If the Reviewer** agrees the PR may be merged

--- a/agents/pr_creation.md
+++ b/agents/pr_creation.md
@@ -1,0 +1,5 @@
+# PR creation
+
+## One topic per PR
+
+Do not combine unrelated work in a single PR. You may resolve multiple issues with one PR, but **only** if they are both symptoms of the same technical issue.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -6,10 +6,9 @@
 - An *Author* agent should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
 - This slightly competitive interaction between at least two parties is important to the SDLC, because it reduces the presence of untested ideas in our code.
 
-## Code review cycles should be overseen by a manager agent.
+## Code review cycles should be overseen by an Orchestrator (manager) agent.
 
-- If a reviewer requests a change, the manager may take on the role of coder to address it, but only for mechanical fixes (typos, import cleanup, renaming) where no design judgment is required.
-- A manager must not step into the role of reviewer, which should be independent.
+- An Orchestrator (manager) must not step into the role of reviewer or programmer, which should be independent.
 
 ## Scope
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -1,8 +1,8 @@
-# Code review standards
+# PR participation
 
-## Code reviews must be conversational, and slightly competitive, between **at least two parties**.
+## Reviews must be conversational, and slightly competitive, between **at least two parties**.
 
-- A *Reviewer* agent (or even its managing agent) must not make code changes itself, but should communicate discoveries clearly enough to convince a code author of the need to change the PR.
+- A *Reviewer* agent must not make code changes itself, but should communicate discoveries clearly enough to convince a code author of the need to change the PR.
 - An *Author* agent should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
 - This slightly competitive interaction between at least two parties is important to the SDLC, because it reduces the presence of untested ideas in our code.
 
@@ -15,7 +15,3 @@
 
 - During the code review process, don't allow the scope of work to increase.
 - Instead, spawn related items in the issue tracker.
-
-## Only one topic per PR
-
-Do not combine unrelated work in a single PR. You may resolve multiple issues with one PR, but **only** if they are both symptoms of the same technical issue.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -2,13 +2,13 @@
 
 ## Reviews must be conversational, and slightly competitive, between **at least two parties**.
 
-- A *Reviewer* agent must not make code changes itself, but should communicate discoveries clearly enough to convince a code author of the need to change the PR.
-- An *Author* agent should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
+- A *Reviewer* must not make code changes itself, but should communicate discoveries clearly enough to convince an Author of the need to change the PR.
+- An *Author* should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a Reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
 - This slightly competitive interaction between at least two parties is important to the SDLC, because it reduces the presence of untested ideas in our code.
 
-## Code review cycles should be overseen by an Orchestrator (manager) agent.
+## Code review cycles should be overseen by an Orchestrator.
 
-- An Orchestrator (manager) must not step into the role of reviewer or programmer, which should be independent.
+- An Orchestrator must not step into the role of Reviewer or Programmer, which should be independent.
 
 ## Scope
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -1,5 +1,7 @@
 # PR participation
 
+**Terminology**: In most cases, the *Author* is also referred to as *Programmer*. In this document, we use the term *Author* to allow for PRs that don't involve code changes.
+
 ## Reviews must be conversational, and slightly competitive, between **at least two parties**.
 
 - A *Reviewer* must not make code changes itself, but should communicate discoveries clearly enough to convince an Author of the need to change the PR.


### PR DESCRIPTION
## Summary

- Adds `agents/dev_orchestration.md` — rules for the orchestrator role and a reusable template prompt. Key constraints: no direct file reads/edits/commits; one subagent per ticket; dispatch in parallel where possible; dispatch a cleanup agent (not act directly) when hooks signal uncommitted work.
- Splits `agents/code_review.md` into two focused files:
  - `agents/pr_participation.md` — conversational/competitive review dynamics, author skepticism, manager constraints, scope guard
  - `agents/pr_creation.md` — one-topic-per-PR rule
- Updates `AGENTS.md` to route each agent role to exactly one guideline file: orchestrators → `dev_orchestration.md`, PR participants → `pr_participation.md`, PR creators → `pr_creation.md`, code editors → `code_edit.md`
- Gitignores `.claude/worktrees/` (agent working directories created by isolated worktree runs)

## Test plan
- [ ] Verify `AGENTS.md` links resolve to existing files
- [ ] Confirm `code_review.md` is gone and its content is fully preserved across the two new files

https://claude.ai/code/session_01VFH5vqVWexnvwGQMmgVikJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFH5vqVWexnvwGQMmgVikJ)_