### PR TITLE
Remove dead updateIcon() method from OverlayManager

### DIFF
--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -112,10 +112,6 @@ class OverlayManager(
         return imageView
     }
 
-    private fun updateIcon() {
-        overlayView?.let { updateIconDrawable(it) }
-    }
-
     /**
      * WG-01: Extract icon live from PackageManager each time.
      * WG-02: Use adaptive icon shape mask.


### PR DESCRIPTION
## Summary

Fixes #56

After PR #51 removed the only call to `updateIcon()` inside `show()`, the private `updateIcon()` method became dead code with no callers. This commit deletes it.

`updateIconDrawable()` (the helper it delegated to) still has a direct caller in `createOverlayView()` and is retained unchanged.

## Test plan
- [ ] All JVM unit tests pass (`./gradlew testDebugUnitTest`).
- [ ] `OverlayManagerTest` still passes — no test referenced the deleted method.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNTz4dYuJED42aF6k37VBc)_