### PR TITLE
Skip debounce if camera no longer foreground

### DIFF
--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -57,7 +57,12 @@ class OverlayServiceLogic(
         // DT-04/DT-05: Only schedule deactivation when ALL cameras have been released
         if (cameraState.areAllCamerasAvailable()) {
             cancelActivationRetry()
-            scheduleDeactivation()
+            // Issue #46: If Pixel Camera is no longer in the foreground, skip the debounce delay.
+            // The debounce is only needed for transient camera switches (where hardware briefly
+            // shows available between switching cameras); for a true app-close we want 0 ms.
+            val pkg = foregroundDetector.getForegroundPackage()
+            val delay = if (ForegroundDetector.isPixelCameraPackage(pkg)) debounceMs else 0L
+            scheduleDeactivation(delay)
         }
     }
 
@@ -112,9 +117,11 @@ class OverlayServiceLogic(
     }
 
     /**
-     * DT-04: Schedule overlay deactivation with a debounce delay.
+     * DT-04: Schedule overlay deactivation with an optional delay.
+     * Defaults to [debounceMs] for transient camera switches; pass 0L when the app has already
+     * left the foreground (Issue #46).
      */
-    fun scheduleDeactivation() {
+    fun scheduleDeactivation(delayMs: Long = debounceMs) {
         cancelPendingDeactivation()
         deactivateRunnable = Runnable {
             if (cameraState.areAllCamerasAvailable()) {
@@ -128,7 +135,7 @@ class OverlayServiceLogic(
                 }
             }
         }
-        handler.postDelayed(deactivateRunnable!!, debounceMs)
+        handler.postDelayed(deactivateRunnable!!, delayMs)
     }
 
     fun cancelPendingDeactivation() {

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -412,4 +412,61 @@ class OverlayServiceLogicTest {
 
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
     }
+
+    // ── Issue #46: foreground-aware deactivation delay ──────────────────────
+
+    /**
+     * When all cameras become available and Pixel Camera is no longer the foreground app
+     * (the user closed the camera app), deactivation should be scheduled with 0 ms delay —
+     * no debounce needed for a true app-close.
+     */
+    @Test
+    fun `issue-46 deactivation uses 0ms delay when Pixel Camera is not foreground on camera release`() {
+        // Activate the overlay while Pixel Camera is in the foreground
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logic.onCameraUnavailable("0")
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+
+        // User closed Pixel Camera; UsageStats now shows a different app
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn("com.example.otherapp")
+
+        logic.onCameraAvailable("0")
+
+        verify(handler).postDelayed(any(), eq(0L))
+    }
+
+    /**
+     * When all cameras become available and Pixel Camera is still the foreground app
+     * (transient camera switch between lenses), deactivation should be scheduled with the
+     * configured debounceMs so the overlay is not prematurely hidden.
+     */
+    @Test
+    fun `issue-46 deactivation uses debounceMs delay when Pixel Camera is still foreground on camera switch`() {
+        val debounce = 50L
+        val logicWithDebounce = OverlayServiceLogic(
+            hasUsageStatsPermission = { true },
+            hasOverlayPermission = { true },
+            overlayManager = overlayManager,
+            cameraState = CameraState(),
+            foregroundDetector = foregroundDetector,
+            sessionTracker = sessionTracker,
+            handler = handler,
+            debounceMs = debounce,
+            onUsageAccessLost = {},
+            onOverlayPermissionLost = {},
+            isKeyguardLocked = { false },
+            onRegisterMediaObserver = {},
+            onUnregisterMediaObserver = {},
+        )
+
+        // Activate the overlay
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logicWithDebounce.onCameraUnavailable("0")
+        assertTrue("Pre-condition: overlay should be active", logicWithDebounce.isOverlayActive)
+
+        // Camera becomes available while Pixel Camera is still in the foreground (camera switch)
+        logicWithDebounce.onCameraAvailable("0")
+
+        verify(handler).postDelayed(any(), eq(debounce))
+    }
 }


### PR DESCRIPTION
Helps #46 a little.

## Summary

The `CameraManager` availability callback fires with ~450 ms latency after the camera app releases the hardware. Even with the 50 ms debounce the total visible time was ~500 ms, because the debounce only adds to — not reduces — the callback latency.

When all cameras become available, `onCameraAvailable` now queries UsageStats to check whether Pixel Camera is still the foreground app:
- **No longer foreground** (normal close): deactivation delay is 0 ms — the overlay hides as soon as the callback arrives.
- **Still foreground** (camera switch): the configured debounce is applied to avoid flickering between front/back cameras.

`scheduleDeactivation` gains an optional `delayMs` parameter (default `debounceMs`) to support this, keeping all existing call sites unchanged.

## Test plan
- [ ] Close Pixel Camera; verify the overlay button disappears promptly (within ~50 ms of the callback, not ~500 ms).
- [ ] Switch between front and back cameras while in Pixel Camera; verify the overlay does not flicker off.
- [ ] New unit tests: `issue-46 deactivation uses 0ms delay when Pixel Camera is not foreground on camera release` and `issue-46 deactivation uses debounceMs delay when Pixel Camera is still foreground on camera switch`.

https://claude.ai/code/session_01VFH5vqVWexnvwGQMmgVikJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFH5vqVWexnvwGQMmgVikJ)_