### PR TITLE
Remove trace-level foreground-ID log statements

### DIFF
--- a/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
+++ b/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
@@ -27,7 +27,6 @@ class ForegroundDetector(
     fun getForegroundPackage(): String? {
         val endTime = System.currentTimeMillis()
         val beginTime = endTime - Constants.USAGE_STATS_WINDOW_MS
-        DebugLog.log("ForegroundDetector: querying window=${Constants.USAGE_STATS_WINDOW_MS}ms ending at $endTime")
 
         val events = usageStatsManager.queryEvents(beginTime, endTime)
         if (events == null) {
@@ -48,11 +47,9 @@ class ForegroundDetector(
             if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
                 if (event.packageName == selfPackage) {
                     skippedSelfEvents++
-                    DebugLog.log("ForegroundDetector: skipping self MOVE_TO_FOREGROUND pkg=${event.packageName} ts=${event.timeStamp} (Issue #80)")
                     continue
                 }
                 foregroundEvents++
-                DebugLog.log("ForegroundDetector: MOVE_TO_FOREGROUND pkg=${event.packageName} ts=${event.timeStamp}")
                 if (event.timeStamp >= latestTimestamp) {
                     latestTimestamp = event.timeStamp
                     latestForegroundPackage = event.packageName
@@ -71,9 +68,7 @@ class ForegroundDetector(
 
     companion object {
         fun isPixelCameraPackage(packageName: String?): Boolean {
-            val result = packageName == Constants.PIXEL_CAMERA_PACKAGE
-            DebugLog.log("ForegroundDetector: isPixelCamera($packageName) = $result")
-            return result
+            return packageName == Constants.PIXEL_CAMERA_PACKAGE
         }
     }
 }

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -92,7 +92,7 @@ class OverlayServiceLogic(
 
         val pkg = foregroundDetector.getForegroundPackage()
         val isPixelCamera = ForegroundDetector.isPixelCameraPackage(pkg)
-        DebugLog.log("Logic: evaluateForeground — foreground=$pkg, isPixelCamera=$isPixelCamera, overlayActive=$isOverlayActive, anyCameraUnavailable=${cameraState.anyCameraUnavailable()}")
+        DebugLog.log("Logic: evaluateForeground — foreground=$pkg, overlayActive=$isOverlayActive, anyCameraUnavailable=${cameraState.anyCameraUnavailable()}")
 
         if (isPixelCamera && !isOverlayActive) {
             cancelActivationRetry()

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -92,14 +92,13 @@ class OverlayServiceLogic(
 
         val pkg = foregroundDetector.getForegroundPackage()
         val isPixelCamera = ForegroundDetector.isPixelCameraPackage(pkg)
-        DebugLog.log("Logic: evaluateForeground — foreground=$pkg, overlayActive=$isOverlayActive, anyCameraUnavailable=${cameraState.anyCameraUnavailable()}")
+        DebugLog.log("Logic: evaluateForeground — overlayActive=$isOverlayActive, anyCameraUnavailable=${cameraState.anyCameraUnavailable()}")
 
         if (isPixelCamera && !isOverlayActive) {
             cancelActivationRetry()
             showOverlay()
         } else if (!isOverlayActive && cameraState.anyCameraUnavailable()) {
             // UsageStats may not have caught up yet; schedule a retry (DT-06a).
-            DebugLog.log("Logic: Pixel Camera not yet in foreground — scheduling activation retry")
             scheduleActivationRetry()
         }
     }


### PR DESCRIPTION
Fixes #90

Removes the trace-level `DebugLog.log()` calls that recorded details about the foreground-app-ID check:

**`ForegroundDetector.kt`** (prior commit on this branch):
- Removed "querying window=…" (about to check)
- Removed per-event "MOVE_TO_FOREGROUND pkg=…" and "skipping self MOVE_TO_FOREGROUND" traces
- Removed `isPixelCameraPackage()` log that recorded the equality-check result; simplified to a direct `return` expression

**`OverlayServiceLogic.kt`**:
- Removed `isPixelCamera=$isPixelCamera` from the `evaluateForeground` log (prior commit)
- Removed `foreground=$pkg` from the same log — the package name is already reported by `ForegroundDetector`'s own summary line
- Removed "Pixel Camera not yet in foreground" log, which explicitly stated the equality-check result

**Kept**:
- `ForegroundDetector`'s result summary lines (`foreground=<pkg>` and `no foreground app detected`) along with total/foreground/skipped event counts — these capture what the FG app is and the full response context
- All other `OverlayServiceLogic` logs (overlay state, camera availability, session lifecycle, etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d)_