### PR TITLE
Add Robolectric test for Issue #45 regression

### DIFF
--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -1,0 +1,88 @@
+package com.gb4pc.overlay
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.view.WindowManager
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import com.gb4pc.data.OverlayPosition
+import com.gb4pc.data.PrefsManager
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowWindowManagerImpl
+
+/**
+ * Robolectric integration test for OverlayManager — Issue #45 regression.
+ *
+ * Verifies that a second call to show() (as fired by a dual-camera device that
+ * triggers onCameraUnavailable once per physical lens) does NOT overwrite a thumbnail
+ * that was already loaded by showLatestPhotoThumbnail() with the app icon.
+ *
+ * Before the fix, OverlayManager.show() called updateIcon() unconditionally when the
+ * overlay was already showing, resetting the ImageView to the gallery icon drawable.
+ * After the fix, show() returns early when isShowing == true, leaving any loaded
+ * thumbnail intact.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OverlayManagerRobolectricTest {
+
+    /**
+     * Three-step regression guard for the dual-camera thumbnail-overwrite bug:
+     *
+     *   1. show()                          → overlay added; ImageView holds icon drawable
+     *   2. overlayView.setImageBitmap(bmp) → simulates showLatestPhotoThumbnail() success
+     *   3. show() again                    → must be a no-op (isShowing guard)
+     *   4. Assert drawable is still BitmapDrawable → updateIcon() was NOT called
+     */
+    @Test
+    fun `second show call does not overwrite thumbnail bitmap with icon`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+
+        // Mock PrefsManager: galleryPackage = null → getGalleryIcon returns the plain
+        // placeholder drawable (a VectorDrawable / LayerDrawable, NOT a BitmapDrawable),
+        // so any BitmapDrawable on the view must have come from setImageBitmap().
+        val prefsManager: PrefsManager = mock {
+            on { galleryPackage } doReturn null
+            on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+        }
+
+        val overlayManager = OverlayManager(context, prefsManager)
+
+        // Step 1: first show() — overlay view is added to the WindowManager.
+        overlayManager.show()
+
+        // Retrieve the view from ShadowWindowManagerImpl (Robolectric shadow).
+        val windowManager = context.getSystemService(WindowManager::class.java)
+        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+        val views = shadowWm.views
+        assertEquals("Expected exactly one view added to WindowManager after show()", 1, views.size)
+        val overlayView = views[0] as ImageView
+
+        // Step 2: simulate showLatestPhotoThumbnail() successfully loading a bitmap.
+        val testBitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
+        overlayView.setImageBitmap(testBitmap)
+        assertTrue(
+            "Sanity: after setImageBitmap the drawable must be a BitmapDrawable",
+            overlayView.drawable is BitmapDrawable
+        )
+
+        // Step 3: second show() call — simulates the second camera lens on a dual-camera
+        // device firing its onCameraUnavailable callback while the overlay is already up.
+        overlayManager.show()
+
+        // Step 4: The drawable must still be a BitmapDrawable — the isShowing guard in
+        // show() returned early so updateIcon() was never called.
+        assertTrue(
+            "After the second show() call the thumbnail BitmapDrawable must not have been " +
+                "replaced by the icon drawable (regression guard for Issue #45)",
+            overlayView.drawable is BitmapDrawable
+        )
+    }
+}

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
@@ -1,6 +1,5 @@
 package com.gb4pc.overlay
 
-import com.gb4pc.Constants
 import com.gb4pc.data.OverlayPosition
 import org.junit.Assert.*
 import org.junit.Test
@@ -18,16 +17,13 @@ import org.junit.Test
  *
  * A direct unit test for this behaviour requires OverlayManager to be instantiated,
  * which in turn needs a real Android Context, WindowManager and KeyguardManager. Those
- * are not available in JVM unit tests without Robolectric. A Robolectric (or
- * instrumented) test should verify:
+ * are not available in JVM unit tests without Robolectric. See
+ * OverlayManagerRobolectricTest for a Robolectric test that verifies:
  *
  *   1. Call show() → overlay is created with the gallery icon drawable.
  *   2. Call showLatestPhotoThumbnail(...) → the ImageView now holds a Bitmap drawable.
  *   3. Call show() again (simulating a second onCameraUnavailable event) → the ImageView
  *      still holds the Bitmap drawable, NOT a Drawable (i.e. updateIcon() was NOT called).
- *
- * Because the fixed code path is a single-line deletion in OverlayManager.show(), the
- * correctness guarantee lives in the diff itself plus this documented contract.
  */
 class OverlayManagerTest {
 


### PR DESCRIPTION
## Summary

Adds a comprehensive Robolectric integration test (`OverlayManagerRobolectricTest`) that validates the fix for Issue #45: verifying that a second call to `OverlayManager.show()` does not overwrite a loaded photo thumbnail with the gallery-app icon.

This addresses the feedback from PR #51: https://github.com/aunger/gallery-button-for-pixel-camera/pull/51#issuecomment-4321458240

## Problem

On dual-camera devices, `CameraManager.onCameraUnavailable()` fires once per physical lens. In PR #51, we removed the redundant `updateIcon()` call from `OverlayManager.show()` that was silently overwriting the thumbnail. However, the fix lacked a regression test.

## Solution

The Robolectric test simulates the exact scenario:
1. Call `show()` → overlay created with icon drawable
2. Call `setImageBitmap()` → simulates `showLatestPhotoThumbnail()` loading a thumbnail
3. Call `show()` again → simulates second camera's `onCameraUnavailable` callback
4. Assert drawable is still `BitmapDrawable` → confirms `updateIcon()` was NOT called

Also updated `OverlayManagerTest` documentation to resolve the contradictory claims about what can be tested without Android frameworks.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all tests pass including new `OverlayManagerRobolectricTest`
- [x] Robolectric test isolates the exact regression scenario without requiring Pixel Camera or device setup

https://claude.ai/code/session_01DvCzDAijh2xvw9BWppKdN6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvCzDAijh2xvw9BWppKdN6)_