### PR TITLE
Fix #64: Follow system theme (dark mode support)

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/ui/theme/ThemeTest.kt
+++ b/app/src/androidTest/java/com/gb4pc/ui/theme/ThemeTest.kt
@@ -1,0 +1,56 @@
+package com.gb4pc.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that GB4PCTheme forwards the correct color scheme based on [darkTheme].
+ */
+@RunWith(AndroidJUnit4::class)
+class ThemeTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun gb4pcTheme_rendersContent() {
+        composeRule.setContent {
+            GB4PCTheme {
+                Text("hello")
+            }
+        }
+        composeRule.onNodeWithText("hello").assertIsDisplayed()
+    }
+
+    @Test
+    fun gb4pcTheme_lightMode_usesLightColorScheme() {
+        var background = androidx.compose.ui.graphics.Color.Unspecified
+        composeRule.setContent {
+            GB4PCTheme(darkTheme = false) {
+                background = MaterialTheme.colorScheme.background
+            }
+        }
+        assertEquals(lightColorScheme().background, background)
+    }
+
+    @Test
+    fun gb4pcTheme_darkMode_usesDarkColorScheme() {
+        var background = androidx.compose.ui.graphics.Color.Unspecified
+        composeRule.setContent {
+            GB4PCTheme(darkTheme = true) {
+                background = MaterialTheme.colorScheme.background
+            }
+        }
+        assertEquals(darkColorScheme().background, background)
+    }
+}

--- a/app/src/main/java/com/gb4pc/ui/picker/PickerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/picker/PickerActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 import com.gb4pc.R
 import com.gb4pc.data.PrefsManager
+import com.gb4pc.ui.theme.GB4PCTheme
 import com.gb4pc.util.DebugLog
 
 /**
@@ -45,7 +46,7 @@ class PickerActivity : ComponentActivity() {
         launchAfterPick = intent.getBooleanExtra(EXTRA_LAUNCH_AFTER_PICK, false)
 
         setContent {
-            MaterialTheme {
+            GB4PCTheme {
                 PickerScreen(
                     prefsManager = prefsManager,
                     onAppSelected = { packageName ->

--- a/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
@@ -24,6 +24,7 @@ import com.gb4pc.R
 import com.gb4pc.data.AspectRatioUtil
 import com.gb4pc.data.OverlayPosition
 import com.gb4pc.data.PrefsManager
+import com.gb4pc.ui.theme.GB4PCTheme
 import com.gb4pc.util.DebugLog
 import java.text.SimpleDateFormat
 import java.util.*
@@ -35,7 +36,7 @@ class AdvancedSettingsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MaterialTheme {
+            GB4PCTheme {
                 AdvancedSettingsScreen(PrefsManager(this))
             }
         }

--- a/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
@@ -23,6 +23,7 @@ import com.gb4pc.data.PrefsManager
 import com.gb4pc.service.OverlayService
 import com.gb4pc.ui.picker.PickerActivity
 import com.gb4pc.ui.setup.SetupActivity
+import com.gb4pc.ui.theme.GB4PCTheme
 import com.gb4pc.util.PermissionHelper
 
 class MainActivity : ComponentActivity() {
@@ -50,7 +51,7 @@ class MainActivity : ComponentActivity() {
 
         // setContent called only once here (H2 fix)
         setContent {
-            MaterialTheme {
+            GB4PCTheme {
                 MainSettingsScreen(
                     prefsManager = prefsManager,
                     isPixelCameraInstalled = isPixelCameraInstalled.value,

--- a/app/src/main/java/com/gb4pc/ui/setup/SetupActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/setup/SetupActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.gb4pc.R
 import com.gb4pc.data.PrefsManager
+import com.gb4pc.ui.theme.GB4PCTheme
 import com.gb4pc.util.PermissionHelper
 
 /**
@@ -68,7 +69,7 @@ class SetupActivity : ComponentActivity() {
         if (setupState.isCompleted) return
 
         setContent {
-            MaterialTheme {
+            GB4PCTheme {
                 SetupScreen(
                     currentStep = setupState.currentStep,
                     onGrantClick = { handleGrant(setupState.currentStep) },

--- a/app/src/main/java/com/gb4pc/ui/theme/Theme.kt
+++ b/app/src/main/java/com/gb4pc/ui/theme/Theme.kt
@@ -1,0 +1,24 @@
+package com.gb4pc.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColors = darkColorScheme()
+private val LightColors = lightColorScheme()
+
+/**
+ * App-wide Material 3 theme that follows the system dark/light preference.
+ */
+@Composable
+fun GB4PCTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColors else LightColors,
+        content = content
+    )
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.GB4PC" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.GB4PC" parent="Theme.MaterialComponents.DayNight.NoActionBar">
     </style>
 
-    <style name="Theme.GB4PC.Transparent" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.GB4PC.Transparent" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowNoTitle">true</item>


### PR DESCRIPTION
## Summary

- Add `GB4PCTheme` composable in `ui/theme/Theme.kt` that selects between `darkColorScheme()` and `lightColorScheme()` based on `isSystemInDarkTheme()`, defaulting to the system preference
- Replace bare `MaterialTheme {}` wrappers in all four activities (`MainActivity`, `AdvancedSettingsActivity`, `PickerActivity`, `SetupActivity`) with `GB4PCTheme`
- Update `themes.xml` to parent `Theme.GB4PC` and `Theme.GB4PC.Transparent` from `Theme.MaterialComponents.DayNight.NoActionBar` (matching the already-correct `Theme.GB4PC.Viewer`) so the activity window chrome also tracks the system theme

## Test plan

- [ ] Build and install on a device/emulator; toggle system Dark Mode — all settings screens (main, advanced, picker, setup) should switch between light and dark palettes
- [ ] Instrumented `ThemeTest` (in `com.gb4pc.ui.theme`) verifies `GB4PCTheme(darkTheme = false)` applies `lightColorScheme` and `GB4PCTheme(darkTheme = true)` applies `darkColorScheme`
- [ ] Run `./gradlew connectedDebugAndroidTest` and confirm all existing tests still pass

Closes #64

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_