### PR TITLE
feat: move log viewer to its own screen (#83)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,11 @@
             android:name=".ui.settings.AdvancedSettingsActivity"
             android:exported="false" />
 
+        <!-- Log Viewer Activity (issue #83) -->
+        <activity
+            android:name=".ui.settings.LogViewerActivity"
+            android:exported="false" />
+
         <!-- Gallery App Picker Activity (can be launched over lock screen camera) -->
         <activity
             android:name=".ui.picker.PickerActivity"

--- a/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/AdvancedSettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.gb4pc.ui.settings
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,7 +8,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -25,9 +25,6 @@ import com.gb4pc.data.AspectRatioUtil
 import com.gb4pc.data.OverlayPosition
 import com.gb4pc.data.PrefsManager
 import com.gb4pc.ui.theme.GB4PCTheme
-import com.gb4pc.util.DebugLog
-import java.text.SimpleDateFormat
-import java.util.*
 
 /**
  * Advanced Settings screen (§6.3, UI-10).
@@ -99,15 +96,6 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
         }
     }
 
-    // M2 fix: live-updating debug log entries via DebugLog listener
-    var debugEntries by remember { mutableStateOf(DebugLog.getEntries()) }
-    DisposableEffect(Unit) {
-        DebugLog.listener = { debugEntries = DebugLog.getEntries() }
-        onDispose { DebugLog.listener = null }
-    }
-
-    val dateFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
-
     Scaffold(
         topBar = {
             TopAppBar(title = { Text(stringResource(R.string.advanced_title)) })
@@ -118,6 +106,7 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 .padding(padding)
                 .padding(16.dp)
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
         ) {
             // UI-10.1: Position sliders with text inputs (M4 fix: persist only on commit/onValueChangeFinished)
             Row(
@@ -280,44 +269,12 @@ fun AdvancedSettingsScreen(prefsManager: PrefsManager) {
                 Text(stringResource(R.string.advanced_reset))
             }
 
-            // UI-10.3: Debug log
-            Text(
-                text = stringResource(R.string.advanced_debug_log),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
+            // UI-10.3: Link to the dedicated log viewer screen (issue #83)
+            OutlinedButton(
+                onClick = { context.startActivity(Intent(context, LogViewerActivity::class.java)) },
+                modifier = Modifier.fillMaxWidth()
             ) {
-                if (debugEntries.isEmpty()) {
-                    Text(
-                        text = "No log entries",
-                        modifier = Modifier.padding(16.dp),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                } else {
-                    // Column+verticalScroll (not LazyColumn) so SelectionContainer can
-                    // maintain selection state across the full list without items being
-                    // disposed on scroll. 200 short strings have negligible memory cost.
-                    SelectionContainer {
-                        Column(
-                            modifier = Modifier
-                                .verticalScroll(rememberScrollState())
-                                .padding(8.dp)
-                        ) {
-                            for (entry in debugEntries.asReversed()) {
-                                Text(
-                                    text = "${dateFormat.format(Date(entry.timestamp))}  ${entry.message}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    modifier = Modifier.padding(vertical = 2.dp)
-                                )
-                            }
-                        }
-                    }
-                }
+                Text(stringResource(R.string.advanced_view_log))
             }
         }
 

--- a/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
@@ -71,10 +71,7 @@ fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
                     }
                 },
                 actions = {
-                    TextButton(onClick = {
-                        DebugLog.clear()
-                        entries = DebugLog.getEntries()
-                    }) {
+                    TextButton(onClick = { DebugLog.clear() }) {
                         Text(stringResource(R.string.log_viewer_clear))
                     }
                 }

--- a/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
@@ -51,8 +51,8 @@ fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
     val listState = rememberLazyListState()
     val dateFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
 
-    // Auto-scroll to the bottom whenever the entry list grows
-    LaunchedEffect(entries.size) {
+    // Auto-scroll to the bottom whenever the entry list changes
+    LaunchedEffect(entries) {
         if (entries.isNotEmpty()) {
             listState.animateScrollToItem(entries.size - 1)
         }

--- a/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
@@ -1,0 +1,99 @@
+package com.gb4pc.ui.settings
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.gb4pc.R
+import com.gb4pc.ui.theme.GB4PCTheme
+import com.gb4pc.util.DebugLog
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Dedicated screen for viewing the in-memory debug log (issue #83).
+ */
+class LogViewerActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            GB4PCTheme {
+                LogViewerScreen(onNavigateUp = { finish() })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
+    var entries by remember { mutableStateOf(DebugLog.getEntries()) }
+
+    DisposableEffect(Unit) {
+        DebugLog.listener = { entries = DebugLog.getEntries() }
+        onDispose { DebugLog.listener = null }
+    }
+
+    val dateFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.log_viewer_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.log_viewer_navigate_up)
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (entries.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+            ) {
+                Text(
+                    text = stringResource(R.string.log_viewer_empty),
+                    modifier = Modifier.padding(16.dp),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        } else {
+            SelectionContainer(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(8.dp)
+                ) {
+                    for (entry in entries.asReversed()) {
+                        Text(
+                            text = "${dateFormat.format(Date(entry.timestamp))}  ${entry.message}",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(vertical = 2.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/ui/settings/LogViewerActivity.kt
@@ -4,9 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -22,6 +23,9 @@ import java.util.*
 
 /**
  * Dedicated screen for viewing the in-memory debug log (issue #83).
+ *
+ * Entries are displayed oldest-first (newest at the bottom) with auto-scroll
+ * to follow the latest entry. A "Clear log" button wipes the buffer.
  */
 class LogViewerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,7 +48,15 @@ fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
         onDispose { DebugLog.listener = null }
     }
 
+    val listState = rememberLazyListState()
     val dateFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
+
+    // Auto-scroll to the bottom whenever the entry list grows
+    LaunchedEffect(entries.size) {
+        if (entries.isNotEmpty()) {
+            listState.animateScrollToItem(entries.size - 1)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -56,6 +68,14 @@ fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.log_viewer_navigate_up)
                         )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = {
+                        DebugLog.clear()
+                        entries = DebugLog.getEntries()
+                    }) {
+                        Text(stringResource(R.string.log_viewer_clear))
                     }
                 }
             )
@@ -79,13 +99,14 @@ fun LogViewerScreen(onNavigateUp: () -> Unit = {}) {
                     .padding(padding)
                     .fillMaxSize()
             ) {
-                Column(
+                LazyColumn(
+                    state = listState,
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
-                        .padding(8.dp)
+                        .padding(horizontal = 8.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp)
                 ) {
-                    for (entry in entries.asReversed()) {
+                    items(entries) { entry ->
                         Text(
                             text = "${dateFormat.format(Date(entry.timestamp))}  ${entry.message}",
                             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/gb4pc/util/DebugLog.kt
+++ b/app/src/main/java/com/gb4pc/util/DebugLog.kt
@@ -34,8 +34,11 @@ object DebugLog {
     }
 
     fun clear() {
+        val snapshot: (() -> Unit)?
         synchronized(lock) {
             buffer.clear()
+            snapshot = listener
         }
+        snapshot?.invoke()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <!-- Log Viewer -->
     <string name="log_viewer_title">Debug Log</string>
     <string name="log_viewer_navigate_up">Back</string>
+    <string name="log_viewer_clear">Clear log</string>
     <string name="log_viewer_empty">No log entries</string>
 
     <!-- Secure Viewer -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,12 @@
     <string name="advanced_reset_confirm_title">Reset Position?</string>
     <string name="advanced_reset_confirm_message">This will restore the default overlay position for the current display aspect ratio.</string>
     <string name="advanced_debug_log">Debug Log</string>
+    <string name="advanced_view_log">View Debug Log</string>
+
+    <!-- Log Viewer -->
+    <string name="log_viewer_title">Debug Log</string>
+    <string name="log_viewer_navigate_up">Back</string>
+    <string name="log_viewer_empty">No log entries</string>
 
     <!-- Secure Viewer -->
     <string name="viewer_no_photos">No photos yet — take a picture!</string>

--- a/app/src/test/java/com/gb4pc/util/DebugLogTest.kt
+++ b/app/src/test/java/com/gb4pc/util/DebugLogTest.kt
@@ -75,14 +75,19 @@ class DebugLogTest {
     }
 
     @Test
-    fun `clear does not invoke the listener`() {
+    fun `clear invokes the listener with empty entries`() {
         var callCount = 0
+        var entriesOnClear: List<DebugLog.Entry>? = null
         DebugLog.log("before")
-        DebugLog.listener = { callCount++ }
+        DebugLog.listener = {
+            callCount++
+            entriesOnClear = DebugLog.getEntries()
+        }
         try {
             DebugLog.clear()
-            assertEquals(0, callCount)
-            assertTrue(DebugLog.getEntries().isEmpty())
+            assertEquals(1, callCount)
+            assertNotNull(entriesOnClear)
+            assertTrue(entriesOnClear!!.isEmpty())
         } finally {
             DebugLog.listener = null
         }

--- a/app/src/test/java/com/gb4pc/util/DebugLogTest.kt
+++ b/app/src/test/java/com/gb4pc/util/DebugLogTest.kt
@@ -60,4 +60,43 @@ class DebugLogTest {
         assertEquals("second", entries[1].message)
         assertEquals("third", entries[2].message)
     }
+
+    @Test
+    fun `listener is invoked on each log call`() {
+        var callCount = 0
+        DebugLog.listener = { callCount++ }
+        try {
+            DebugLog.log("a")
+            DebugLog.log("b")
+            assertEquals(2, callCount)
+        } finally {
+            DebugLog.listener = null
+        }
+    }
+
+    @Test
+    fun `clear does not invoke the listener`() {
+        var callCount = 0
+        DebugLog.log("before")
+        DebugLog.listener = { callCount++ }
+        try {
+            DebugLog.clear()
+            assertEquals(0, callCount)
+            assertTrue(DebugLog.getEntries().isEmpty())
+        } finally {
+            DebugLog.listener = null
+        }
+    }
+
+    @Test
+    fun `getEntries returns entries in oldest-first order after clear and re-log`() {
+        DebugLog.log("old")
+        DebugLog.clear()
+        DebugLog.log("new1")
+        DebugLog.log("new2")
+        val entries = DebugLog.getEntries()
+        assertEquals(2, entries.size)
+        assertEquals("new1", entries[0].message)
+        assertEquals("new2", entries[1].message)
+    }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extracts the inline debug log panel from `AdvancedSettingsActivity` into a new `LogViewerActivity` with its own full screen
- Log entries are now displayed oldest-first (newest at the **bottom**), replacing the previous newest-at-top reversed list
- The `LazyColumn` auto-scrolls to the bottom whenever new entries arrive
- A "Clear log" button is added to the top-bar actions
- `AdvancedSettingsActivity` now shows a "View Debug Log" button that launches the new activity
- `LogViewerActivity` is registered in `AndroidManifest.xml`

## Commits

1. **Refactor** (no behavior change): move the embedded log viewer out of `AdvancedSettingsActivity` into `LogViewerActivity`; add navigation button and manifest entry
2. **Behavior**: switch to newest-at-bottom order with `LazyColumn`, add auto-scroll on new entries, add "Clear log" button; extend `DebugLogTest` with listener and clear tests

## Test plan

- [ ] Build and run on device/emulator: Advanced Settings → "View Debug Log" opens the new screen
- [ ] Log entries appear newest at the bottom; screen auto-scrolls as new entries arrive
- [ ] "Clear log" button clears all entries and shows the empty-state message
- [ ] Back arrow returns to Advanced Settings
- [ ] Unit tests pass: `./gradlew :app:testDebugUnitTest`

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_