### PR TITLE
Fix #75: run ServiceCheckerTest under Robolectric

### DIFF
--- a/app/src/test/java/com/gb4pc/service/ServiceCheckerTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ServiceCheckerTest.kt
@@ -7,8 +7,11 @@ import com.gb4pc.util.DebugLog
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.*
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ServiceCheckerTest {
 
     private lateinit var context: Context


### PR DESCRIPTION
## Summary

- `ServiceCheckerTest` was written using real Android framework types (`ComponentName`, `ActivityManager.RunningServiceInfo`) but was not annotated with `@RunWith(RobolectricTestRunner::class)`.
- In plain JUnit / Android-stub tests, `ComponentName(String, String)` is a no-op constructor and `getClassName()` always returns `null`. This caused `ServiceChecker.isServiceRunning()` to always return `false` in the test environment, failing two of the six `ServiceCheckerTest` cases introduced by #73.
- Fix: add `@RunWith(RobolectricTestRunner::class)` (and the two required imports) to `ServiceCheckerTest`, exactly as done in the existing `OverlayManagerRobolectricTest`. No production code was changed.

## Test plan

- [ ] `./gradlew assembleDebug` — build succeeds
- [ ] `./gradlew test` — all 149 unit tests pass (previously 2 failures in `ServiceCheckerTest`)

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_