### PR TITLE
Fix #78: Add explicit least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # Gate for PRs and merges: compiles, runs unit tests, then E2E tests on an emulator.
   # Unit tests run first so a fast failure skips the slower emulator phase.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
         description: 'Release tag (e.g. v0.0.2)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   tagged-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds explicit least-privilege `permissions` blocks to the GitHub Actions workflows to address CodeQL security alerts:

- **build.yml**: Added workflow-level `permissions: contents: read` to restrict access to repository contents
- **release.yml**: Added workflow-level `permissions: contents: read` (job-level `contents: write` overrides this for the tagged-release job as needed)

## Changes

Both workflows now follow GitHub's security best practice of explicitly defining minimal required permissions rather than implicitly inheriting all permissions.

## Testing

- No test changes needed for workflow configuration updates
- Workflows will execute with explicitly scoped permissions

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_