### PR TITLE
Fix #80: skip own package in ForegroundDetector to prevent overlay hiding itself

### DIFF
--- a/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
+++ b/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
@@ -7,12 +7,21 @@ import com.gb4pc.util.DebugLog
 
 /**
  * Detects the current foreground app using UsageStatsManager (DT-02, DT-06).
+ *
+ * @param selfPackage The package name of this app (com.gb4pc). MOVE_TO_FOREGROUND events for
+ *   this package are ignored because the overlay window causes Android to report GB4PC itself
+ *   as the foreground app — which would displace the camera from the detected foreground app
+ *   and hide the overlay (Issue #80).
  */
-class ForegroundDetector(private val usageStatsManager: UsageStatsManager) {
+class ForegroundDetector(
+    private val usageStatsManager: UsageStatsManager,
+    private val selfPackage: String,
+) {
 
     /**
      * Queries UsageStatsManager for the most recent MOVE_TO_FOREGROUND event
      * in the last [Constants.USAGE_STATS_WINDOW_MS] milliseconds.
+     * Events for [selfPackage] are skipped (Issue #80).
      * Returns the package name, or null if no event found (EC-09).
      */
     fun getForegroundPackage(): String? {
@@ -31,11 +40,17 @@ class ForegroundDetector(private val usageStatsManager: UsageStatsManager) {
         var latestTimestamp = 0L
         var totalEvents = 0
         var foregroundEvents = 0
+        var skippedSelfEvents = 0
 
         while (events.hasNextEvent()) {
             events.getNextEvent(event)
             totalEvents++
             if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+                if (event.packageName == selfPackage) {
+                    skippedSelfEvents++
+                    DebugLog.log("ForegroundDetector: skipping self MOVE_TO_FOREGROUND pkg=${event.packageName} ts=${event.timeStamp} (Issue #80)")
+                    continue
+                }
                 foregroundEvents++
                 DebugLog.log("ForegroundDetector: MOVE_TO_FOREGROUND pkg=${event.packageName} ts=${event.timeStamp}")
                 if (event.timeStamp >= latestTimestamp) {
@@ -45,10 +60,11 @@ class ForegroundDetector(private val usageStatsManager: UsageStatsManager) {
             }
         }
 
+        val selfNote = if (skippedSelfEvents > 0) ", skipped $skippedSelfEvents self-event(s)" else ""
         if (latestForegroundPackage != null) {
-            DebugLog.log("ForegroundDetector: foreground=$latestForegroundPackage ($foregroundEvents foreground event(s) of $totalEvents total)")
+            DebugLog.log("ForegroundDetector: foreground=$latestForegroundPackage ($foregroundEvents foreground event(s) of $totalEvents total$selfNote)")
         } else {
-            DebugLog.log("ForegroundDetector: no foreground app detected ($foregroundEvents foreground event(s) of $totalEvents total)")
+            DebugLog.log("ForegroundDetector: no foreground app detected ($foregroundEvents foreground event(s) of $totalEvents total$selfNote)")
         }
         return latestForegroundPackage
     }

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -71,7 +71,7 @@ class OverlayService : Service() {
         handler = Handler(Looper.getMainLooper())
         cameraManager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
         val usm = getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
-        foregroundDetector = ForegroundDetector(usm)
+        foregroundDetector = ForegroundDetector(usm, packageName)
         prefsManager = PrefsManager(this)
         overlayManager = OverlayManager(
             context = this,

--- a/app/src/test/java/com/gb4pc/service/ForegroundDetectorEventTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ForegroundDetectorEventTest.kt
@@ -22,7 +22,7 @@ class ForegroundDetectorEventTest {
     @Before
     fun setUp() {
         usm = mock()
-        detector = ForegroundDetector(usm)
+        detector = ForegroundDetector(usm, "com.gb4pc")
     }
 
     @Test

--- a/app/src/test/java/com/gb4pc/service/ForegroundDetectorSelfFilterTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ForegroundDetectorSelfFilterTest.kt
@@ -1,0 +1,176 @@
+package com.gb4pc.service
+
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for Issue #80: ForegroundDetector must skip its own package name so that the
+ * overlay window's presence does not displace the camera from the detected foreground app.
+ *
+ * UsageEvents.Event is a real Android framework class with public fields in Robolectric
+ * (mPackage, mEventType, mTimeStamp). Robolectric is required so those fields are
+ * accessible — they are stubs with default values under the plain JVM test runner.
+ */
+@Suppress("DEPRECATION") // MOVE_TO_FOREGROUND / MOVE_TO_BACKGROUND are deprecated by the SDK
+                          // but are the correct event types for pre-API-29 paths exercised here.
+@RunWith(RobolectricTestRunner::class)
+class ForegroundDetectorSelfFilterTest {
+
+    private val selfPkg = "com.gb4pc"
+    private val cameraPkg = "com.google.android.GoogleCamera"
+    private val otherPkg = "com.example.other"
+
+    private lateinit var usm: UsageStatsManager
+    private lateinit var detector: ForegroundDetector
+
+    @Before
+    fun setUp() {
+        usm = mock()
+        detector = ForegroundDetector(usm, selfPkg)
+    }
+
+    /**
+     * Helper: returns a mock UsageEvents whose getNextEvent() populates the passed Event
+     * object with each successive event descriptor.
+     *
+     * Each descriptor is a Triple(packageName, eventType, timestamp).
+     *
+     * Field names (mPackage, mEventType, mTimeStamp) are set via reflection because the
+     * compile-time android.jar exposes only stubs. Robolectric's android-all implementation
+     * makes these fields public and settable at runtime.
+     */
+    private fun eventsOf(vararg specs: Triple<String, Int, Long>): UsageEvents {
+        val specList = specs.toList()
+        var index = 0
+        val events: UsageEvents = mock()
+        whenever(events.hasNextEvent()).thenAnswer { index < specList.size }
+        whenever(events.getNextEvent(any())).thenAnswer { invocation ->
+            val event = invocation.getArgument<UsageEvents.Event>(0)
+            val spec = specList[index++]
+            setEventField(event, "mPackage", spec.first)
+            setEventField(event, "mEventType", spec.second)
+            setEventField(event, "mTimeStamp", spec.third)
+            true
+        }
+        whenever(usm.queryEvents(any(), any())).thenReturn(events)
+        return events
+    }
+
+    private fun setEventField(event: UsageEvents.Event, fieldName: String, value: Any) {
+        val field = event.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(event, value)
+    }
+
+    // ── Self-filter: GB4PC events are skipped ───────────────────────────────
+
+    @Test
+    fun `self MOVE_TO_FOREGROUND alone returns null`() {
+        // Only GB4PC itself appears in events — overlay is visible, no camera event.
+        eventsOf(Triple(selfPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L))
+
+        assertNull(
+            "GB4PC's own MOVE_TO_FOREGROUND must not be returned as the foreground package",
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `self MOVE_TO_FOREGROUND does not displace earlier camera event`() {
+        // Camera opened first, then GB4PC overlay fired its own event — camera should remain.
+        eventsOf(
+            Triple(cameraPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(selfPkg,    UsageEvents.Event.MOVE_TO_FOREGROUND, 2000L),
+        )
+
+        assertEquals(
+            "Camera package must remain the detected foreground app when GB4PC fires after it (Issue #80)",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `self MOVE_TO_FOREGROUND between two other apps is skipped`() {
+        // Some other app, then GB4PC overlay, then camera — camera wins on timestamp.
+        eventsOf(
+            Triple(otherPkg,  UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(selfPkg,   UsageEvents.Event.MOVE_TO_FOREGROUND, 2000L),
+            Triple(cameraPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 3000L),
+        )
+
+        assertEquals(
+            "Camera package (latest non-self MOVE_TO_FOREGROUND) must be detected",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    // ── Edge cases: genuine navigation away from camera ─────────────────────
+
+    @Test
+    fun `user navigating to another app is still detected`() {
+        // Camera first, then user opens another app — that app should be returned.
+        eventsOf(
+            Triple(cameraPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(otherPkg,  UsageEvents.Event.MOVE_TO_FOREGROUND, 2000L),
+        )
+
+        assertEquals(
+            "When the user genuinely navigates away, the new foreground app must be detected",
+            otherPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `self event after genuine navigation does not restore camera`() {
+        // Camera → user navigates away → GB4PC overlay fires (shouldn't matter) → other stays.
+        eventsOf(
+            Triple(cameraPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(otherPkg,  UsageEvents.Event.MOVE_TO_FOREGROUND, 2000L),
+            Triple(selfPkg,   UsageEvents.Event.MOVE_TO_FOREGROUND, 3000L),
+        )
+
+        assertEquals(
+            "The other app must remain detected even when GB4PC fires after it",
+            otherPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `multiple self events are all skipped`() {
+        eventsOf(
+            Triple(selfPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(selfPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 2000L),
+            Triple(selfPkg, UsageEvents.Event.MOVE_TO_FOREGROUND, 3000L),
+        )
+
+        assertNull(
+            "Multiple GB4PC self-events must all be skipped, returning null",
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `non-foreground events for self package are not affected`() {
+        // Self fires a non-foreground event type — should not interfere with detection.
+        eventsOf(
+            Triple(cameraPkg, UsageEvents.Event.MOVE_TO_FOREGROUND,  1000L),
+            Triple(selfPkg,   UsageEvents.Event.MOVE_TO_BACKGROUND,  2000L),
+        )
+
+        assertEquals(
+            "Non-foreground events for selfPkg must not interfere with camera detection",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+}

--- a/app/src/test/java/com/gb4pc/service/ForegroundDetectorTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ForegroundDetectorTest.kt
@@ -16,7 +16,7 @@ class ForegroundDetectorTest {
     @Before
     fun setUp() {
         usm = mock()
-        detector = ForegroundDetector(usm)
+        detector = ForegroundDetector(usm, "com.gb4pc")
     }
 
     @Test


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: When the overlay is visible, Android reports GB4PC as a foreground app via `UsageStatsManager` `MOVE_TO_FOREGROUND` events. `ForegroundDetector` then thinks the camera is no longer the foreground app and hides the overlay — reproducing the mode-switch disappearance described in #80.
- **Fix**: Add a `selfPackage` constructor parameter to `ForegroundDetector`. Any `MOVE_TO_FOREGROUND` event whose `packageName` matches `selfPackage` is skipped. The camera (or any app the user genuinely navigates to) remains the detected foreground app. `OverlayService` passes its own `packageName` on construction.
- **Tests**: New `ForegroundDetectorSelfFilterTest` (Robolectric) covers: self-only events return null, self event does not displace an earlier camera event, genuine navigation away is still detected, multiple self-events are all skipped, and non-foreground self-events do not interfere.

## Commits

1. `Fix #80` — production code: `selfPackage` parameter + skip logic in `ForegroundDetector`, wire-up in `OverlayService`, and update existing test constructors.
2. `Test #80` — new `ForegroundDetectorSelfFilterTest` with 7 Robolectric test cases covering the filter and its edge cases.

## Test plan

- [ ] All unit tests pass: `./gradlew :app:testDebugUnitTest`
- [ ] Open Pixel Camera → overlay appears; switch to photo-sphere mode → overlay stays visible
- [ ] Navigate away from camera to another app → overlay disappears (genuine navigation still works)

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_