### PR TITLE
Skip deactivation checklist in onCameraAvailable when overlay is inactive

### DIFF
--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -57,7 +57,12 @@ class OverlayServiceLogic(
     fun onCameraAvailable(cameraId: String) {
         cameraState.setCameraAvailable(cameraId)
         val allAvailable = cameraState.areAllCamerasAvailable()
-        DebugLog.log("Logic: camera $cameraId available; allAvailable=$allAvailable, remaining=${cameraState.getUnavailableCameraIds()}")
+        DebugLog.log("Logic: camera $cameraId available; allAvailable=$allAvailable, remaining=${cameraState.getUnavailableCameraIds()}, overlayActive=$isOverlayActive")
+        // Issue #89: If the overlay is not active there is nothing to deactivate.
+        if (!isOverlayActive) {
+            cancelActivationRetry()
+            return
+        }
         // DT-04/DT-05: Only schedule deactivation when ALL cameras have been released
         if (allAvailable) {
             cancelActivationRetry()

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -398,6 +398,8 @@ class OverlayServiceLogicTest {
     /**
      * If the camera is released while a retry is pending (e.g. a non-Pixel-Camera app
      * briefly opened the camera), the retry should be cancelled so it doesn't fire stale.
+     * Issue #89: the early-exit guard also ensures no deactivation is scheduled in this case
+     * (overlay was never active, so there is nothing to deactivate).
      */
     @Test
     fun `DT-06a pending retry cancelled when camera released before retry fires`() {
@@ -407,10 +409,14 @@ class OverlayServiceLogicTest {
         val runnableCaptor = argumentCaptor<Runnable>()
         verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
 
-        // Camera released — all cameras now available
+        // Camera released before activation completed — overlay still inactive
+        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
         logic.onCameraAvailable("0")
 
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
+        // Issue #89: no deactivation should be scheduled — overlay was never active
+        verify(handler, never()).postDelayed(any(), eq(0L))
+        verify(handler, never()).postDelayed(any(), eq(Constants.CAMERA_DEBOUNCE_MS))
     }
 
     // ── Issue #89: skip deactivation when overlay is already inactive ────────
@@ -443,27 +449,6 @@ class OverlayServiceLogicTest {
 
         verify(handler, never()).postDelayed(any(), any())
         verify(overlayManager, never()).hide()
-    }
-
-    /**
-     * When a camera-now-available event arrives and the overlay is inactive, any pending
-     * activation retry should be cancelled (the camera was released before activation completed).
-     */
-    @Test
-    fun `issue-89 onCameraAvailable when overlay inactive cancels pending activation retry`() {
-        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
-        logic.onCameraUnavailable("0") // retry scheduled because foreground not detected
-
-        val runnableCaptor = argumentCaptor<Runnable>()
-        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
-
-        // Camera released before activation completed — overlay still inactive
-        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
-        logic.onCameraAvailable("0")
-
-        verify(handler).removeCallbacks(runnableCaptor.firstValue)
-        verify(handler, never()).postDelayed(any(), eq(0L))
-        verify(handler, never()).postDelayed(any(), eq(Constants.CAMERA_DEBOUNCE_MS))
     }
 
     // ── Issue #46: foreground-aware deactivation delay ──────────────────────

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -413,6 +413,59 @@ class OverlayServiceLogicTest {
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
     }
 
+    // ── Issue #89: skip deactivation when overlay is already inactive ────────
+
+    /**
+     * When a camera-now-available event arrives and the overlay was never activated,
+     * no deactivation should be scheduled.
+     */
+    @Test
+    fun `issue-89 onCameraAvailable does not schedule deactivation when overlay is inactive`() {
+        // Overlay was never activated — simulate the initial-startup priming case
+        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
+
+        logic.onCameraAvailable("0")
+
+        verify(handler, never()).postDelayed(any(), any())
+        assertFalse("Overlay should still be inactive", logic.isOverlayActive)
+    }
+
+    /**
+     * When the last camera is released but the overlay is inactive, no deactivation runnable
+     * fires, and overlayManager.hide() is never called.
+     */
+    @Test
+    fun `issue-89 onCameraAvailable when all cameras released and overlay inactive skips deactivation`() {
+        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
+
+        cameraState.setCameraUnavailable("0")
+        logic.onCameraAvailable("0") // all cameras now available, but overlay was never shown
+
+        verify(handler, never()).postDelayed(any(), any())
+        verify(overlayManager, never()).hide()
+    }
+
+    /**
+     * When a camera-now-available event arrives and the overlay is inactive, any pending
+     * activation retry should be cancelled (the camera was released before activation completed).
+     */
+    @Test
+    fun `issue-89 onCameraAvailable when overlay inactive cancels pending activation retry`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        logic.onCameraUnavailable("0") // retry scheduled because foreground not detected
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+
+        // Camera released before activation completed — overlay still inactive
+        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
+        logic.onCameraAvailable("0")
+
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+        verify(handler, never()).postDelayed(any(), eq(0L))
+        verify(handler, never()).postDelayed(any(), eq(Constants.CAMERA_DEBOUNCE_MS))
+    }
+
     // ── Issue #46: foreground-aware deactivation delay ──────────────────────
 
     /**


### PR DESCRIPTION
Fixes #89

## What changed

In `onCameraAvailable()`, added an early-exit guard: if the overlay is not currently active, cancel any pending activation retry and return immediately — without running the deactivation checklist.

## Why

The camera-now-available event fires in two situations where the overlay was never shown:
- **Initial startup**: the `CameraManager` listener is primed with the current camera status, which is typically "all cameras available".
- **Another app releases the camera**: any process that held the camera (e.g. a QR scanner) releases it, triggering the event even though Pixel Camera was never in the foreground.

In both cases, `isOverlayActive` is `false`, so there is nothing to deactivate. The old code would still proceed into the `allAvailable` branch and potentially schedule a deactivation runnable (a no-op at runtime, but unnecessary work and an incorrect code path to walk).

## Tests added

Three new unit tests in `OverlayServiceLogicTest` under the `Issue #89` section:

1. `onCameraAvailable does not schedule deactivation when overlay is inactive` — initial-startup priming case.
2. `onCameraAvailable when all cameras released and overlay inactive skips deactivation` — all cameras released but overlay was never shown.
3. `onCameraAvailable when overlay inactive cancels pending activation retry` — camera released before the UsageStats retry fired, overlay still inactive; verifies the retry runnable is removed and no deactivation is scheduled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d)_