### PR TITLE
Fix #81: overlay thumbnail and session media not updated on lock screen

### DIFF
--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -44,6 +44,9 @@ object Constants {
     const val SESSION_TIMESTAMP_TOLERANCE_MS = 2000L
     const val MEDIA_RELATIVE_PATH_PREFIX = "DCIM/Camera/"
 
+    // Retry delay when ContentObserver fires before MediaStore commits the new item (IS_PENDING race)
+    const val MEDIA_OBSERVER_RETRY_MS = 500L
+
     // Snackbar undo timeout
     const val UNDO_TIMEOUT_MS = 5000L
 }

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -100,24 +100,45 @@ class OverlayManager(
         val targetView = overlayView ?: return
         val uri = android.net.Uri.parse(photoUri)
         Thread {
-            try {
-                val bitmap = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                    context.contentResolver.loadThumbnail(uri, android.util.Size(200, 200), null)
-                } else {
-                    context.contentResolver.openInputStream(uri)?.use { stream ->
-                        val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = 4 }
-                        android.graphics.BitmapFactory.decodeStream(stream, null, opts)
-                    }
+            val bitmap = loadThumbnailBitmap(uri)
+            bitmap?.let { bmp ->
+                android.os.Handler(android.os.Looper.getMainLooper()).post {
+                    targetView.setImageBitmap(bmp)
                 }
-                bitmap?.let { bmp ->
-                    android.os.Handler(android.os.Looper.getMainLooper()).post {
-                        targetView.setImageBitmap(bmp)
-                    }
-                }
-            } catch (e: Exception) {
-                DebugLog.log("Failed to load thumbnail: ${e.message}")
             }
         }.start()
+    }
+
+    /**
+     * Loads a thumbnail-sized bitmap for [uri].
+     *
+     * On API 29+, tries [ContentResolver.loadThumbnail] first. This can fail on a locked
+     * device if the thumbnail cache lives in credential-encrypted storage (the photos
+     * themselves on external storage remain accessible). In that case, falls back to
+     * decoding a downsampled copy of the original file via [ContentResolver.openInputStream].
+     *
+     * On pre-API 29, always uses the stream-based path.
+     *
+     * Returns null (and logs) if all attempts fail.
+     */
+    internal fun loadThumbnailBitmap(uri: android.net.Uri): android.graphics.Bitmap? {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            try {
+                return context.contentResolver.loadThumbnail(uri, android.util.Size(200, 200), null)
+            } catch (e: Exception) {
+                DebugLog.log("loadThumbnail failed (locked device?), falling back to stream decode: ${e.message}")
+            }
+        }
+        // Fallback: decode a downsampled version of the original file directly.
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { stream ->
+                val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = 4 }
+                android.graphics.BitmapFactory.decodeStream(stream, null, opts)
+            }
+        } catch (e: Exception) {
+            DebugLog.log("Failed to load thumbnail via stream: ${e.message}")
+            null
+        }
     }
 
     private fun createOverlayView(): ImageView {

--- a/app/src/main/java/com/gb4pc/service/MediaChangeDispatcher.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaChangeDispatcher.kt
@@ -1,0 +1,64 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.Constants
+import com.gb4pc.util.DebugLog
+import com.gb4pc.viewer.MediaItem
+import com.gb4pc.viewer.SessionTracker
+
+/**
+ * Handles media-change events from the session ContentObserver.
+ *
+ * Extracted from [OverlayService] for unit-testability. All Android-framework
+ * side-effects are accessed through constructor lambdas so this class can be
+ * exercised in plain JVM tests.
+ *
+ * ## IS_PENDING race
+ *
+ * Pixel Camera (and other modern camera apps on API 29+) inserts new photos into
+ * MediaStore with IS_PENDING = 1 while the file is being written, then clears the
+ * flag once the write completes. The ContentObserver fires on both state transitions.
+ * On the first fire (IS_PENDING = 1) the default query excludes the pending row and
+ * [queryLatestMedia] returns null. On the second fire (IS_PENDING cleared) the
+ * committed row is found and added to the session.
+ *
+ * However, on some devices/firmware the second ContentObserver callback for the
+ * IS_PENDING→0 transition is not delivered reliably. [onMediaChanged] therefore
+ * schedules a single retry after [Constants.MEDIA_OBSERVER_RETRY_MS] when the
+ * initial query returns null, picking up committed rows that the first callback
+ * missed.
+ */
+class MediaChangeDispatcher(
+    private val sessionTracker: SessionTracker,
+    private val handler: Handler,
+    /** Returns the most recent [MediaItem] added after [sessionStartMs], or null. */
+    private val queryLatestMedia: (sessionStartMs: Long) -> MediaItem?,
+    private val retryDelayMs: Long = Constants.MEDIA_OBSERVER_RETRY_MS,
+) {
+
+    /**
+     * Called whenever the media ContentObserver detects a change.
+     *
+     * Immediately queries for the latest committed media added since [sessionStartMs].
+     * If the query returns null (item is still IS_PENDING), schedules a single retry
+     * after [retryDelayMs] ms.
+     */
+    fun onMediaChanged(sessionStartMs: Long) {
+        val item = queryLatestMedia(sessionStartMs)
+        if (item != null) {
+            sessionTracker.addMedia(item)
+            DebugLog.log("Media added to session: ${item.uri}")
+        } else {
+            // First onChange may fire while the photo is IS_PENDING; schedule a retry so we
+            // catch it once it has been committed to MediaStore.
+            DebugLog.log("Media query returned null — scheduling retry in ${retryDelayMs}ms")
+            handler.postDelayed({
+                val retryItem = queryLatestMedia(sessionStartMs)
+                if (retryItem != null) {
+                    sessionTracker.addMedia(retryItem)
+                    DebugLog.log("Media added to session (retry): ${retryItem.uri}")
+                }
+            }, retryDelayMs)
+        }
+    }
+}

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -53,6 +53,7 @@ class OverlayService : Service() {
     private var thumbnailObserver: ContentObserver? = null
     private var overlayActiveTimestamp: Long = 0L
     private lateinit var mediaChangeDispatcher: MediaChangeDispatcher
+    private lateinit var thumbnailChangeDispatcher: ThumbnailChangeDispatcher
 
     private val cameraCallback = object : CameraManager.AvailabilityCallback() {
         override fun onCameraUnavailable(cameraId: String) {
@@ -87,6 +88,12 @@ class OverlayService : Service() {
             sessionTracker = SessionTracker.instance,
             handler = handler,
             queryLatestMedia = ::queryLatestMedia,
+        )
+
+        thumbnailChangeDispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = ::queryLatestMedia,
+            showThumbnail = { uri -> overlayManager.showLatestPhotoThumbnail(uri) },
         )
 
         logic = OverlayServiceLogic(
@@ -268,11 +275,7 @@ class OverlayService : Service() {
         val startMs = overlayActiveTimestamp
         thumbnailObserver = object : ContentObserver(handler) {
             override fun onChange(selfChange: Boolean, uri: Uri?) {
-                val item = queryLatestMedia(startMs)
-                if (item != null) {
-                    overlayManager.showLatestPhotoThumbnail(item.uri)
-                    DebugLog.log("Thumbnail updated: ${item.uri}")
-                }
+                thumbnailChangeDispatcher.onThumbnailChanged(startMs)
             }
         }
         contentResolver.registerContentObserver(

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -231,11 +231,7 @@ class OverlayService : Service() {
         val sessionStartMs = SessionTracker.instance.sessionStartTimestamp
         mediaObserver = object : ContentObserver(handler) {
             override fun onChange(selfChange: Boolean, uri: Uri?) {
-                val item = queryLatestMedia(sessionStartMs)
-                if (item != null) {
-                    SessionTracker.instance.addMedia(item)
-                    DebugLog.log("Media added to session: ${item.uri}")
-                }
+                onMediaChanged(sessionStartMs)
             }
         }
         contentResolver.registerContentObserver(
@@ -249,6 +245,40 @@ class OverlayService : Service() {
             mediaObserver!!
         )
         DebugLog.log("ContentObserver registered at session start")
+    }
+
+    /**
+     * Called by the media ContentObserver when a change is detected.
+     *
+     * Pixel Camera (and other modern camera apps on API 29+) inserts new photos into
+     * MediaStore with IS_PENDING=1 while the file is being written, then clears the flag
+     * once the write completes. The ContentObserver fires on both state transitions. On the
+     * first fire (IS_PENDING=1) the default query excludes the pending row and returns null.
+     * On the second fire (IS_PENDING cleared) the committed row is found and added to the
+     * session.
+     *
+     * However, on some devices/firmware the second ContentObserver callback for the
+     * IS_PENDING→0 transition is not delivered reliably. To defend against this, we schedule
+     * a single retry [MEDIA_OBSERVER_RETRY_MS] after a null result so we pick up newly
+     * committed rows that the initial query missed.
+     */
+    private fun onMediaChanged(sessionStartMs: Long) {
+        val item = queryLatestMedia(sessionStartMs)
+        if (item != null) {
+            SessionTracker.instance.addMedia(item)
+            DebugLog.log("Media added to session: ${item.uri}")
+        } else {
+            // First onChange may fire while the photo is IS_PENDING; schedule a retry so we
+            // catch it once it has been committed to MediaStore.
+            DebugLog.log("Media query returned null — scheduling retry in ${Constants.MEDIA_OBSERVER_RETRY_MS}ms")
+            handler.postDelayed({
+                val retryItem = queryLatestMedia(sessionStartMs)
+                if (retryItem != null) {
+                    SessionTracker.instance.addMedia(retryItem)
+                    DebugLog.log("Media added to session (retry): ${retryItem.uri}")
+                }
+            }, Constants.MEDIA_OBSERVER_RETRY_MS)
+        }
     }
 
     private fun unregisterMediaObserver() {
@@ -297,7 +327,10 @@ class OverlayService : Service() {
             MediaStore.MediaColumns.DATE_ADDED,
             MediaStore.MediaColumns.DATE_TAKEN
         )
-        val selectionArgs = arrayOf((sessionStartMs / 1000).toString())
+        // Apply SESSION_TIMESTAMP_TOLERANCE_MS (same tolerance used by SessionTracker.isMediaInSession)
+        // so photos whose DATE_ADDED was rounded to the same second as session start are not missed.
+        val effectiveStartSec = (sessionStartMs - Constants.SESSION_TIMESTAMP_TOLERANCE_MS) / 1000
+        val selectionArgs = arrayOf(effectiveStartSec.toString())
 
         // Query images
         val imageResult = queryMediaStore(

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -52,6 +52,7 @@ class OverlayService : Service() {
     private var mediaObserver: ContentObserver? = null
     private var thumbnailObserver: ContentObserver? = null
     private var overlayActiveTimestamp: Long = 0L
+    private lateinit var mediaChangeDispatcher: MediaChangeDispatcher
 
     private val cameraCallback = object : CameraManager.AvailabilityCallback() {
         override fun onCameraUnavailable(cameraId: String) {
@@ -81,6 +82,12 @@ class OverlayService : Service() {
         )
         cameraState = CameraState()
         val km = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+        mediaChangeDispatcher = MediaChangeDispatcher(
+            sessionTracker = SessionTracker.instance,
+            handler = handler,
+            queryLatestMedia = ::queryLatestMedia,
+        )
 
         logic = OverlayServiceLogic(
             hasUsageStatsPermission = { PermissionHelper.hasUsageStatsPermission(this) },
@@ -231,7 +238,7 @@ class OverlayService : Service() {
         val sessionStartMs = SessionTracker.instance.sessionStartTimestamp
         mediaObserver = object : ContentObserver(handler) {
             override fun onChange(selfChange: Boolean, uri: Uri?) {
-                onMediaChanged(sessionStartMs)
+                mediaChangeDispatcher.onMediaChanged(sessionStartMs)
             }
         }
         contentResolver.registerContentObserver(
@@ -245,40 +252,6 @@ class OverlayService : Service() {
             mediaObserver!!
         )
         DebugLog.log("ContentObserver registered at session start")
-    }
-
-    /**
-     * Called by the media ContentObserver when a change is detected.
-     *
-     * Pixel Camera (and other modern camera apps on API 29+) inserts new photos into
-     * MediaStore with IS_PENDING=1 while the file is being written, then clears the flag
-     * once the write completes. The ContentObserver fires on both state transitions. On the
-     * first fire (IS_PENDING=1) the default query excludes the pending row and returns null.
-     * On the second fire (IS_PENDING cleared) the committed row is found and added to the
-     * session.
-     *
-     * However, on some devices/firmware the second ContentObserver callback for the
-     * IS_PENDING→0 transition is not delivered reliably. To defend against this, we schedule
-     * a single retry [MEDIA_OBSERVER_RETRY_MS] after a null result so we pick up newly
-     * committed rows that the initial query missed.
-     */
-    private fun onMediaChanged(sessionStartMs: Long) {
-        val item = queryLatestMedia(sessionStartMs)
-        if (item != null) {
-            SessionTracker.instance.addMedia(item)
-            DebugLog.log("Media added to session: ${item.uri}")
-        } else {
-            // First onChange may fire while the photo is IS_PENDING; schedule a retry so we
-            // catch it once it has been committed to MediaStore.
-            DebugLog.log("Media query returned null — scheduling retry in ${Constants.MEDIA_OBSERVER_RETRY_MS}ms")
-            handler.postDelayed({
-                val retryItem = queryLatestMedia(sessionStartMs)
-                if (retryItem != null) {
-                    SessionTracker.instance.addMedia(retryItem)
-                    DebugLog.log("Media added to session (retry): ${retryItem.uri}")
-                }
-            }, Constants.MEDIA_OBSERVER_RETRY_MS)
-        }
     }
 
     private fun unregisterMediaObserver() {

--- a/app/src/main/java/com/gb4pc/service/ThumbnailChangeDispatcher.kt
+++ b/app/src/main/java/com/gb4pc/service/ThumbnailChangeDispatcher.kt
@@ -1,0 +1,57 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.Constants
+import com.gb4pc.util.DebugLog
+import com.gb4pc.viewer.MediaItem
+
+/**
+ * Handles media-change events from the thumbnail ContentObserver.
+ *
+ * Extracted from [OverlayService] for unit-testability. All Android-framework
+ * side-effects are accessed through constructor lambdas so this class can be
+ * exercised in plain JVM tests.
+ *
+ * ## IS_PENDING retry
+ *
+ * On some devices the IS_PENDING→0 second ContentObserver callback (which signals
+ * the file is fully written) is not delivered reliably. When [queryLatestMedia]
+ * returns null on the first callback, [onThumbnailChanged] schedules a single retry
+ * after [retryDelayMs] ms so the thumbnail update is not silently dropped.
+ */
+class ThumbnailChangeDispatcher(
+    private val handler: Handler,
+    /** Returns the most recent [MediaItem] added after [startMs], or null. */
+    private val queryLatestMedia: (startMs: Long) -> MediaItem?,
+    /** Called with the URI string of the resolved media item so the overlay can display it. */
+    private val showThumbnail: (uri: String) -> Unit,
+    private val retryDelayMs: Long = Constants.MEDIA_OBSERVER_RETRY_MS,
+) {
+
+    /**
+     * Called whenever the thumbnail ContentObserver detects a change.
+     *
+     * Immediately queries for the latest committed media added since [startMs].
+     * If the query returns null (item is still IS_PENDING), schedules a single retry
+     * after [retryDelayMs] ms.
+     */
+    fun onThumbnailChanged(startMs: Long) {
+        val item = queryLatestMedia(startMs)
+        if (item != null) {
+            showThumbnail(item.uri)
+            DebugLog.log("Thumbnail updated: ${item.uri}")
+        } else {
+            // Item may still be IS_PENDING; schedule a single retry so we don't
+            // silently drop the thumbnail update on devices where the second
+            // ContentObserver callback (IS_PENDING→0) is unreliable.
+            DebugLog.log("Thumbnail query returned null — scheduling retry in ${retryDelayMs}ms")
+            handler.postDelayed({
+                val retryItem = queryLatestMedia(startMs)
+                if (retryItem != null) {
+                    showThumbnail(retryItem.uri)
+                    DebugLog.log("Thumbnail updated (retry): ${retryItem.uri}")
+                }
+            }, retryDelayMs)
+        }
+    }
+}

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -26,6 +26,8 @@ import org.robolectric.shadows.ShadowWindowManagerImpl
  * - Issue #66: overlay must remain visible after show() when focusableOverlay is false
  *   (FLAG_NOT_FOCUSABLE windows never receive focus, so onWindowFocusChanged(false) fires
  *   immediately — the focus callbacks must be suppressed in that mode).
+ * - Issue #81: loadThumbnailBitmap must return null (not throw) when the URI is invalid
+ *   and must fall back gracefully when loadThumbnail fails.
  */
 @RunWith(RobolectricTestRunner::class)
 class OverlayManagerRobolectricTest {
@@ -126,5 +128,68 @@ class OverlayManagerRobolectricTest {
                 "replaced by the icon drawable (regression guard for Issue #45)",
             overlayView.drawable is BitmapDrawable
         )
+    }
+
+    // ── Issue #81: loadThumbnailBitmap fallback ──────────────────────────────
+
+    /**
+     * When the URI is inaccessible (URI not accessible — as can happen on a locked device
+     * or for a pending media item), loadThumbnailBitmap must complete without throwing.
+     * The real assertion here is that no exception propagates out of the method.
+     */
+    @Test
+    fun `loadThumbnailBitmap completes without throwing for an inaccessible URI`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager = mock {
+            on { galleryPackage } doReturn null
+            on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+            on { focusableOverlay } doReturn false
+        }
+        val overlayManager = OverlayManager(context, prefsManager)
+
+        // A URI with an unregistered authority — this exercises the fallback exception-
+        // handling path so we know an inaccessible URI never crashes the overlay service.
+        val unregisteredUri = android.net.Uri.parse("content://com.gb4pc.unregistered.authority/images/999")
+
+        // If loadThumbnailBitmap throws, the test fails automatically. No explicit assert needed.
+        overlayManager.loadThumbnailBitmap(unregisteredUri)
+    }
+
+    /**
+     * Verifies that loadThumbnailBitmap's fallback path (openInputStream) is reachable
+     * and returns null gracefully when the stream is empty/invalid.
+     *
+     * This guards against a regression where an exception from the pre-Q path
+     * propagates out of loadThumbnailBitmap and crashes the service.
+     */
+    @Test
+    fun `loadThumbnailBitmap does not throw for any URI`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager = mock {
+            on { galleryPackage } doReturn null
+            on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+            on { focusableOverlay } doReturn false
+        }
+        val overlayManager = OverlayManager(context, prefsManager)
+
+        val urisToTest = listOf(
+            "content://media/external/images/media/99999",
+            "content://com.gb4pc.unregistered/images/1",
+            "content://invalid",
+        )
+
+        for (uriString in urisToTest) {
+            val uri = android.net.Uri.parse(uriString)
+            var threw = false
+            try {
+                overlayManager.loadThumbnailBitmap(uri)
+            } catch (e: Exception) {
+                threw = true
+            }
+            assertFalse(
+                "loadThumbnailBitmap must not throw for URI: $uriString",
+                threw
+            )
+        }
     }
 }

--- a/app/src/test/java/com/gb4pc/service/MediaChangeDispatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/service/MediaChangeDispatcherTest.kt
@@ -1,0 +1,210 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.viewer.MediaItem
+import com.gb4pc.viewer.SessionTracker
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+/**
+ * Unit tests for [MediaChangeDispatcher].
+ *
+ * Covers the IS_PENDING race: when a photo is first inserted into MediaStore with
+ * IS_PENDING=1 the default query returns null; a retry is scheduled so the item is
+ * captured once IS_PENDING is cleared. Also verifies that when the item is already
+ * committed on the first query no retry is scheduled.
+ */
+class MediaChangeDispatcherTest {
+
+    private lateinit var sessionTracker: SessionTracker
+    private lateinit var handler: Handler
+    private val retryDelayMs = 500L
+
+    private val sampleItem = MediaItem(
+        uri = "content://media/external/images/media/42",
+        dateTaken = 1_000_000L,
+        isVideo = false
+    )
+
+    @Before
+    fun setUp() {
+        sessionTracker = mock()
+        handler = mock()
+    }
+
+    // ── Immediate-hit path ──────────────────────────────────────────────────
+
+    /**
+     * When the query immediately finds a committed item, it is added to the session
+     * and no retry is scheduled.
+     */
+    @Test
+    fun `onMediaChanged adds item immediately when query succeeds`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { sampleItem },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        verify(sessionTracker).addMedia(sampleItem)
+        verify(handler, never()).postDelayed(any(), any())
+    }
+
+    /**
+     * The item passed to addMedia is the one returned by the query, not a copy.
+     */
+    @Test
+    fun `onMediaChanged passes exact query result to sessionTracker`() {
+        val captor = argumentCaptor<MediaItem>()
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { sampleItem },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 0L)
+
+        verify(sessionTracker).addMedia(captor.capture())
+        assertEquals(sampleItem.uri, captor.firstValue.uri)
+    }
+
+    // ── IS_PENDING retry path ───────────────────────────────────────────────
+
+    /**
+     * When the first query returns null (item is IS_PENDING), a retry runnable is
+     * scheduled via handler.postDelayed with the configured retryDelayMs.
+     */
+    @Test
+    fun `onMediaChanged schedules retry when first query returns null`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { null },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        verify(sessionTracker, never()).addMedia(any())
+        verify(handler).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    /**
+     * When the retry fires and the item has been committed (query returns non-null),
+     * it is added to the session.
+     */
+    @Test
+    fun `retry runnable adds item when query succeeds on second attempt`() {
+        var callCount = 0
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { if (callCount++ == 0) null else sampleItem },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        // Nothing added yet; a retry was posted
+        verify(sessionTracker, never()).addMedia(any())
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        verify(sessionTracker).addMedia(sampleItem)
+    }
+
+    /**
+     * When the retry fires but the query STILL returns null (photo was deleted or
+     * never committed), nothing is added to the session and no further retry is
+     * scheduled — the retry is strictly one-shot.
+     */
+    @Test
+    fun `retry is one-shot - no further retry when second query also returns null`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { null },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        // No item added; no further postDelayed beyond the original one
+        verify(sessionTracker, never()).addMedia(any())
+        verify(handler, times(1)).postDelayed(any(), any())
+    }
+
+    /**
+     * Two rapid media changes: first fires while item is pending (null result →
+     * retry scheduled), second fires after item is committed (non-null → item added
+     * immediately). The retry still fires but deduplication in SessionTracker
+     * prevents double-adding (by design in addMedia, not tested here since we
+     * use a mock tracker).
+     */
+    @Test
+    fun `two onChange calls for same photo - first schedules retry, second adds immediately`() {
+        var callCount = 0
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { if (callCount++ == 0) null else sampleItem },
+            retryDelayMs = retryDelayMs,
+        )
+
+        // First change: item is pending
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+        verify(handler, times(1)).postDelayed(any(), eq(retryDelayMs))
+        verify(sessionTracker, never()).addMedia(any())
+
+        // Second change: item is now committed
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+        verify(sessionTracker, times(1)).addMedia(sampleItem)
+        // No additional retry posted
+        verify(handler, times(1)).postDelayed(any(), any())
+    }
+
+    // ── Session start parameter is forwarded correctly ───────────────────────
+
+    /**
+     * The sessionStartMs value passed to onMediaChanged is forwarded to the query
+     * lambda on both the initial call and the retry.
+     */
+    @Test
+    fun `sessionStartMs is forwarded to queryLatestMedia on initial call and retry`() {
+        val capturedStartMs = mutableListOf<Long>()
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryLatestMedia = { startMs ->
+                capturedStartMs.add(startMs)
+                null
+            },
+            retryDelayMs = retryDelayMs,
+        )
+
+        val expectedStartMs = 1_234_567L
+        dispatcher.onMediaChanged(sessionStartMs = expectedStartMs)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), any())
+        runnableCaptor.firstValue.run()
+
+        assertEquals("Both calls should use the same sessionStartMs", 2, capturedStartMs.size)
+        assertTrue(capturedStartMs.all { it == expectedStartMs })
+    }
+}

--- a/app/src/test/java/com/gb4pc/service/ThumbnailChangeDispatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ThumbnailChangeDispatcherTest.kt
@@ -1,0 +1,178 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.viewer.MediaItem
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+/**
+ * Unit tests for [ThumbnailChangeDispatcher].
+ *
+ * Covers the IS_PENDING retry: when a photo is still IS_PENDING the thumbnail query
+ * returns null; a retry is scheduled so the overlay thumbnail is updated once the
+ * item is committed. Also verifies that when the item is already committed on the
+ * first query no retry is scheduled.
+ */
+class ThumbnailChangeDispatcherTest {
+
+    private lateinit var handler: Handler
+    private lateinit var showThumbnail: (String) -> Unit
+    private val retryDelayMs = 500L
+
+    private val sampleItem = MediaItem(
+        uri = "content://media/external/images/media/42",
+        dateTaken = 1_000_000L,
+        isVideo = false
+    )
+
+    @Before
+    fun setUp() {
+        handler = mock()
+        showThumbnail = mock()
+    }
+
+    // ── Immediate-hit path ──────────────────────────────────────────────────
+
+    /**
+     * When the query immediately finds a committed item, showThumbnail is called and
+     * no retry is scheduled.
+     */
+    @Test
+    fun `onThumbnailChanged shows thumbnail immediately when query succeeds`() {
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { sampleItem },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        verify(showThumbnail).invoke(sampleItem.uri)
+        verify(handler, never()).postDelayed(any(), any())
+    }
+
+    /**
+     * The URI passed to showThumbnail is the one from the query result.
+     */
+    @Test
+    fun `onThumbnailChanged passes exact query result URI to showThumbnail`() {
+        val uriCaptor = argumentCaptor<String>()
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { sampleItem },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 0L)
+
+        verify(showThumbnail).invoke(uriCaptor.capture())
+        assertEquals(sampleItem.uri, uriCaptor.firstValue)
+    }
+
+    // ── IS_PENDING retry path ───────────────────────────────────────────────
+
+    /**
+     * When the first query returns null (item is IS_PENDING), a retry runnable is
+     * scheduled via handler.postDelayed with the configured retryDelayMs.
+     */
+    @Test
+    fun `onThumbnailChanged schedules retry when first query returns null`() {
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { null },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        verify(showThumbnail, never()).invoke(any())
+        verify(handler).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    /**
+     * When the retry fires and the item has been committed (query returns non-null),
+     * showThumbnail is called with the item URI.
+     */
+    @Test
+    fun `retry runnable shows thumbnail when query succeeds on second attempt`() {
+        var callCount = 0
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { if (callCount++ == 0) null else sampleItem },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        // Nothing shown yet; a retry was posted
+        verify(showThumbnail, never()).invoke(any())
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        verify(showThumbnail).invoke(sampleItem.uri)
+    }
+
+    /**
+     * When the retry fires but the query STILL returns null (photo was deleted or
+     * never committed), showThumbnail is not called and no further retry is
+     * scheduled — the retry is strictly one-shot.
+     */
+    @Test
+    fun `retry is one-shot - no further retry when second query also returns null`() {
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { null },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        // No thumbnail shown; no further postDelayed beyond the original one
+        verify(showThumbnail, never()).invoke(any())
+        verify(handler, times(1)).postDelayed(any(), any())
+    }
+
+    /**
+     * The startMs value passed to onThumbnailChanged is forwarded to the query
+     * lambda on both the initial call and the retry.
+     */
+    @Test
+    fun `startMs is forwarded to queryLatestMedia on initial call and retry`() {
+        val capturedStartMs = mutableListOf<Long>()
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { startMs ->
+                capturedStartMs.add(startMs)
+                null
+            },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        val expectedStartMs = 1_234_567L
+        dispatcher.onThumbnailChanged(startMs = expectedStartMs)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), any())
+        runnableCaptor.firstValue.run()
+
+        assertEquals("Both calls should use the same startMs", 2, capturedStartMs.size)
+        assertTrue(capturedStartMs.all { it == expectedStartMs })
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes two symptoms from issue #81: the overlay button not updating its thumbnail while the device is locked, and the secure viewer showing an empty filmstrip after taking photos on the lock screen.

- **Thumbnail fallback (symptom 1):** `OverlayManager.showLatestPhotoThumbnail` called `ContentResolver.loadThumbnail` on API 29+, which can fail on a locked device when the thumbnail cache lives in credential-encrypted storage (the photo file on external storage is still accessible). Added a `loadThumbnailBitmap` helper (internal, testable) that falls back to `openInputStream` + `BitmapFactory` when `loadThumbnail` throws, rather than silently abandoning the update.

- **Session media IS_PENDING race (symptom 2):** Modern camera apps insert new photos into MediaStore with `IS_PENDING=1` while writing the file. The `ContentObserver` fires immediately, but the default query excludes pending rows, so `queryLatestMedia` returns null and nothing is added to the session. Extracted the onChange logic into `MediaChangeDispatcher`, which schedules a single 500 ms retry (`Constants.MEDIA_OBSERVER_RETRY_MS`) when the first query returns null — picking up committed rows once IS_PENDING is cleared.

- **Timestamp tolerance (symptom 2, secondary):** `queryLatestMedia` previously queried `DATE_ADDED >= sessionStartMs/1000` with no tolerance, potentially missing photos whose `DATE_ADDED` was rounded to the same second as session start. Now applies the same `SESSION_TIMESTAMP_TOLERANCE_MS` (2 s) already used by `SessionTracker.isMediaInSession`.

## Commits

1. `Fix thumbnail loading on locked device by falling back to stream decode` — `OverlayManager.loadThumbnailBitmap` with API 29+ fallback
2. `Fix session media not captured while device is locked` — `MediaChangeDispatcher` retry + timestamp tolerance
3. `Refactor: extract MediaChangeDispatcher for testability` — pure refactor, no behavior change
4. `Add tests for issue-81 fixes` — `MediaChangeDispatcherTest` (7 JVM tests) + Robolectric tests for `loadThumbnailBitmap`

## Test plan

- [ ] All existing unit tests pass (`./gradlew test`)
- [ ] `MediaChangeDispatcherTest`: immediate-hit path, IS_PENDING retry path, one-shot retry guard, sessionStartMs forwarding
- [ ] `OverlayManagerRobolectricTest`: `loadThumbnailBitmap` does not throw for inaccessible URIs
- [ ] Manual: open Pixel Camera from lock screen, take photos — overlay button should update thumbnail
- [ ] Manual: open Pixel Camera from lock screen, take photos, tap overlay — secure viewer should show taken photos

https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCeZhTm4m7jLoyyDuyCKs)_