### PR TITLE
Fix #82: change default overlay position to X=20%, Y=69%, Size=16%

### DIFF
--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -4,9 +4,9 @@ object Constants {
     const val PIXEL_CAMERA_PACKAGE = "com.google.android.GoogleCamera"
 
     // Default overlay position (PS-02)
-    const val DEFAULT_X_PERCENT = 13.0f
-    const val DEFAULT_Y_PERCENT = 91.5f
-    const val DEFAULT_SIZE_PERCENT = 11.5f
+    const val DEFAULT_X_PERCENT = 20.0f
+    const val DEFAULT_Y_PERCENT = 69.0f
+    const val DEFAULT_SIZE_PERCENT = 16.0f
 
     // Overlay size bounds
     const val MIN_SIZE_PERCENT = 1.0f

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
@@ -93,11 +93,11 @@ class OverlayManagerTest {
         val xPx = OverlayPositionCalculator.calculateXPx(pos.xPercent, displayWidth, sizePx)
         val yPx = OverlayPositionCalculator.calculateYPx(pos.yPercent, displayHeight, sizePx)
 
-        // Size: 1080 * 11.5 / 100 = 124
-        assertEquals(124, sizePx)
-        // X: 1080 * 13.0 / 100 - 62 = 140 - 62 = 78
-        assertEquals(78, xPx)
-        // Y: 2400 * 91.5 / 100 - 62 = 2196 - 62 = 2134
-        assertEquals(2134, yPx)
+        // Size: 1080 * 16.0 / 100 = 172.8 → 173
+        assertEquals(173, sizePx)
+        // X: 1080 * 20.0 / 100 - 86 = 216 - 86 = 130
+        assertEquals(130, xPx)
+        // Y: 2400 * 69.0 / 100 - 86 = 1656 - 86 = 1570
+        assertEquals(1570, yPx)
     }
 }


### PR DESCRIPTION
## Summary

- Updates `Constants.DEFAULT_X_PERCENT` from 13.0 to 20.0
- Updates `Constants.DEFAULT_Y_PERCENT` from 91.5 to 69.0
- Updates `Constants.DEFAULT_SIZE_PERCENT` from 11.5 to 16.0
- Updates the expected pixel-coordinate assertions in `OverlayManagerTest` to match the new defaults (no behavior change; the test was asserting the exact computed values for the old defaults)

## Test plan

- [x] All 149 unit tests pass locally (`./gradlew testDebugUnitTest`)
- [x] No new tests added (pure default-value change per issue instructions)
- [x] No existing tests deleted or disabled

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_