### PR TITLE
Fix #63: prevent settings title from rendering behind the status bar

### DIFF
--- a/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
@@ -90,6 +90,7 @@ fun MainSettingsScreen(
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
+                .windowInsetsPadding(WindowInsets.statusBars)
                 .padding(16.dp)
                 .fillMaxWidth()
         ) {


### PR DESCRIPTION
## Summary

- On Android 15 (`targetSdk = 35`) edge-to-edge is enforced for all activities, causing the `MainSettingsScreen` `Column` to start at the very top of the screen.
- The "GB4PC" title was rendered behind the status bar clock, as reported in issue #63.
- Added `windowInsetsPadding(WindowInsets.statusBars)` to the `Column` modifier in `MainSettingsScreen` so content begins below the status bar.

## Test plan

- [ ] Build and run on a device or emulator with Android 15 (API 35) and verify the "GB4PC" title is fully visible below the status bar.
- [ ] Confirm the existing instrumented test `MainSettingsScreenTest.mainScreen_showsAppName()` still passes.
- [ ] Confirm no other existing tests are broken.

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_