### PR TITLE
docs: add branch-isolation rules and inaugurate.md

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -22,6 +22,10 @@ The Orchestrator is not a Reviewer or a Programmer.
 - Dispatch and communicate with subagents
 - Relay subagent results to the user
 
+## Inaugurating work for a hitherto unworked issue
+
+- See `inaugurate.md` for the full protocol when starting fresh work.
+
 ## Assigning a Programmer
 
 - Create a Sonnet sub-agent unless the user requested otherwise
@@ -40,9 +44,9 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 ## Delegation rules
 
-- **One branch per ticket.** Each issue gets its own dedicated branch. Parallel independent issues must each have their own branch. See `inaugurate.md` for the full protocol when starting fresh work.
 - **One subagent per ticket.** Each issue or PR gets its own independent subagent.
-- **Dispatch in parallel** for independent issues.
+- **One branch per ticket.** Each issue gets its own dedicated branch.  
+- **Dispatch in parallel** for independent issues. Parallel independent issues must each have their own branch.
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - **If a system hook or event signals uncommitted work, a test failure, or an error**, dispatch a cleanup subagent with the hook output as context — do not act directly.
 - **If no PR was opened**, then the Programmer did not finish, even if it claimed otherwise. Assign another to finish the job.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -27,6 +27,7 @@ The Orchestrator is not a Reviewer or a Programmer.
 - Create a Sonnet sub-agent unless the user requested otherwise
 - Inform the agent of its role as an expert software developer resolving the issue
 - Inform the agent of its responsibility to commit its work to a branch and open a PR (if one doesn't already exist)
+- Specify a dedicated per-issue branch name for the Programmer to use. Branch names should follow the pattern `fix/issue-N-short-description` for bug fixes or `feature/issue-N-short-description` for new features. Never direct two Programmers for unrelated issues to the same branch.
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user
 
@@ -39,6 +40,7 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 ## Delegation rules
 
+- **One branch per ticket.** Each issue gets its own dedicated branch. Parallel independent issues must each have their own branch. See `inaugurate.md` for the full protocol when starting fresh work.
 - **One subagent per ticket.** Each issue or PR gets its own independent subagent.
 - **Dispatch in parallel** for independent issues.
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.

--- a/agents/inaugurate.md
+++ b/agents/inaugurate.md
@@ -1,0 +1,26 @@
+# Inaugurating work on new issues
+
+Use this protocol when acting as Orchestrator and tasked with starting fresh work on one or more issues that have no existing PR or branch.
+
+## One branch per issue — no exceptions
+
+Each issue must be developed on its own dedicated branch. This is the branch-level enforcement of the one-topic-per-PR rule.
+
+- Never direct two Programmers for unrelated issues to the same branch.
+- Name branches: `fix/issue-N-short-description` for bug fixes, `feature/issue-N-short-description` for new features.
+
+## Session-designated branches
+
+A session setup may specify a single "development branch." Treat this as context or a naming hint — not as the branch each Programmer must commit to. Each Programmer still gets their own per-issue branch (which may incorporate the session branch name as inspiration, e.g. `fix/issue-56-...`).
+
+## What to tell each Programmer
+
+When dispatching a Programmer for a new issue, always specify:
+
+1. The branch name they must create and use (one per issue, following the naming pattern above).
+2. That they must push to their own branch and open a PR from it.
+3. That they must not push to any branch already holding another issue's work.
+
+## Parallel dispatch
+
+Dispatching Programmers in parallel for independent issues is correct — but each must receive a different branch name. Verify this before sending the parallel dispatch.

--- a/agents/pr_creation.md
+++ b/agents/pr_creation.md
@@ -3,3 +3,7 @@
 ## One topic per PR
 
 Do not combine unrelated work in a single PR. You may resolve multiple issues with one PR, but **only** if they are both symptoms of the same technical issue.
+
+## One branch per PR
+
+Each PR must originate from its own dedicated branch containing only that topic's commits. A branch shared across unrelated issues will produce a PR that violates the one-topic rule regardless of how the commits are organised. If a session specifies a shared development branch, do not use it as the commit target for multiple issues — follow `inaugurate.md` instead.


### PR DESCRIPTION
## Summary

- Adds a "One branch per ticket" rule to `agents/dev_orchestration.md` (Delegation rules) and a branch-naming requirement in "Assigning a Programmer", preventing Orchestrators from directing two Programmers for unrelated issues to the same branch.
- Adds a "One branch per PR" section to `agents/pr_creation.md`, making explicit that a shared branch violates the one-topic rule at the branch level.
- Creates `agents/inaugurate.md`, a new protocol document for Orchestrators starting fresh work on issues with no existing PR or branch, covering the one-branch-per-issue rule, session-designated branch handling, what to tell each Programmer, and parallel dispatch verification.

These changes address the root causes of the incident where an Orchestrator dispatched Programmers for issues #55 and #56 to the same branch (`claude/implement-issues-55-56-EOurs`), resulting in a single mixed-topic PR that had to be closed and re-opened as two separate PRs.

Replaces #61, which was accidentally based on `claude/implement-issues-55-56-EOurs` instead of `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNTz4dYuJED42aF6k37VBc)_