### PR TITLE
Fix #68: start service on app install/update

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,12 +87,15 @@
                 android:value="Monitors camera hardware availability to show gallery shortcut overlay on Pixel Camera" />
         </service>
 
-        <!-- Boot Receiver -->
+        <!-- Boot Receiver (also handles install/update via MY_PACKAGE_REPLACED) -->
         <receiver
             android:name=".receiver.BootReceiver"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/gb4pc/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/gb4pc/receiver/BootReceiver.kt
@@ -7,21 +7,25 @@ import com.gb4pc.service.OverlayService
 import com.gb4pc.util.DebugLog
 
 /**
- * Restarts the overlay service after device reboot if it was previously enabled (FS-05).
+ * Starts the overlay service after device reboot (FS-05) or app install/update (FS-68),
+ * if the service was previously enabled.
  * L1: Delegates all decision logic to BootReceiverLogic to avoid duplicating PrefsManager checks.
  */
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (!BootReceiverLogic.isBootIntent(intent.action)) return
+        val isBoot = BootReceiverLogic.isBootIntent(intent.action)
+        val isInstallOrUpdate = BootReceiverLogic.isInstallOrUpdateIntent(intent.action)
+        if (!isBoot && !isInstallOrUpdate) return
 
+        val trigger = if (isBoot) "Boot" else "Install/update"
         val wasEnabled = BootReceiverLogic.shouldStartService(context)
-        DebugLog.log("Boot completed: serviceWasEnabled=$wasEnabled")
+        DebugLog.log("$trigger completed: serviceWasEnabled=$wasEnabled")
 
         if (wasEnabled) {
-            DebugLog.log("Boot: starting overlay service")
+            DebugLog.log("$trigger: starting overlay service")
             OverlayService.start(context)
         } else {
-            DebugLog.log("Boot: service not enabled, skipping start")
+            DebugLog.log("$trigger: service not enabled, skipping start")
         }
     }
 }

--- a/app/src/main/java/com/gb4pc/receiver/BootReceiverLogic.kt
+++ b/app/src/main/java/com/gb4pc/receiver/BootReceiverLogic.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import com.gb4pc.Constants
 
 /**
- * Testable logic for boot receiver decisions (FS-05).
+ * Testable logic for boot receiver decisions (FS-05) and install/update decisions (FS-68).
  */
 object BootReceiverLogic {
     fun shouldStartService(context: Context): Boolean {
@@ -15,5 +15,9 @@ object BootReceiverLogic {
 
     fun isBootIntent(action: String?): Boolean {
         return action == Intent.ACTION_BOOT_COMPLETED
+    }
+
+    fun isInstallOrUpdateIntent(action: String?): Boolean {
+        return action == Intent.ACTION_MY_PACKAGE_REPLACED
     }
 }

--- a/app/src/test/java/com/gb4pc/receiver/BootReceiverTest.kt
+++ b/app/src/test/java/com/gb4pc/receiver/BootReceiverTest.kt
@@ -52,4 +52,16 @@ class BootReceiverTest {
         assertFalse(BootReceiverLogic.isBootIntent("com.example.OTHER"))
         assertFalse(BootReceiverLogic.isBootIntent(null))
     }
+
+    @Test
+    fun `isInstallOrUpdateIntent returns true for MY_PACKAGE_REPLACED`() {
+        assertTrue(BootReceiverLogic.isInstallOrUpdateIntent(Intent.ACTION_MY_PACKAGE_REPLACED))
+    }
+
+    @Test
+    fun `isInstallOrUpdateIntent returns false for other actions`() {
+        assertFalse(BootReceiverLogic.isInstallOrUpdateIntent(Intent.ACTION_BOOT_COMPLETED))
+        assertFalse(BootReceiverLogic.isInstallOrUpdateIntent("com.example.OTHER"))
+        assertFalse(BootReceiverLogic.isInstallOrUpdateIntent(null))
+    }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extends `BootReceiver` to also handle `android.intent.action.MY_PACKAGE_REPLACED`, which fires when the app is updated in-place.
- Adds `BootReceiverLogic.isInstallOrUpdateIntent()` to keep the intent-matching logic testable and DRY.
- Registers the new intent filter in `AndroidManifest.xml`.
- For fresh installs, the user completes setup and enables the service manually; `MY_PACKAGE_REPLACED` only fires on updates, so no extra receiver is needed for the install case.

## Commits

1. **Handle MY_PACKAGE_REPLACED in BootReceiver** — logic changes: new `isInstallOrUpdateIntent()` helper in `BootReceiverLogic`, updated `BootReceiver.onReceive()` to act on boot or install/update, and new unit tests in `BootReceiverTest`.
2. **Register MY_PACKAGE_REPLACED intent filter in AndroidManifest** — manifest-only change, no behaviour change on its own.

## Test plan

- [ ] Existing `BootReceiverTest` tests still pass (not deleted or disabled).
- [ ] New `isInstallOrUpdateIntent returns true for MY_PACKAGE_REPLACED` passes.
- [ ] New `isInstallOrUpdateIntent returns false for other actions` passes.
- [ ] On a device/emulator: enable the service, update the APK via `adb install -r`, confirm the overlay service starts automatically without opening the app.
- [ ] On a device/emulator: disable the service, update the APK, confirm the service does NOT start.

Closes #68

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_