### PR TITLE
Fix #66: overlay never shows in v0.0.6

### DIFF
--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -136,6 +136,11 @@ class OverlayManager(
 
             override fun onWindowFocusChanged(hasFocus: Boolean) {
                 super.onWindowFocusChanged(hasFocus)
+                // Only invoke focus callbacks when the focusable-overlay mode is active.
+                // With FLAG_NOT_FOCUSABLE (default), the window never receives focus, so
+                // onWindowFocusChanged(false) fires immediately after show() — calling
+                // onFocusLost() here would hide the overlay the instant it appears (Issue #66).
+                if (!prefsManager.focusableOverlay) return
                 if (hasFocus) {
                     DebugLog.log("Overlay gained window focus")
                     onFocusGained()

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -19,19 +19,61 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowWindowManagerImpl
 
 /**
- * Robolectric integration test for OverlayManager — Issue #45 regression.
+ * Robolectric integration tests for OverlayManager.
  *
- * Verifies that a second call to show() (as fired by a dual-camera device that
- * triggers onCameraUnavailable once per physical lens) does NOT overwrite a thumbnail
- * that was already loaded by showLatestPhotoThumbnail() with the app icon.
- *
- * Before the fix, OverlayManager.show() called updateIcon() unconditionally when the
- * overlay was already showing, resetting the ImageView to the gallery icon drawable.
- * After the fix, show() returns early when isShowing == true, leaving any loaded
- * thumbnail intact.
+ * Covers:
+ * - Issue #45: second show() must not overwrite a thumbnail with the icon.
+ * - Issue #66: overlay must remain visible after show() when focusableOverlay is false
+ *   (FLAG_NOT_FOCUSABLE windows never receive focus, so onWindowFocusChanged(false) fires
+ *   immediately — the focus callbacks must be suppressed in that mode).
  */
 @RunWith(RobolectricTestRunner::class)
 class OverlayManagerRobolectricTest {
+
+    /**
+     * Regression guard for Issue #66: when focusableOverlay is false (the default),
+     * onFocusLost must not be called when the overlay is shown.
+     *
+     * With FLAG_NOT_FOCUSABLE the window never receives input focus, so Android fires
+     * onWindowFocusChanged(false) immediately after the view is attached. Before the fix,
+     * this fired the onFocusLost callback unconditionally, which hid the overlay the instant
+     * it was shown — causing the overlay to never appear in v0.0.6.
+     */
+    @Test
+    fun `show with non-focusable overlay does not trigger onFocusLost`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+
+        val prefsManager: PrefsManager = mock {
+            on { galleryPackage } doReturn null
+            on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+            on { focusableOverlay } doReturn false
+        }
+
+        var focusLostCount = 0
+        val overlayManager = OverlayManager(
+            context = context,
+            prefsManager = prefsManager,
+            onFocusLost = { focusLostCount++ },
+            onFocusGained = {},
+        )
+
+        overlayManager.show()
+
+        // onFocusLost must not have been called — the overlay should stay visible.
+        assertEquals(
+            "onFocusLost must not fire when focusableOverlay is false (Issue #66 regression)",
+            0,
+            focusLostCount
+        )
+
+        val windowManager = context.getSystemService(WindowManager::class.java)
+        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+        assertEquals(
+            "Overlay view must remain in the WindowManager after show()",
+            1,
+            shadowWm.views.size
+        )
+    }
 
     /**
      * Three-step regression guard for the dual-camera thumbnail-overwrite bug:


### PR DESCRIPTION
## Summary

- Fixes #66 — overlay never appears in v0.0.6 (regression introduced by PR #60).

**Root cause:** PR #60 added `onWindowFocusChanged` to the overlay `ImageView` to power the experimental focusable-overlay mode. When the default `FLAG_NOT_FOCUSABLE` window flags are used, Android immediately fires `onWindowFocusChanged(false)` as soon as the view is attached to the window. Without a guard, this called `onFocusLost()` unconditionally, which hid the overlay the instant it was shown — making the overlay never appear.

**Fix:** Add `if (!prefsManager.focusableOverlay) return` at the top of `onWindowFocusChanged` so focus callbacks are only dispatched when the experimental focusable-overlay preference is actually enabled.

## Test plan

- [x] New Robolectric regression test `show with non-focusable overlay does not trigger onFocusLost` verifies that `onFocusLost` is not called and the view remains in the `WindowManager` after `show()` when `focusableOverlay` is `false`.
- [x] Existing Issue #45 regression test is unchanged and still passes.
- [ ] All JVM unit tests pass (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_