### PR TITLE
Fix lock-screen photo detection: UsageStats bypass, all-items query, always retry

### DIFF
--- a/app/src/main/java/com/gb4pc/service/MediaChangeDispatcher.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaChangeDispatcher.kt
@@ -18,47 +18,67 @@ import com.gb4pc.viewer.SessionTracker
  * Pixel Camera (and other modern camera apps on API 29+) inserts new photos into
  * MediaStore with IS_PENDING = 1 while the file is being written, then clears the
  * flag once the write completes. The ContentObserver fires on both state transitions.
- * On the first fire (IS_PENDING = 1) the default query excludes the pending row and
- * [queryLatestMedia] returns null. On the second fire (IS_PENDING cleared) the
- * committed row is found and added to the session.
+ * On the first fire (IS_PENDING = 1) the default query excludes the pending row, so
+ * any item returned by [queryAllMedia] is a previously committed photo.  On the second
+ * fire (IS_PENDING = 0) the newly committed row is found and added to the session.
  *
  * However, on some devices/firmware the second ContentObserver callback for the
- * IS_PENDING→0 transition is not delivered reliably. [onMediaChanged] therefore
- * schedules a single retry after [Constants.MEDIA_OBSERVER_RETRY_MS] when the
- * initial query returns null, picking up committed rows that the first callback
- * missed.
+ * IS_PENDING→0 transition is not delivered reliably (particularly on locked devices).
+ * [onMediaChanged] therefore always schedules a single retry after [retryDelayMs]
+ * (cancel-and-reschedule on rapid-fire shots) that queries for all newly committed
+ * items — picking up photos whose IS_PENDING=0 notification was missed.
+ *
+ * ## Multiple photos
+ *
+ * When multiple photos are taken in quick succession, only the most recent IS_PENDING=1
+ * callback would have found a null result (no committed item) with the old single-retry
+ * approach.  Each subsequent IS_PENDING=1 callback found the *previous* committed photo
+ * (non-null), so no retry was scheduled for the new photo.  By querying *all* items
+ * since [sessionStartMs] on every callback and on the retry, every committed photo is
+ * captured regardless of whether its IS_PENDING=0 notification fires.  Deduplication
+ * inside [SessionTracker.addMedia] prevents double-adds.
  */
 class MediaChangeDispatcher(
     private val sessionTracker: SessionTracker,
     private val handler: Handler,
-    /** Returns the most recent [MediaItem] added after [sessionStartMs], or null. */
-    private val queryLatestMedia: (sessionStartMs: Long) -> MediaItem?,
+    /** Returns all [MediaItem]s with DATE_ADDED after [sessionStartMs], newest-first. */
+    private val queryAllMedia: (sessionStartMs: Long) -> List<MediaItem>,
     private val retryDelayMs: Long = Constants.MEDIA_OBSERVER_RETRY_MS,
 ) {
+    // At most one pending retry runnable at a time; cancelled and rescheduled on each onChange.
+    private var pendingRetry: Runnable? = null
 
     /**
      * Called whenever the media ContentObserver detects a change.
      *
-     * Immediately queries for the latest committed media added since [sessionStartMs].
-     * If the query returns null (item is still IS_PENDING), schedules a single retry
-     * after [retryDelayMs] ms.
+     * Immediately adds all committed media items found since [sessionStartMs] to the session.
+     * Then cancels any in-flight retry and schedules a fresh one after [retryDelayMs] ms so
+     * that items still in IS_PENDING state at the time of this call are captured once they
+     * are committed.  Rapid-fire photos produce at most one pending retry at any moment.
      */
     fun onMediaChanged(sessionStartMs: Long) {
-        val item = queryLatestMedia(sessionStartMs)
-        if (item != null) {
+        val items = queryAllMedia(sessionStartMs)
+        items.forEach { item ->
             sessionTracker.addMedia(item)
             DebugLog.log("Media added to session: ${item.uri}")
-        } else {
-            // First onChange may fire while the photo is IS_PENDING; schedule a retry so we
-            // catch it once it has been committed to MediaStore.
-            DebugLog.log("Media query returned null — scheduling retry in ${retryDelayMs}ms")
-            handler.postDelayed({
-                val retryItem = queryLatestMedia(sessionStartMs)
-                if (retryItem != null) {
-                    sessionTracker.addMedia(retryItem)
-                    DebugLog.log("Media added to session (retry): ${retryItem.uri}")
-                }
-            }, retryDelayMs)
         }
+        if (items.isEmpty()) {
+            DebugLog.log("Media query returned empty — scheduling retry in ${retryDelayMs}ms")
+        }
+
+        // Always schedule a retry: the onChange may have fired while the new item was
+        // still IS_PENDING and therefore excluded from the query.  Cancel any previous
+        // pending retry to avoid stacking runnables during burst-mode shooting.
+        pendingRetry?.let { handler.removeCallbacks(it) }
+        val runnable = Runnable {
+            pendingRetry = null
+            val retryItems = queryAllMedia(sessionStartMs)
+            retryItems.forEach { item ->
+                sessionTracker.addMedia(item)
+                DebugLog.log("Media added to session (retry): ${item.uri}")
+            }
+        }
+        pendingRetry = runnable
+        handler.postDelayed(runnable, retryDelayMs)
     }
 }

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -87,7 +87,7 @@ class OverlayService : Service() {
         mediaChangeDispatcher = MediaChangeDispatcher(
             sessionTracker = SessionTracker.instance,
             handler = handler,
-            queryLatestMedia = ::queryLatestMedia,
+            queryAllMedia = ::queryAllMedia,
         )
 
         thumbnailChangeDispatcher = ThumbnailChangeDispatcher(
@@ -295,8 +295,9 @@ class OverlayService : Service() {
         }
     }
 
-    // H4: Query for latest media item added after session start
-    private fun queryLatestMedia(sessionStartMs: Long): MediaItem? {
+    // H4: Query for all committed media items added after session start.
+    // Used by MediaChangeDispatcher to populate the secure session.
+    private fun queryAllMedia(sessionStartMs: Long): List<MediaItem> {
         val projection = arrayOf(
             MediaStore.MediaColumns._ID,
             MediaStore.MediaColumns.MIME_TYPE,
@@ -308,43 +309,49 @@ class OverlayService : Service() {
         val effectiveStartSec = (sessionStartMs - Constants.SESSION_TIMESTAMP_TOLERANCE_MS) / 1000
         val selectionArgs = arrayOf(effectiveStartSec.toString())
 
-        // Query images
-        val imageResult = queryMediaStore(
-            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-            projection,
-            selectionArgs,
-            isVideo = false
-        )
-        if (imageResult != null) return imageResult
-
-        // Query videos
-        return queryMediaStore(
-            MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
-            projection,
-            selectionArgs,
-            isVideo = true
-        )
+        val result = mutableListOf<MediaItem>()
+        result.addAll(queryAllFromMediaStore(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, selectionArgs, isVideo = false))
+        result.addAll(queryAllFromMediaStore(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, projection, selectionArgs, isVideo = true))
+        return result
     }
 
-    private fun queryMediaStore(
+    // H4: Query for the most recent committed media item added after startMs.
+    // Used by ThumbnailChangeDispatcher to update the overlay button.
+    private fun queryLatestMedia(startMs: Long): MediaItem? {
+        val projection = arrayOf(
+            MediaStore.MediaColumns._ID,
+            MediaStore.MediaColumns.MIME_TYPE,
+            MediaStore.MediaColumns.DATE_ADDED,
+            MediaStore.MediaColumns.DATE_TAKEN
+        )
+        val effectiveStartSec = (startMs - Constants.SESSION_TIMESTAMP_TOLERANCE_MS) / 1000
+        val selectionArgs = arrayOf(effectiveStartSec.toString())
+
+        val imageResult = queryAllFromMediaStore(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, selectionArgs, isVideo = false)
+        if (imageResult.isNotEmpty()) return imageResult.first()
+        val videoResult = queryAllFromMediaStore(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, projection, selectionArgs, isVideo = true)
+        return videoResult.firstOrNull()
+    }
+
+    private fun queryAllFromMediaStore(
         contentUri: Uri,
         projection: Array<String>,
         selectionArgs: Array<String>,
         isVideo: Boolean
-    ): MediaItem? {
+    ): List<MediaItem> {
         val selection = "${MediaStore.MediaColumns.DATE_ADDED} >= ?"
         val sortOrder = "${MediaStore.MediaColumns.DATE_ADDED} DESC"
+        val items = mutableListOf<MediaItem>()
         contentResolver.query(contentUri, projection, selection, selectionArgs, sortOrder)?.use { cursor ->
-            if (cursor.moveToFirst()) {
+            while (cursor.moveToNext()) {
                 val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
-                val mime = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE))
                 val dateTakenCol = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_TAKEN)
                 val dateTaken = if (dateTakenCol >= 0) cursor.getLong(dateTakenCol) else System.currentTimeMillis()
                 val uri = ContentUris.withAppendedId(contentUri, id)
-                return MediaItem(uri.toString(), dateTaken, isVideo)
+                items.add(MediaItem(uri.toString(), dateTaken, isVideo))
             }
         }
-        return null
+        return items
     }
 
     private fun buildNotification(): Notification {

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -64,9 +64,18 @@ class OverlayServiceLogic(
             // Issue #46: If Pixel Camera is no longer in the foreground, skip the debounce delay.
             // The debounce is only needed for transient camera switches (where hardware briefly
             // shows available between switching cameras); for a true app-close we want 0 ms.
-            val pkg = foregroundDetector.getForegroundPackage()
-            val delay = if (ForegroundDetector.isPixelCameraPackage(pkg)) debounceMs else 0L
-            DebugLog.log("Logic: all cameras released; scheduling deactivation delay=${delay}ms (foreground=$pkg)")
+            //
+            // Issue #81: When the device is locked, UsageStats returns null for the foreground
+            // package, so isPixelCameraPackage() would always be false — incorrectly using 0 ms
+            // and prematurely hiding the overlay during a transient camera switch on the lock
+            // screen.  Take the conservative (debounceMs) path whenever the keyguard is locked.
+            val delay = if (isKeyguardLocked()) {
+                debounceMs
+            } else {
+                val pkg = foregroundDetector.getForegroundPackage()
+                if (ForegroundDetector.isPixelCameraPackage(pkg)) debounceMs else 0L
+            }
+            DebugLog.log("Logic: all cameras released; scheduling deactivation delay=${delay}ms (keyguardLocked=${isKeyguardLocked()})")
             scheduleDeactivation(delay)
         }
     }
@@ -98,12 +107,19 @@ class OverlayServiceLogic(
         }
 
         // Issue #81: UsageStats does not report foreground events while the device is locked.
-        // When locked and the camera is in use, activate the overlay without a UsageStats lookup:
-        // the lock-screen camera shortcut can only launch Pixel Camera.
-        if (isKeyguardLocked() && cameraState.anyCameraUnavailable() && !isOverlayActive) {
-            DebugLog.log("Logic: evaluateForeground — device locked with camera in use; activating overlay without UsageStats lookup")
-            cancelActivationRetry()
-            showOverlay()
+        // When locked and the camera is in use, skip the UsageStats lookup entirely:
+        // - If the overlay is not yet active, activate it (the lock-screen camera shortcut can
+        //   only launch Pixel Camera).
+        // - If the overlay is already active, return early so we never call getForegroundPackage()
+        //   on a locked device (it would return null and could cause incorrect side-effects).
+        if (isKeyguardLocked() && cameraState.anyCameraUnavailable()) {
+            if (!isOverlayActive) {
+                DebugLog.log("Logic: evaluateForeground — device locked with camera in use; activating overlay without UsageStats lookup")
+                cancelActivationRetry()
+                showOverlay()
+            } else {
+                DebugLog.log("Logic: evaluateForeground — device locked, overlay already active; skipping UsageStats lookup")
+            }
             return
         }
 

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -76,6 +76,13 @@ class OverlayServiceLogic(
     /**
      * DT-02/DT-03: Check if Pixel Camera is the foreground app and show/hide overlay.
      * DT-06a: If the foreground event hasn't appeared in UsageStats yet (lag), schedule a retry.
+     *
+     * Lock-screen bypass (Issue #81): When the device is locked,
+     * [android.app.usage.UsageStatsManager] does not emit MOVE_TO_FOREGROUND events, so
+     * [ForegroundDetector.getForegroundPackage] always returns null regardless of which app
+     * opened the camera.  On a locked device the camera can only be launched via the lock-screen
+     * camera shortcut — which is always Pixel Camera — so we bypass the UsageStats check and
+     * activate the overlay directly.
      */
     fun evaluateForeground() {
         if (!hasUsageStatsPermission()) {
@@ -87,6 +94,16 @@ class OverlayServiceLogic(
                 onUsageAccessLost()
             }
             cancelActivationRetry()
+            return
+        }
+
+        // Issue #81: UsageStats does not report foreground events while the device is locked.
+        // When locked and the camera is in use, activate the overlay without a UsageStats lookup:
+        // the lock-screen camera shortcut can only launch Pixel Camera.
+        if (isKeyguardLocked() && cameraState.anyCameraUnavailable() && !isOverlayActive) {
+            DebugLog.log("Logic: evaluateForeground — device locked with camera in use; activating overlay without UsageStats lookup")
+            cancelActivationRetry()
+            showOverlay()
             return
         }
 

--- a/app/src/main/java/com/gb4pc/service/ThumbnailChangeDispatcher.kt
+++ b/app/src/main/java/com/gb4pc/service/ThumbnailChangeDispatcher.kt
@@ -14,10 +14,18 @@ import com.gb4pc.viewer.MediaItem
  *
  * ## IS_PENDING retry
  *
- * On some devices the IS_PENDING→0 second ContentObserver callback (which signals
- * the file is fully written) is not delivered reliably. When [queryLatestMedia]
- * returns null on the first callback, [onThumbnailChanged] schedules a single retry
- * after [retryDelayMs] ms so the thumbnail update is not silently dropped.
+ * When a new photo is taken, the ContentObserver fires while the photo is still
+ * IS_PENDING=1.  [queryLatestMedia] returns the most recently *committed* item at
+ * that moment — which is the previous photo, not the new one.  The overlay would
+ * therefore remain showing the old thumbnail until the IS_PENDING=0 callback fired.
+ *
+ * On some devices (particularly on the lock screen) the IS_PENDING=0 callback is
+ * not delivered reliably.  [onThumbnailChanged] therefore always schedules a retry
+ * after [retryDelayMs] ms.  Any in-flight retry is cancelled and rescheduled on
+ * each new callback so that burst-mode photos produce at most one pending retry.
+ * The retry queries for the most recently committed item and updates the overlay
+ * thumbnail, ensuring the overlay shows the correct photo within [retryDelayMs] ms
+ * even when the IS_PENDING=0 notification is suppressed.
  */
 class ThumbnailChangeDispatcher(
     private val handler: Handler,
@@ -27,13 +35,16 @@ class ThumbnailChangeDispatcher(
     private val showThumbnail: (uri: String) -> Unit,
     private val retryDelayMs: Long = Constants.MEDIA_OBSERVER_RETRY_MS,
 ) {
+    // At most one pending retry runnable at a time; cancelled and rescheduled on each onChange.
+    private var pendingRetry: Runnable? = null
 
     /**
      * Called whenever the thumbnail ContentObserver detects a change.
      *
-     * Immediately queries for the latest committed media added since [startMs].
-     * If the query returns null (item is still IS_PENDING), schedules a single retry
-     * after [retryDelayMs] ms.
+     * Immediately updates the thumbnail if a committed item is found.  Then cancels any
+     * in-flight retry and schedules a fresh one after [retryDelayMs] ms.  This ensures
+     * the overlay shows the newest photo even when the IS_PENDING=0 callback is suppressed
+     * or arrives after a long delay on locked devices.
      */
     fun onThumbnailChanged(startMs: Long) {
         val item = queryLatestMedia(startMs)
@@ -41,17 +52,23 @@ class ThumbnailChangeDispatcher(
             showThumbnail(item.uri)
             DebugLog.log("Thumbnail updated: ${item.uri}")
         } else {
-            // Item may still be IS_PENDING; schedule a single retry so we don't
-            // silently drop the thumbnail update on devices where the second
-            // ContentObserver callback (IS_PENDING→0) is unreliable.
             DebugLog.log("Thumbnail query returned null — scheduling retry in ${retryDelayMs}ms")
-            handler.postDelayed({
-                val retryItem = queryLatestMedia(startMs)
-                if (retryItem != null) {
-                    showThumbnail(retryItem.uri)
-                    DebugLog.log("Thumbnail updated (retry): ${retryItem.uri}")
-                }
-            }, retryDelayMs)
         }
+
+        // Always schedule a retry: when the new photo is IS_PENDING, the query above returns
+        // the previous photo (if any).  The retry fires after the new photo is committed and
+        // shows the correct, up-to-date thumbnail.  Cancel any previous pending retry to avoid
+        // stacking runnables during burst-mode shooting.
+        pendingRetry?.let { handler.removeCallbacks(it) }
+        val runnable = Runnable {
+            pendingRetry = null
+            val retryItem = queryLatestMedia(startMs)
+            if (retryItem != null) {
+                showThumbnail(retryItem.uri)
+                DebugLog.log("Thumbnail updated (retry): ${retryItem.uri}")
+            }
+        }
+        pendingRetry = runnable
+        handler.postDelayed(runnable, retryDelayMs)
     }
 }

--- a/app/src/test/java/com/gb4pc/service/MediaChangeDispatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/service/MediaChangeDispatcherTest.kt
@@ -11,10 +11,17 @@ import org.mockito.kotlin.*
 /**
  * Unit tests for [MediaChangeDispatcher].
  *
- * Covers the IS_PENDING race: when a photo is first inserted into MediaStore with
- * IS_PENDING=1 the default query returns null; a retry is scheduled so the item is
- * captured once IS_PENDING is cleared. Also verifies that when the item is already
- * committed on the first query no retry is scheduled.
+ * Covers:
+ * - Immediate-hit path: all committed items are added to the session right away.
+ * - Always-retry: a retry is always scheduled after every onChange, not just when the
+ *   query returns empty. This ensures IS_PENDING items that were excluded from the
+ *   initial query are captured once committed.
+ * - Multiple photos: each committed photo since session start is added (not just the
+ *   single most-recent), fixing the case where a new photo's IS_PENDING=1 callback
+ *   finds an older committed photo and skips the retry.
+ * - Cancel-and-reschedule: rapid-fire photos replace any pending retry with a fresh one,
+ *   keeping at most one outstanding runnable at any time.
+ * - sessionStartMs forwarding.
  */
 class MediaChangeDispatcherTest {
 
@@ -22,9 +29,14 @@ class MediaChangeDispatcherTest {
     private lateinit var handler: Handler
     private val retryDelayMs = 500L
 
-    private val sampleItem = MediaItem(
-        uri = "content://media/external/images/media/42",
+    private val item1 = MediaItem(
+        uri = "content://media/external/images/media/1",
         dateTaken = 1_000_000L,
+        isVideo = false
+    )
+    private val item2 = MediaItem(
+        uri = "content://media/external/images/media/2",
+        dateTaken = 2_000_000L,
         isVideo = false
     )
 
@@ -37,55 +49,72 @@ class MediaChangeDispatcherTest {
     // ── Immediate-hit path ──────────────────────────────────────────────────
 
     /**
-     * When the query immediately finds a committed item, it is added to the session
-     * and no retry is scheduled.
+     * When committed items are found immediately, all of them are added to the session.
      */
     @Test
-    fun `onMediaChanged adds item immediately when query succeeds`() {
+    fun `onMediaChanged adds all items immediately when query returns results`() {
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { sampleItem },
+            queryAllMedia = { listOf(item1, item2) },
             retryDelayMs = retryDelayMs,
         )
 
         dispatcher.onMediaChanged(sessionStartMs = 999_000L)
 
-        verify(sessionTracker).addMedia(sampleItem)
-        verify(handler, never()).postDelayed(any(), any())
+        verify(sessionTracker).addMedia(item1)
+        verify(sessionTracker).addMedia(item2)
     }
 
     /**
-     * The item passed to addMedia is the one returned by the query, not a copy.
+     * Items passed to addMedia are the exact objects returned by the query.
      */
     @Test
-    fun `onMediaChanged passes exact query result to sessionTracker`() {
+    fun `onMediaChanged passes exact query results to sessionTracker`() {
         val captor = argumentCaptor<MediaItem>()
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { sampleItem },
+            queryAllMedia = { listOf(item1) },
             retryDelayMs = retryDelayMs,
         )
 
         dispatcher.onMediaChanged(sessionStartMs = 0L)
 
         verify(sessionTracker).addMedia(captor.capture())
-        assertEquals(sampleItem.uri, captor.firstValue.uri)
+        assertEquals(item1.uri, captor.firstValue.uri)
     }
 
-    // ── IS_PENDING retry path ───────────────────────────────────────────────
+    // ── Always-retry path ───────────────────────────────────────────────────
 
     /**
-     * When the first query returns null (item is IS_PENDING), a retry runnable is
-     * scheduled via handler.postDelayed with the configured retryDelayMs.
+     * A retry is always scheduled, even when the query returned items immediately.
+     * This ensures IS_PENDING items (invisible on the first query) are captured once
+     * committed.
      */
     @Test
-    fun `onMediaChanged schedules retry when first query returns null`() {
+    fun `onMediaChanged always schedules a retry`() {
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { null },
+            queryAllMedia = { listOf(item1) },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        verify(handler).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    /**
+     * A retry is also scheduled when the query returns empty (IS_PENDING race).
+     */
+    @Test
+    fun `onMediaChanged schedules retry when query returns empty`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryAllMedia = { emptyList() },
             retryDelayMs = retryDelayMs,
         )
 
@@ -96,43 +125,15 @@ class MediaChangeDispatcherTest {
     }
 
     /**
-     * When the retry fires and the item has been committed (query returns non-null),
-     * it is added to the session.
+     * When the retry fires and new items are committed, they are added to the session.
      */
     @Test
-    fun `retry runnable adds item when query succeeds on second attempt`() {
+    fun `retry runnable adds items when query succeeds on second attempt`() {
         var callCount = 0
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { if (callCount++ == 0) null else sampleItem },
-            retryDelayMs = retryDelayMs,
-        )
-
-        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
-
-        // Nothing added yet; a retry was posted
-        verify(sessionTracker, never()).addMedia(any())
-        val runnableCaptor = argumentCaptor<Runnable>()
-        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
-
-        // Execute the retry runnable
-        runnableCaptor.firstValue.run()
-
-        verify(sessionTracker).addMedia(sampleItem)
-    }
-
-    /**
-     * When the retry fires but the query STILL returns null (photo was deleted or
-     * never committed), nothing is added to the session and no further retry is
-     * scheduled — the retry is strictly one-shot.
-     */
-    @Test
-    fun `retry is one-shot - no further retry when second query also returns null`() {
-        val dispatcher = MediaChangeDispatcher(
-            sessionTracker = sessionTracker,
-            handler = handler,
-            queryLatestMedia = { null },
+            queryAllMedia = { if (callCount++ == 0) emptyList() else listOf(item1) },
             retryDelayMs = retryDelayMs,
         )
 
@@ -144,55 +145,115 @@ class MediaChangeDispatcherTest {
         // Execute the retry runnable
         runnableCaptor.firstValue.run()
 
-        // No item added; no further postDelayed beyond the original one
-        verify(sessionTracker, never()).addMedia(any())
-        verify(handler, times(1)).postDelayed(any(), any())
+        verify(sessionTracker).addMedia(item1)
     }
 
     /**
-     * Two rapid media changes: first fires while item is pending (null result →
-     * retry scheduled), second fires after item is committed (non-null → item added
-     * immediately). The retry still fires but deduplication in SessionTracker
-     * prevents double-adding (by design in addMedia, not tested here since we
-     * use a mock tracker).
+     * When the retry fires and the query still returns empty (item never committed),
+     * nothing is added to the session. No further retry is scheduled.
      */
     @Test
-    fun `two onChange calls for same photo - first schedules retry, second adds immediately`() {
+    fun `retry is one-shot - no further retry when second query also returns empty`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryAllMedia = { emptyList() },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry runnable
+        runnableCaptor.firstValue.run()
+
+        verify(sessionTracker, never()).addMedia(any())
+        // Only one postDelayed call (from onMediaChanged, not from the retry itself)
+        verify(handler, times(1)).postDelayed(any(), any())
+    }
+
+    // ── Multiple-photo scenario ─────────────────────────────────────────────
+
+    /**
+     * When Photo2's IS_PENDING=1 onChange fires, Photo1 is already committed.
+     * onMediaChanged returns [item1] immediately and schedules a retry.
+     * The retry fires and finds both item1 and item2 committed — both are added
+     * (dedup in SessionTracker prevents the item1 double-add in practice).
+     */
+    @Test
+    fun `multiple photos - retry captures newly committed photo not found on initial call`() {
+        // First call: only item1 is committed; item2 is still IS_PENDING
+        // Retry: both item1 and item2 are committed
         var callCount = 0
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { if (callCount++ == 0) null else sampleItem },
+            queryAllMedia = { if (callCount++ == 0) listOf(item1) else listOf(item1, item2) },
             retryDelayMs = retryDelayMs,
         )
 
-        // First change: item is pending
         dispatcher.onMediaChanged(sessionStartMs = 999_000L)
-        verify(handler, times(1)).postDelayed(any(), eq(retryDelayMs))
-        verify(sessionTracker, never()).addMedia(any())
 
-        // Second change: item is now committed
-        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
-        verify(sessionTracker, times(1)).addMedia(sampleItem)
-        // No additional retry posted
-        verify(handler, times(1)).postDelayed(any(), any())
+        // item1 added immediately
+        verify(sessionTracker).addMedia(item1)
+
+        // Retry is scheduled
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+
+        // Execute the retry — item1 and item2 both found (item1 is dedup'd by SessionTracker)
+        runnableCaptor.firstValue.run()
+
+        // item2 is added by retry
+        verify(sessionTracker).addMedia(item2)
     }
 
-    // ── Session start parameter is forwarded correctly ───────────────────────
+    // ── Cancel-and-reschedule ───────────────────────────────────────────────
 
     /**
-     * The sessionStartMs value passed to onMediaChanged is forwarded to the query
-     * lambda on both the initial call and the retry.
+     * When a second onMediaChanged fires before the previous retry runs, the pending retry
+     * is cancelled and a fresh one is scheduled. At most one retry is outstanding at a time.
      */
     @Test
-    fun `sessionStartMs is forwarded to queryLatestMedia on initial call and retry`() {
+    fun `rapid-fire photos cancel previous retry and reschedule fresh one`() {
+        val dispatcher = MediaChangeDispatcher(
+            sessionTracker = sessionTracker,
+            handler = handler,
+            queryAllMedia = { emptyList() },
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+        val firstRetry = runnableCaptor.firstValue
+
+        // Second onChange fires — should cancel first retry and post a new one
+        dispatcher.onMediaChanged(sessionStartMs = 999_000L)
+
+        verify(handler).removeCallbacks(firstRetry)
+        // Two postDelayed calls total (one per onChange)
+        verify(handler, times(2)).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    // ── sessionStartMs forwarding ───────────────────────────────────────────
+
+    /**
+     * The sessionStartMs passed to onMediaChanged is forwarded to the query lambda on both
+     * the initial call and the retry.
+     */
+    @Test
+    fun `sessionStartMs is forwarded to queryAllMedia on initial call and retry`() {
         val capturedStartMs = mutableListOf<Long>()
         val dispatcher = MediaChangeDispatcher(
             sessionTracker = sessionTracker,
             handler = handler,
-            queryLatestMedia = { startMs ->
+            queryAllMedia = { startMs ->
                 capturedStartMs.add(startMs)
-                null
+                emptyList()
             },
             retryDelayMs = retryDelayMs,
         )

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -601,7 +601,8 @@ class OverlayServiceLogicTest {
 
     /**
      * The lock-screen bypass is idempotent: a second evaluateForeground() while the overlay
-     * is already active must not activate it a second time.
+     * is already active must not activate it a second time, and must not consult UsageStats
+     * (which returns null on a locked device and could cause incorrect side-effects).
      */
     @Test
     fun `issue-81 lock-screen bypass is idempotent when overlay is already active`() {
@@ -615,6 +616,9 @@ class OverlayServiceLogicTest {
 
         // show() must be called exactly once (not twice)
         verify(overlayManager, times(1)).show()
+        // UsageStats must never be consulted on a locked device — getForegroundPackage() returns
+        // null on lock screen and calling it would be both wrong and misleading.
+        verify(foregroundDetector, never()).getForegroundPackage()
     }
 
     /**
@@ -673,5 +677,45 @@ class OverlayServiceLogicTest {
         assertFalse("Overlay should be inactive after deactivation", logic.isOverlayActive)
         verify(sessionTracker).endSession()
         assertFalse("Media observer should be unregistered", mediaObserverRegistered)
+    }
+
+    /**
+     * On the lock screen, when the camera is released, deactivation must use debounceMs
+     * (not 0 ms). UsageStats returns null on a locked device, so without this guard the
+     * deactivation code would see isPixelCameraPackage=false and use 0 ms — prematurely
+     * hiding the overlay during a transient lens switch.
+     *
+     * This test uses a non-zero debounceMs to distinguish the two delay values.
+     */
+    @Test
+    fun `issue-81 deactivation uses debounceMs on lock screen, not 0ms`() {
+        val debounce = 50L
+        val logicWithDebounce = OverlayServiceLogic(
+            hasUsageStatsPermission = { true },
+            hasOverlayPermission = { true },
+            overlayManager = overlayManager,
+            cameraState = CameraState(),
+            foregroundDetector = foregroundDetector,
+            sessionTracker = sessionTracker,
+            handler = handler,
+            debounceMs = debounce,
+            onUsageAccessLost = {},
+            onOverlayPermissionLost = {},
+            isKeyguardLocked = { true },  // device is locked
+            onRegisterMediaObserver = {},
+            onUnregisterMediaObserver = {},
+        )
+
+        // Activate via lock-screen bypass
+        logicWithDebounce.onCameraUnavailable("0")
+        assertTrue("Pre-condition: overlay should be active via lock-screen bypass", logicWithDebounce.isOverlayActive)
+
+        // Camera released — on lock screen, getForegroundPackage() returns null, so without
+        // the fix the delay would be 0 ms; with the fix it must be debounceMs.
+        logicWithDebounce.onCameraAvailable("0")
+
+        verify(handler).postDelayed(any(), eq(debounce))
+        // UsageStats must not be consulted during deactivation on a locked device
+        verify(foregroundDetector, never()).getForegroundPackage()
     }
 }

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -563,4 +563,115 @@ class OverlayServiceLogicTest {
         assertFalse(logic.isOverlayActive)
         assertEquals("Overlay-permission-lost notification should fire", 1, overlayLostCount)
     }
+
+    // ── Issue #81: lock-screen bypass ───────────────────────────────────────
+
+    /**
+     * When the device is locked and a camera is in use, evaluateForeground() must activate
+     * the overlay without consulting UsageStats (which does not emit MOVE_TO_FOREGROUND
+     * events while the device is locked).
+     */
+    @Test
+    fun `issue-81 lock-screen bypass activates overlay when device is locked and camera in use`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+
+        logic.evaluateForeground()
+
+        assertTrue("Overlay should be active via lock-screen bypass", logic.isOverlayActive)
+        verify(overlayManager).show()
+        // UsageStats should NOT be consulted — foregroundDetector must not be called
+        verify(foregroundDetector, never()).getForegroundPackage()
+    }
+
+    /**
+     * The lock-screen bypass starts a secure session immediately, since the device is already
+     * locked when the overlay activates.
+     */
+    @Test
+    fun `issue-81 lock-screen bypass starts secure session immediately`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+
+        logic.evaluateForeground()
+
+        verify(sessionTracker).startSession()
+        assertTrue("Media observer should be registered", mediaObserverRegistered)
+    }
+
+    /**
+     * The lock-screen bypass is idempotent: a second evaluateForeground() while the overlay
+     * is already active must not activate it a second time.
+     */
+    @Test
+    fun `issue-81 lock-screen bypass is idempotent when overlay is already active`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+
+        logic.evaluateForeground()
+
+        // show() must be called exactly once (not twice)
+        verify(overlayManager, times(1)).show()
+    }
+
+    /**
+     * The lock-screen bypass does NOT fire when the device is unlocked — normal UsageStats
+     * detection applies instead.
+     */
+    @Test
+    fun `issue-81 lock-screen bypass does not fire when device is unlocked`() {
+        keyguardLocked = false
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        cameraState.setCameraUnavailable("0")
+
+        logic.evaluateForeground()
+
+        // Normal path: UsageStats IS consulted
+        verify(foregroundDetector, atLeastOnce()).getForegroundPackage()
+    }
+
+    /**
+     * The lock-screen bypass does NOT fire when the keyguard is locked but no camera is in use.
+     * Without this guard, locking the screen while no camera is active could incorrectly show
+     * the overlay.
+     */
+    @Test
+    fun `issue-81 lock-screen bypass does not fire when no camera is in use`() {
+        keyguardLocked = true
+        // No camera is unavailable — cameraState.anyCameraUnavailable() == false
+
+        logic.evaluateForeground()
+
+        assertFalse("Overlay should not be shown when no camera is in use", logic.isOverlayActive)
+        verify(overlayManager, never()).show()
+    }
+
+    /**
+     * When the lock-screen bypass activates the overlay and the camera is later released,
+     * the deactivation path cleans up correctly (session ended, observer unregistered).
+     */
+    @Test
+    fun `issue-81 deactivation after lock-screen activation ends session and unregisters observer`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // Camera released
+        logic.onCameraAvailable("0")
+
+        // Capture and run the deactivation runnable
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), any())
+        runnableCaptor.firstValue.run()
+
+        verify(overlayManager).hide()
+        assertFalse("Overlay should be inactive after deactivation", logic.isOverlayActive)
+        verify(sessionTracker).endSession()
+        assertFalse("Media observer should be unregistered", mediaObserverRegistered)
+    }
 }

--- a/app/src/test/java/com/gb4pc/service/ThumbnailChangeDispatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ThumbnailChangeDispatcherTest.kt
@@ -10,10 +10,14 @@ import org.mockito.kotlin.*
 /**
  * Unit tests for [ThumbnailChangeDispatcher].
  *
- * Covers the IS_PENDING retry: when a photo is still IS_PENDING the thumbnail query
- * returns null; a retry is scheduled so the overlay thumbnail is updated once the
- * item is committed. Also verifies that when the item is already committed on the
- * first query no retry is scheduled.
+ * Covers:
+ * - Immediate-hit path: showThumbnail is called right away when a committed item is found.
+ * - Always-retry: a retry is always scheduled after every onChange, even when an item was
+ *   found immediately. This ensures that when a new photo is IS_PENDING, the query returns
+ *   the previous photo but the retry fires 500ms later and shows the newly committed photo.
+ * - Cancel-and-reschedule: rapid-fire photos replace any pending retry with a fresh one,
+ *   keeping at most one outstanding runnable at any time.
+ * - startMs forwarding.
  */
 class ThumbnailChangeDispatcherTest {
 
@@ -36,8 +40,7 @@ class ThumbnailChangeDispatcherTest {
     // ── Immediate-hit path ──────────────────────────────────────────────────
 
     /**
-     * When the query immediately finds a committed item, showThumbnail is called and
-     * no retry is scheduled.
+     * When the query immediately finds a committed item, showThumbnail is called.
      */
     @Test
     fun `onThumbnailChanged shows thumbnail immediately when query succeeds`() {
@@ -51,7 +54,6 @@ class ThumbnailChangeDispatcherTest {
         dispatcher.onThumbnailChanged(startMs = 999_000L)
 
         verify(showThumbnail).invoke(sampleItem.uri)
-        verify(handler, never()).postDelayed(any(), any())
     }
 
     /**
@@ -73,14 +75,32 @@ class ThumbnailChangeDispatcherTest {
         assertEquals(sampleItem.uri, uriCaptor.firstValue)
     }
 
-    // ── IS_PENDING retry path ───────────────────────────────────────────────
+    // ── Always-retry path ───────────────────────────────────────────────────
 
     /**
-     * When the first query returns null (item is IS_PENDING), a retry runnable is
-     * scheduled via handler.postDelayed with the configured retryDelayMs.
+     * A retry is always scheduled, even when the query found an item immediately.
+     * This ensures the overlay shows the newest photo even when the initial onChange
+     * fired while the new photo was IS_PENDING (the query returns the previous photo).
      */
     @Test
-    fun `onThumbnailChanged schedules retry when first query returns null`() {
+    fun `onThumbnailChanged always schedules a retry`() {
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { sampleItem },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        verify(handler).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    /**
+     * A retry is also scheduled when the query returns null.
+     */
+    @Test
+    fun `onThumbnailChanged schedules retry when query returns null`() {
         val dispatcher = ThumbnailChangeDispatcher(
             handler = handler,
             queryLatestMedia = { null },
@@ -95,8 +115,7 @@ class ThumbnailChangeDispatcherTest {
     }
 
     /**
-     * When the retry fires and the item has been committed (query returns non-null),
-     * showThumbnail is called with the item URI.
+     * When the retry fires and the item has been committed, showThumbnail is called.
      */
     @Test
     fun `retry runnable shows thumbnail when query succeeds on second attempt`() {
@@ -110,8 +129,6 @@ class ThumbnailChangeDispatcherTest {
 
         dispatcher.onThumbnailChanged(startMs = 999_000L)
 
-        // Nothing shown yet; a retry was posted
-        verify(showThumbnail, never()).invoke(any())
         val runnableCaptor = argumentCaptor<Runnable>()
         verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
 
@@ -122,9 +139,8 @@ class ThumbnailChangeDispatcherTest {
     }
 
     /**
-     * When the retry fires but the query STILL returns null (photo was deleted or
-     * never committed), showThumbnail is not called and no further retry is
-     * scheduled — the retry is strictly one-shot.
+     * When the retry fires but the query still returns null, showThumbnail is not called.
+     * No further retry is scheduled — the retry is one-shot.
      */
     @Test
     fun `retry is one-shot - no further retry when second query also returns null`() {
@@ -143,14 +159,45 @@ class ThumbnailChangeDispatcherTest {
         // Execute the retry runnable
         runnableCaptor.firstValue.run()
 
-        // No thumbnail shown; no further postDelayed beyond the original one
         verify(showThumbnail, never()).invoke(any())
+        // Only one postDelayed call (from onThumbnailChanged, not the retry itself)
         verify(handler, times(1)).postDelayed(any(), any())
     }
 
+    // ── Cancel-and-reschedule ───────────────────────────────────────────────
+
     /**
-     * The startMs value passed to onThumbnailChanged is forwarded to the query
-     * lambda on both the initial call and the retry.
+     * When a second onThumbnailChanged fires before the previous retry runs, the pending
+     * retry is cancelled and a fresh one is scheduled. At most one retry is outstanding.
+     */
+    @Test
+    fun `rapid-fire photos cancel previous retry and reschedule fresh one`() {
+        val dispatcher = ThumbnailChangeDispatcher(
+            handler = handler,
+            queryLatestMedia = { null },
+            showThumbnail = showThumbnail,
+            retryDelayMs = retryDelayMs,
+        )
+
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+        val firstRetry = runnableCaptor.firstValue
+
+        // Second onChange fires — should cancel first retry and post a new one
+        dispatcher.onThumbnailChanged(startMs = 999_000L)
+
+        verify(handler).removeCallbacks(firstRetry)
+        // Two postDelayed calls total (one per onThumbnailChanged)
+        verify(handler, times(2)).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    // ── startMs forwarding ──────────────────────────────────────────────────
+
+    /**
+     * The startMs value passed to onThumbnailChanged is forwarded to the query lambda on
+     * both the initial call and the retry.
      */
     @Test
     fun `startMs is forwarded to queryLatestMedia on initial call and retry`() {


### PR DESCRIPTION
## Summary

Fixes #81 — photos taken from the lock screen are not detected and the gallery button does not update.

Three separate bugs combined to produce the symptom:

- **Overlay never activates on lock screen** (`OverlayServiceLogic`): `evaluateForeground()` relied entirely on `UsageStatsManager` to identify the foreground app. `UsageStatsManager` does not report `MOVE_TO_FOREGROUND` events while the device is locked, so the overlay was never shown when the camera was opened via the lock-screen shortcut. Fix: when `isKeyguardLocked() && cameraState.anyCameraUnavailable()`, activate the overlay directly without a UsageStats lookup. The lock-screen camera shortcut can only launch Pixel Camera, so this bypass is safe and correct.

- **Only the first committed photo is detected per burst** (`MediaChangeDispatcher`): the dispatcher previously scheduled a retry only when `queryLatestMedia` returned `null`. When Photo N's `IS_PENDING=1` callback fired, the query returned Photo N-1 (already committed, non-null), so no retry was scheduled. If the `IS_PENDING=0` notification for Photo N was suppressed (common on locked devices), Photo N was silently lost. Fix: switch from `queryLatestMedia` (single item) to `queryAllMedia` (all items since session start), add every returned item to the session immediately, and _always_ schedule a cancel-and-reschedule retry — so pending photos are captured once committed regardless of whether the `IS_PENDING=0` callback fires. Deduplication in `SessionTracker.addMedia()` prevents double-adds.

- **Thumbnail does not update to the latest photo** (`ThumbnailChangeDispatcher`): same conditional-retry bug. When the new photo was still `IS_PENDING`, the query returned the previous photo's URI and no retry was scheduled, leaving the thumbnail stale. Fix: always schedule a cancel-and-reschedule retry, identical pattern to `MediaChangeDispatcher`.

## Commits

1. `Fix #81: bypass UsageStats on lock screen to activate overlay` — `OverlayServiceLogic` + 6 new unit tests
2. `Fix MediaChangeDispatcher: query all photos and always retry` — `MediaChangeDispatcher` + rewritten unit tests
3. `Fix ThumbnailChangeDispatcher: always retry with cancel-and-reschedule` — `ThumbnailChangeDispatcher` + rewritten unit tests

## Test plan

- [ ] All existing unit tests pass (`./gradlew test`)
- [ ] New lock-screen bypass tests in `OverlayServiceLogicTest` cover: activation, session start, idempotency, no false activation when unlocked, no false activation when no camera in use, clean deactivation
- [ ] `MediaChangeDispatcherTest` covers: immediate multi-item add, always-retry (even when items found immediately), retry on empty, retry is one-shot, multi-photo capture via retry, cancel-and-reschedule, `sessionStartMs` forwarding
- [ ] `ThumbnailChangeDispatcherTest` covers: immediate thumbnail show, always-retry (even when item found immediately), retry on null, retry is one-shot, cancel-and-reschedule, `startMs` forwarding
- [ ] Manual: open camera from lock screen, take one or more photos, unlock device — verify gallery button is visible with correct thumbnail and session media count

https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d)_