### PR TITLE
Accept ACTIVITY_RESUMED events in ForegroundDetector

### DIFF
--- a/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
+++ b/app/src/main/java/com/gb4pc/service/ForegroundDetector.kt
@@ -8,7 +8,7 @@ import com.gb4pc.util.DebugLog
 /**
  * Detects the current foreground app using UsageStatsManager (DT-02, DT-06).
  *
- * @param selfPackage The package name of this app (com.gb4pc). MOVE_TO_FOREGROUND events for
+ * @param selfPackage The package name of this app (com.gb4pc). Foreground events for
  *   this package are ignored because the overlay window causes Android to report GB4PC itself
  *   as the foreground app — which would displace the camera from the detected foreground app
  *   and hide the overlay (Issue #80).
@@ -19,11 +19,17 @@ class ForegroundDetector(
 ) {
 
     /**
-     * Queries UsageStatsManager for the most recent MOVE_TO_FOREGROUND event
+     * Queries UsageStatsManager for the most recent foreground event
      * in the last [Constants.USAGE_STATS_WINDOW_MS] milliseconds.
+     *
+     * On Android 10+ (API 29+) the system emits [UsageEvents.Event.ACTIVITY_RESUMED] instead
+     * of the deprecated [UsageEvents.Event.MOVE_TO_FOREGROUND]. Both event types are accepted
+     * so that detection works across all supported API levels (Issue #86).
+     *
      * Events for [selfPackage] are skipped (Issue #80).
      * Returns the package name, or null if no event found (EC-09).
      */
+    @Suppress("DEPRECATION") // MOVE_TO_FOREGROUND is deprecated in API 29; we accept both types
     fun getForegroundPackage(): String? {
         val endTime = System.currentTimeMillis()
         val beginTime = endTime - Constants.USAGE_STATS_WINDOW_MS
@@ -44,12 +50,19 @@ class ForegroundDetector(
         while (events.hasNextEvent()) {
             events.getNextEvent(event)
             totalEvents++
-            if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+            // Accept both ACTIVITY_RESUMED (API 29+) and the legacy MOVE_TO_FOREGROUND so that
+            // detection works on all supported Android versions. On API 29+ the system emits
+            // ACTIVITY_RESUMED instead of MOVE_TO_FOREGROUND (Issue #86).
+            val isForegroundEvent = event.eventType == UsageEvents.Event.ACTIVITY_RESUMED ||
+                event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND
+            if (isForegroundEvent) {
                 if (event.packageName == selfPackage) {
                     skippedSelfEvents++
+                    DebugLog.log("ForegroundDetector: skipping self foreground event pkg=${event.packageName} ts=${event.timeStamp} (Issue #80)")
                     continue
                 }
                 foregroundEvents++
+                DebugLog.log("ForegroundDetector: foreground event type=${event.eventType} pkg=${event.packageName} ts=${event.timeStamp}")
                 if (event.timeStamp >= latestTimestamp) {
                     latestTimestamp = event.timeStamp
                     latestForegroundPackage = event.packageName

--- a/app/src/test/java/com/gb4pc/service/ForegroundDetectorSelfFilterTest.kt
+++ b/app/src/test/java/com/gb4pc/service/ForegroundDetectorSelfFilterTest.kt
@@ -18,7 +18,7 @@ import org.robolectric.RobolectricTestRunner
  * accessible — they are stubs with default values under the plain JVM test runner.
  */
 @Suppress("DEPRECATION") // MOVE_TO_FOREGROUND / MOVE_TO_BACKGROUND are deprecated by the SDK
-                          // but are the correct event types for pre-API-29 paths exercised here.
+                          // but are valid event types still exercised in mixed-event tests here.
 @RunWith(RobolectricTestRunner::class)
 class ForegroundDetectorSelfFilterTest {
 
@@ -171,6 +171,77 @@ class ForegroundDetectorSelfFilterTest {
             "Non-foreground events for selfPkg must not interfere with camera detection",
             cameraPkg,
             detector.getForegroundPackage()
+        )
+    }
+
+    // ── ACTIVITY_RESUMED (API 29+): replaces MOVE_TO_FOREGROUND on modern devices ──
+
+    @Test
+    fun `ACTIVITY_RESUMED for camera is detected (Issue #86)`() {
+        // On API 29+ the system emits ACTIVITY_RESUMED instead of MOVE_TO_FOREGROUND.
+        // The detector must recognise it as a foreground event.
+        eventsOf(Triple(cameraPkg, UsageEvents.Event.ACTIVITY_RESUMED, 1000L))
+
+        assertEquals(
+            "ACTIVITY_RESUMED must be recognised as a foreground event (Issue #86)",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `self ACTIVITY_RESUMED is skipped (Issue #86)`() {
+        // GB4PC's own ACTIVITY_RESUMED must be filtered out, same as MOVE_TO_FOREGROUND.
+        eventsOf(Triple(selfPkg, UsageEvents.Event.ACTIVITY_RESUMED, 1000L))
+
+        assertNull(
+            "Self ACTIVITY_RESUMED must be skipped (Issue #86)",
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `self ACTIVITY_RESUMED does not displace earlier camera ACTIVITY_RESUMED (Issue #86)`() {
+        eventsOf(
+            Triple(cameraPkg, UsageEvents.Event.ACTIVITY_RESUMED, 1000L),
+            Triple(selfPkg,   UsageEvents.Event.ACTIVITY_RESUMED, 2000L),
+        )
+
+        assertEquals(
+            "Camera ACTIVITY_RESUMED must not be displaced by self ACTIVITY_RESUMED (Issue #86)",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `camera ACTIVITY_RESUMED beats older launcher MOVE_TO_FOREGROUND (Issue #86)`() {
+        // Real-world scenario on Android 10+: launcher has an old MOVE_TO_FOREGROUND event
+        // from before the user launched Pixel Camera, which then emits ACTIVITY_RESUMED.
+        eventsOf(
+            Triple("com.android.launcher3", UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+            Triple(cameraPkg,               UsageEvents.Event.ACTIVITY_RESUMED,   2000L),
+        )
+
+        assertEquals(
+            "Camera ACTIVITY_RESUMED (newer) must win over older launcher MOVE_TO_FOREGROUND (Issue #86)",
+            cameraPkg,
+            detector.getForegroundPackage()
+        )
+    }
+
+    @Test
+    fun `launcher MOVE_TO_FOREGROUND alone does not match camera (Issue #86)`() {
+        // If only a launcher MOVE_TO_FOREGROUND event is present (no camera event yet),
+        // isPixelCameraPackage must return false so the retry logic can kick in.
+        eventsOf(
+            Triple("com.android.launcher3", UsageEvents.Event.MOVE_TO_FOREGROUND, 1000L),
+        )
+
+        val pkg = detector.getForegroundPackage()
+        assertFalse(
+            "Launcher MOVE_TO_FOREGROUND must not be detected as Pixel Camera (Issue #86)",
+            ForegroundDetector.isPixelCameraPackage(pkg)
         )
     }
 }


### PR DESCRIPTION
## Summary

Fixes #86

On Android 10+ (API 29+), `UsageStatsManager` emits `ACTIVITY_RESUMED` (value=7) instead of the deprecated `MOVE_TO_FOREGROUND` (value=1). `ForegroundDetector` was only checking for `MOVE_TO_FOREGROUND`, so it never saw the camera's foreground event on modern Pixel devices.

The result: the only `MOVE_TO_FOREGROUND` event visible in the 5-second query window was the launcher's stale event from before the user tapped the camera icon — so `getForegroundPackage()` returned `com.android.launcher3`, `isPixelCameraPackage()` returned `false`, and the overlay never appeared.

### Fix

`getForegroundPackage()` now accepts **both** `ACTIVITY_RESUMED` and `MOVE_TO_FOREGROUND` as foreground events, so detection works correctly on all supported API levels (26–35). The self-package filter (Issue #80) applies to both event types.

### Tests added (`ForegroundDetectorSelfFilterTest`)

- `ACTIVITY_RESUMED` for camera is correctly detected
- `ACTIVITY_RESUMED` for self (`com.gb4pc`) is filtered out
- Self `ACTIVITY_RESUMED` does not displace an earlier camera `ACTIVITY_RESUMED`
- Camera `ACTIVITY_RESUMED` (newer timestamp) beats an older launcher `MOVE_TO_FOREGROUND` — the exact scenario from the bug report
- Launcher `MOVE_TO_FOREGROUND` alone is not mistakenly identified as Pixel Camera

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d)_