### PR TITLE
Fix focusable-overlay teardown in onOverlayFocusLost and onOverlayFocusGained

### DIFF
--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -337,6 +337,10 @@ class OverlayServiceLogic(
      * Issue #92: Must re-register the thumbnail observer (via onRegisterThumbnailObserver) so
      * the overlay button thumbnail works correctly after focus is regained, matching the
      * behaviour of showOverlay().
+     *
+     * Issue #92 (lock-screen): mirrors [showOverlay]'s lock-screen path — if the device is
+     * locked when focus is regained, re-start the secure session and re-register the media
+     * observer so newly captured photos update the thumbnail button.
      */
     fun onOverlayFocusGained() {
         DebugLog.log("Logic: overlay focus gained; overlayActive=$isOverlayActive")
@@ -350,5 +354,10 @@ class OverlayServiceLogic(
         isOverlayActive = true
         onOverlayStateChanged(true)
         onRegisterThumbnailObserver()
+        if (isKeyguardLocked()) {
+            DebugLog.log("Logic: overlay focus gained on locked device — starting secure session")
+            sessionTracker.startSession()
+            onRegisterMediaObserver()
+        }
     }
 }

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -314,19 +314,29 @@ class OverlayServiceLogic(
      * Indicates a system surface (task-switcher, notification shade, etc.) has covered the
      * camera app. Hides the overlay so it does not obscure the system surface.
      * Only fired when the experimental focusable-overlay preference is enabled.
+     *
+     * Issue #92: Must cancel any pending camera-available deactivation runnable before hiding,
+     * otherwise the runnable fires after focus-loss hides the overlay and calls
+     * hideOverlayAndCleanup() on an already-hidden overlay — double-firing onOverlayStateChanged
+     * and incorrectly unregistering the thumbnail observer a second time.
+     * Uses hideOverlayAndCleanup() (not a bare hide()) so the thumbnail observer and any active
+     * secure session are torn down correctly on focus loss.
      */
     fun onOverlayFocusLost() {
         DebugLog.log("Logic: overlay focus lost; overlayActive=$isOverlayActive")
         if (!isOverlayActive) return
-        overlayManager.hide()
-        isOverlayActive = false
-        onOverlayStateChanged(false)
+        cancelPendingDeactivation()
+        hideOverlayAndCleanup()
     }
 
     /**
      * Called by [com.gb4pc.overlay.OverlayManager] when the overlay window regains focus.
      * Indicates the camera app is back in the foreground. Re-shows the overlay.
      * Only fired when the experimental focusable-overlay preference is enabled.
+     *
+     * Issue #92: Must re-register the thumbnail observer (via onRegisterThumbnailObserver) so
+     * the overlay button thumbnail works correctly after focus is regained, matching the
+     * behaviour of showOverlay().
      */
     fun onOverlayFocusGained() {
         DebugLog.log("Logic: overlay focus gained; overlayActive=$isOverlayActive")
@@ -339,5 +349,6 @@ class OverlayServiceLogic(
         overlayManager.show()
         isOverlayActive = true
         onOverlayStateChanged(true)
+        onRegisterThumbnailObserver()
     }
 }

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -606,6 +606,94 @@ class OverlayServiceLogicTest {
         assertEquals("Overlay-permission-lost notification should fire", 1, overlayLostCount)
     }
 
+    // ── Issue #92: focusable-overlay teardown correctness ────────────────────
+
+    /**
+     * Issue #92: onOverlayFocusLost must cancel any pending camera-available deactivation
+     * runnable before hiding the overlay. Without this, the deactivation runnable fires after
+     * focus-loss has already hidden the overlay, calling hideOverlayAndCleanup() a second time
+     * — double-firing onOverlayStateChanged and incorrectly unregistering the thumbnail
+     * observer again.
+     */
+    @Test
+    fun `issue-92 onOverlayFocusLost cancels pending deactivation runnable`() {
+        // Activate the overlay
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logic.showOverlay()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+
+        // Schedule a deactivation (simulates onCameraAvailable firing just before focus loss)
+        logic.scheduleDeactivation(50L)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(50L))
+
+        // Focus lost — must cancel the pending deactivation
+        logic.onOverlayFocusLost()
+
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+        assertFalse("Overlay should be inactive after focus loss", logic.isOverlayActive)
+    }
+
+    /**
+     * Issue #92: onOverlayFocusLost must call hideOverlayAndCleanup() (not a bare hide()) so
+     * the thumbnail observer is unregistered. Without this, when the task switcher covers
+     * Pixel Camera the thumbnail observer leaks until the camera-available deactivation fires.
+     */
+    @Test
+    fun `issue-92 onOverlayFocusLost unregisters thumbnail observer`() {
+        // Activate the overlay — this registers the thumbnail observer
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logic.showOverlay()
+        assertTrue("Pre-condition: thumbnail observer should be registered", thumbnailObserverRegistered)
+
+        logic.onOverlayFocusLost()
+
+        assertFalse("Thumbnail observer must be unregistered on focus loss (Issue #92)", thumbnailObserverRegistered)
+    }
+
+    /**
+     * Issue #92: onOverlayFocusLost must end an active secure session (via hideOverlayAndCleanup).
+     * If the overlay was activated while the device was locked and the session is still active
+     * when focus is lost, the session and media observer must be torn down.
+     */
+    @Test
+    fun `issue-92 onOverlayFocusLost ends active secure session`() {
+        // Activate via lock-screen bypass — starts a session immediately
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+        assertTrue("Pre-condition: media observer should be registered", mediaObserverRegistered)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        logic.onOverlayFocusLost()
+
+        assertFalse("Overlay should be inactive after focus loss", logic.isOverlayActive)
+        verify(sessionTracker).endSession()
+        assertFalse("Media observer must be unregistered when session ends (Issue #92)", mediaObserverRegistered)
+    }
+
+    /**
+     * Issue #92: onOverlayFocusGained must re-register the thumbnail observer so that
+     * subsequent photo thumbnails are displayed in the overlay button after focus is regained.
+     * The original implementation omitted this call, leaving the observer unregistered until
+     * the next full showOverlay() activation.
+     */
+    @Test
+    fun `issue-92 onOverlayFocusGained re-registers thumbnail observer`() {
+        // Show the overlay (registers thumbnail observer), then lose focus (unregisters it)
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(Constants.PIXEL_CAMERA_PACKAGE)
+        logic.showOverlay()
+        assertTrue("Pre-condition: thumbnail observer should be registered", thumbnailObserverRegistered)
+
+        logic.onOverlayFocusLost()
+        assertFalse("Thumbnail observer should be unregistered after focus loss", thumbnailObserverRegistered)
+
+        // Regain focus — thumbnail observer must be re-registered
+        logic.onOverlayFocusGained()
+        assertTrue("Thumbnail observer must be re-registered on focus gained (Issue #92)", thumbnailObserverRegistered)
+    }
+
     // ── Issue #81: lock-screen bypass ───────────────────────────────────────
 
     /**

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -694,6 +694,36 @@ class OverlayServiceLogicTest {
         assertTrue("Thumbnail observer must be re-registered on focus gained (Issue #92)", thumbnailObserverRegistered)
     }
 
+    /**
+     * Issue #92 (lock-screen): when the device is locked at focus-gained time,
+     * onOverlayFocusGained must mirror showOverlay()'s lock-screen behaviour — start the
+     * secure session and re-register the media observer so newly captured photos update the
+     * thumbnail button.  Without this, a focus-lost/focus-gained cycle on a locked device
+     * would re-show the overlay but leave the media observer absent.
+     */
+    @Test
+    fun `issue-92 onOverlayFocusGained on locked device starts session and registers media observer`() {
+        // Activate via lock-screen bypass, then lose focus (tears down session + observers)
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+        verify(sessionTracker).startSession()
+        assertTrue("Pre-condition: media observer should be registered", mediaObserverRegistered)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        logic.onOverlayFocusLost()
+        assertFalse("Pre-condition: overlay should be hidden after focus loss", logic.isOverlayActive)
+        assertFalse("Pre-condition: media observer should be unregistered after focus loss", mediaObserverRegistered)
+
+        // Regain focus on a still-locked device — session and media observer must be restored
+        logic.onOverlayFocusGained()
+
+        assertTrue("Overlay should be active after focus regained", logic.isOverlayActive)
+        verify(sessionTracker, times(2)).startSession()  // once on activation, once on focus regained
+        assertTrue("Media observer must be re-registered on focus gained while locked (Issue #92)", mediaObserverRegistered)
+    }
+
     // ── Issue #81: lock-screen bypass ───────────────────────────────────────
 
     /**


### PR DESCRIPTION
Fixes #92

## Finding

The focusable-overlay mechanism is **implemented incorrectly** (case b from the issue). The focus-lost callback does fire — it just doesn't do enough when it does.

### Bug 1: `onOverlayFocusLost()` used a bare `hide()` instead of full teardown

In `main`, `onOverlayFocusLost()` called `overlayManager.hide()` directly. This missed three things that every hide path must do:

1. **Cancel the pending camera-available deactivation runnable.** When the task-switcher opens, Pixel Camera may release the camera shortly after, scheduling a deactivation runnable. If focus-loss hid the overlay first and the runnable fired later, it would call `hideOverlayAndCleanup()` on an already-hidden overlay — double-firing `onOverlayStateChanged` and double-unregistering the thumbnail observer.

2. **Unregister the thumbnail `ContentObserver`.** Without this, the observer leaked until the deactivation runnable eventually fired.

3. **End the active secure session.** If the overlay was activated on the lock screen, a secure session was in progress. Focus loss did not end it, leaving the session and its media observer running.

### Bug 2: `onOverlayFocusGained()` did not re-register the thumbnail observer

After a focus-lost/focus-gained cycle the thumbnail observer was left unregistered, so new-photo thumbnails were not shown in the overlay button until the next full re-activation.

## Fix

`onOverlayFocusLost()` now calls `cancelPendingDeactivation()` and `hideOverlayAndCleanup()` — the same teardown used by the normal camera-available path.

`onOverlayFocusGained()` now calls `onRegisterThumbnailObserver()` — matching `showOverlay()`.

## Tests added (4 new unit tests)

- `issue-92 onOverlayFocusLost cancels pending deactivation runnable` — verifies `removeCallbacks` is called on the pending runnable
- `issue-92 onOverlayFocusLost unregisters thumbnail observer` — verifies observer flag cleared on focus loss
- `issue-92 onOverlayFocusLost ends active secure session` — verifies `endSession()` + media observer unregistered
- `issue-92 onOverlayFocusGained re-registers thumbnail observer` — verifies observer re-registered after focus-lost/gained cycle

All 4 tests were failing against the `main` implementation and pass with the fix.

`./gradlew test` — BUILD SUCCESSFUL, 96 tasks.

https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUjuNR7mUghQediPG3U8d)_