### PR TITLE
Fix #67: check for service when app opens

### DIFF
--- a/app/src/main/java/com/gb4pc/service/ServiceChecker.kt
+++ b/app/src/main/java/com/gb4pc/service/ServiceChecker.kt
@@ -1,0 +1,44 @@
+package com.gb4pc.service
+
+import android.app.ActivityManager
+import android.content.Context
+import com.gb4pc.data.PrefsManager
+import com.gb4pc.util.DebugLog
+
+/**
+ * Checks whether the overlay service should be running and starts it if it isn't (issue #67).
+ *
+ * Extracted as a standalone object so the logic can be unit-tested without a real Activity.
+ */
+object ServiceChecker {
+
+    /**
+     * Returns true if [OverlayService] currently has a running instance.
+     *
+     * [ActivityManager.getRunningServices] is deprecated for third-party use on API 26+ but
+     * remains functional for an app querying its own services, which is exactly our use case.
+     */
+    @Suppress("DEPRECATION")
+    fun isServiceRunning(context: Context): Boolean {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val serviceName = OverlayService::class.java.name
+        return am.getRunningServices(Int.MAX_VALUE)
+            .any { it.service.className == serviceName }
+    }
+
+    /**
+     * If the service is enabled in preferences but is not currently running, logs the
+     * discrepancy and starts the service.
+     *
+     * Call this on app launch (e.g. [android.app.Activity.onCreate]) so a crashed or
+     * killed service is automatically recovered.
+     */
+    fun ensureServiceRunningIfEnabled(context: Context, prefs: PrefsManager) {
+        if (!prefs.isServiceEnabled) return
+
+        if (!isServiceRunning(context)) {
+            DebugLog.log("Service should be running but isn't — starting it now")
+            OverlayService.start(context)
+        }
+    }
+}

--- a/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.gb4pc.R
 import com.gb4pc.data.PrefsManager
 import com.gb4pc.service.OverlayService
+import com.gb4pc.service.ServiceChecker
 import com.gb4pc.ui.picker.PickerActivity
 import com.gb4pc.ui.setup.SetupActivity
 import com.gb4pc.ui.theme.GB4PCTheme
@@ -48,6 +49,9 @@ class MainActivity : ComponentActivity() {
             finish()
             return
         }
+
+        // Issue #67: recover a service that should be running but was killed
+        ServiceChecker.ensureServiceRunningIfEnabled(this, prefsManager)
 
         // setContent called only once here (H2 fix)
         setContent {

--- a/app/src/test/java/com/gb4pc/service/ServiceCheckerTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ServiceCheckerTest.kt
@@ -1,0 +1,101 @@
+package com.gb4pc.service
+
+import android.app.ActivityManager
+import android.content.Context
+import com.gb4pc.data.PrefsManager
+import com.gb4pc.util.DebugLog
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class ServiceCheckerTest {
+
+    private lateinit var context: Context
+    private lateinit var prefs: PrefsManager
+    private lateinit var activityManager: ActivityManager
+
+    @Before
+    fun setUp() {
+        activityManager = mock()
+        context = mock {
+            on { getSystemService(Context.ACTIVITY_SERVICE) } doReturn activityManager
+        }
+        prefs = mock {
+            on { isServiceEnabled } doReturn false
+        }
+        DebugLog.clear()
+    }
+
+    // ---------------------------------------------------------------------------
+    // isServiceRunning
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `isServiceRunning returns true when service is in running list`() {
+        val serviceInfo = ActivityManager.RunningServiceInfo().apply {
+            service = android.content.ComponentName("com.gb4pc", OverlayService::class.java.name)
+        }
+        whenever(activityManager.getRunningServices(Int.MAX_VALUE)).thenReturn(listOf(serviceInfo))
+        assertTrue(ServiceChecker.isServiceRunning(context))
+    }
+
+    @Test
+    fun `isServiceRunning returns false when service is not in running list`() {
+        whenever(activityManager.getRunningServices(Int.MAX_VALUE)).thenReturn(emptyList())
+        assertFalse(ServiceChecker.isServiceRunning(context))
+    }
+
+    @Test
+    fun `isServiceRunning returns false when list contains a different service`() {
+        val serviceInfo = ActivityManager.RunningServiceInfo().apply {
+            service = android.content.ComponentName("com.other", "com.other.SomeService")
+        }
+        whenever(activityManager.getRunningServices(Int.MAX_VALUE)).thenReturn(listOf(serviceInfo))
+        assertFalse(ServiceChecker.isServiceRunning(context))
+    }
+
+    // ---------------------------------------------------------------------------
+    // ensureServiceRunningIfEnabled
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `ensureServiceRunningIfEnabled does nothing when service is disabled`() {
+        whenever(prefs.isServiceEnabled).thenReturn(false)
+        // Should not query ActivityManager at all
+        ServiceChecker.ensureServiceRunningIfEnabled(context, prefs)
+        verify(activityManager, never()).getRunningServices(any())
+        assertTrue(DebugLog.getEntries().isEmpty())
+    }
+
+    @Test
+    fun `ensureServiceRunningIfEnabled does nothing when service is enabled and already running`() {
+        whenever(prefs.isServiceEnabled).thenReturn(true)
+        val serviceInfo = ActivityManager.RunningServiceInfo().apply {
+            service = android.content.ComponentName("com.gb4pc", OverlayService::class.java.name)
+        }
+        whenever(activityManager.getRunningServices(Int.MAX_VALUE)).thenReturn(listOf(serviceInfo))
+
+        ServiceChecker.ensureServiceRunningIfEnabled(context, prefs)
+
+        verify(context, never()).startForegroundService(any())
+    }
+
+    @Test
+    fun `ensureServiceRunningIfEnabled logs and starts service when enabled but not running`() {
+        whenever(prefs.isServiceEnabled).thenReturn(true)
+        whenever(activityManager.getRunningServices(Int.MAX_VALUE)).thenReturn(emptyList())
+        // startForegroundService requires a real Context, so we accept any invocation
+        whenever(context.startForegroundService(any())).thenReturn(null)
+
+        ServiceChecker.ensureServiceRunningIfEnabled(context, prefs)
+
+        val logEntry = DebugLog.getEntries().firstOrNull()
+        assertNotNull("Expected a log entry", logEntry)
+        assertTrue(
+            "Log should mention service not running",
+            logEntry!!.message.contains("should be running but isn't")
+        )
+        verify(context).startForegroundService(any())
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ServiceChecker` object with `isServiceRunning()` (queries `ActivityManager` for the app's own service) and `ensureServiceRunningIfEnabled()` (checks prefs, logs if the service is absent, and starts it).
- Call `ServiceChecker.ensureServiceRunningIfEnabled()` from `MainActivity.onCreate` (after the setup-redirect guard) so a crashed or OOM-killed service is automatically recovered when the app is launched.
- Add `ServiceCheckerTest` covering all three branches of `isServiceRunning` and all three branches of `ensureServiceRunningIfEnabled`.

## Test plan

- [ ] Run `./gradlew :app:testDebugUnitTest` — all unit tests pass, including the new `ServiceCheckerTest`.
- [ ] Manual: enable the service toggle, force-stop the service via adb/Settings → Apps, then re-open the app. The service should restart automatically.
- [ ] Manual: enable the service toggle and open the app while the service is already running — no duplicate start, no log entry containing "should be running but isn't".
- [ ] Manual: disable the service toggle and open the app — service is not started.

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_