### PR TITLE
Poll MediaStore alongside ContentObserver to detect locked-screen photos

### DIFF
--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -47,6 +47,11 @@ object Constants {
     // Retry delay when ContentObserver fires before MediaStore commits the new item (IS_PENDING race)
     const val MEDIA_OBSERVER_RETRY_MS = 500L
 
+    // Polling interval for MediaPoller — the safety-net poller that runs alongside the
+    // session ContentObserver so newly captured photos are detected even when the system
+    // suppresses ContentObserver dispatch on a locked device (Issue #81).
+    const val MEDIA_POLL_INTERVAL_MS = 1500L
+
     // Snackbar undo timeout
     const val UNDO_TIMEOUT_MS = 5000L
 

--- a/app/src/main/java/com/gb4pc/service/MediaPoller.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaPoller.kt
@@ -1,0 +1,94 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import com.gb4pc.Constants
+import com.gb4pc.util.DebugLog
+
+/**
+ * Periodically fans new MediaStore changes out to [MediaChangeDispatcher] and
+ * [ThumbnailChangeDispatcher] while a secure camera session is active.
+ *
+ * ## Why polling is needed (Issue #81)
+ *
+ * The session and thumbnail [android.database.ContentObserver]s are normally the fast
+ * path that detects newly captured photos.  Two earlier fixes (PR #88 and PR #98)
+ * tightened the IS_PENDING retry logic inside the dispatchers, but both relied on
+ * the observers' `onChange` callback firing in the first place.
+ *
+ * Field reports for issue #81 show that on a *locked* device the system can suppress
+ * or delay [android.database.ContentObserver] dispatch indefinitely — so the
+ * dispatcher's `onChange` is never invoked, the retry runnable is never scheduled,
+ * and photos written to MediaStore are silently missed.  The overlay therefore stays
+ * on the gallery icon and the secure-viewer filmstrip stays empty.
+ *
+ * [MediaPoller] adds a safety-net poll: every [intervalMs] it invokes the same
+ * dispatcher entry points the observers would have invoked, so newly committed
+ * photos are picked up within the polling interval even when no observer callback
+ * arrives.  Detection on the lock screen therefore degrades from "never" to "within
+ * one polling interval" in the worst case.
+ *
+ * The poller only runs while [start] / [stop] bracket an active session — typically
+ * mirroring the lifecycle of the media observer.  When the device is unlocked and
+ * the observer fires reliably the poller still runs but is a cheap no-op duplicate
+ * (deduplication in [com.gb4pc.viewer.SessionTracker.addMedia] guarantees idempotency).
+ *
+ * ## Side-effect-free
+ *
+ * The poller does not query MediaStore itself — it delegates to the existing
+ * dispatchers, so the test surface is unchanged and there is one canonical query
+ * path for both the observer and the poller.
+ */
+class MediaPoller(
+    private val handler: Handler,
+    private val onPoll: () -> Unit,
+    private val intervalMs: Long = Constants.MEDIA_POLL_INTERVAL_MS,
+) {
+    private var pollRunnable: Runnable? = null
+    private var running: Boolean = false
+
+    /** True while the poller has an outstanding scheduled tick. */
+    val isRunning: Boolean
+        get() = running
+
+    /**
+     * Starts the periodic poll.  Idempotent — calling [start] while already running is
+     * a no-op (no second runnable is scheduled).  The first poll fires after [intervalMs]
+     * milliseconds, not immediately, since the caller has just performed any work the
+     * triggering event implies.
+     */
+    fun start() {
+        if (running) {
+            DebugLog.log("MediaPoller.start: already running, ignoring")
+            return
+        }
+        running = true
+        scheduleNext()
+        DebugLog.log("MediaPoller started (interval=${intervalMs}ms)")
+    }
+
+    /**
+     * Stops the periodic poll and removes any in-flight scheduled tick.  Idempotent.
+     */
+    fun stop() {
+        if (!running) return
+        running = false
+        pollRunnable?.let { handler.removeCallbacks(it) }
+        pollRunnable = null
+        DebugLog.log("MediaPoller stopped")
+    }
+
+    private fun scheduleNext() {
+        val runnable = Runnable {
+            try {
+                onPoll()
+            } catch (e: Exception) {
+                DebugLog.log("MediaPoller.onPoll threw: ${e.message}")
+            }
+            // Only re-schedule if we are still running.  If [onPoll] (or anything else) called
+            // [stop] during this tick, the loop terminates here.
+            if (running) scheduleNext()
+        }
+        pollRunnable = runnable
+        handler.postDelayed(runnable, intervalMs)
+    }
+}

--- a/app/src/main/java/com/gb4pc/service/MediaPoller.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaPoller.kt
@@ -82,7 +82,7 @@ class MediaPoller(
             try {
                 onPoll()
             } catch (e: Exception) {
-                DebugLog.log("MediaPoller.onPoll threw: ${e.message}")
+                DebugLog.log("MediaPoller.onPoll threw: ${e.stackTraceToString()}")
             }
             // Only re-schedule if we are still running.  If [onPoll] (or anything else) called
             // [stop] during this tick, the loop terminates here.

--- a/app/src/main/java/com/gb4pc/service/MediaPoller.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaPoller.kt
@@ -82,7 +82,7 @@ class MediaPoller(
             try {
                 onPoll()
             } catch (e: Exception) {
-                DebugLog.log("MediaPoller.onPoll threw: ${e.stackTraceToString()}")
+                DebugLog.log("MediaPoller.onPoll threw: ${e.message}")
             }
             // Only re-schedule if we are still running.  If [onPoll] (or anything else) called
             // [stop] during this tick, the loop terminates here.

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -54,6 +54,7 @@ class OverlayService : Service() {
     private var overlayActiveTimestamp: Long = 0L
     private lateinit var mediaChangeDispatcher: MediaChangeDispatcher
     private lateinit var thumbnailChangeDispatcher: ThumbnailChangeDispatcher
+    private lateinit var mediaPoller: MediaPoller
 
     private val cameraCallback = object : CameraManager.AvailabilityCallback() {
         override fun onCameraUnavailable(cameraId: String) {
@@ -97,6 +98,24 @@ class OverlayService : Service() {
             showThumbnail = { uri -> overlayManager.showLatestPhotoThumbnail(uri) },
         )
 
+        // Issue #81: safety-net poll that runs alongside the session ContentObserver.
+        // The system can suppress ContentObserver dispatch on a locked device, leaving the
+        // overlay stuck on the gallery icon and the secure-viewer filmstrip empty.  Polling
+        // re-uses the existing dispatchers (so retry / dedup / IS_PENDING handling are
+        // identical) and runs only while a secure session is active.
+        mediaPoller = MediaPoller(
+            handler = handler,
+            onPoll = {
+                val sessionStartMs = SessionTracker.instance.sessionStartTimestamp
+                if (SessionTracker.instance.isSessionActive) {
+                    mediaChangeDispatcher.onMediaChanged(sessionStartMs)
+                }
+                if (overlayActiveTimestamp != 0L) {
+                    thumbnailChangeDispatcher.onThumbnailChanged(overlayActiveTimestamp)
+                }
+            },
+        )
+
         logic = OverlayServiceLogic(
             hasUsageStatsPermission = { PermissionHelper.hasUsageStatsPermission(this) },
             hasOverlayPermission = { PermissionHelper.hasOverlayPermission(this) },
@@ -123,6 +142,8 @@ class OverlayService : Service() {
             onUnregisterMediaObserver = ::unregisterMediaObserver,
             onRegisterThumbnailObserver = ::registerThumbnailObserver,
             onUnregisterThumbnailObserver = ::unregisterThumbnailObserver,
+            onStartMediaPoll = { mediaPoller.start() },
+            onStopMediaPoll = { mediaPoller.stop() },
             onOverlayStateChanged = { active -> isOverlayActive = active },
         )
     }
@@ -171,6 +192,7 @@ class OverlayService : Service() {
         unregisterScreenEventReceiver()
         unregisterThumbnailObserver()
         unregisterMediaObserver()
+        mediaPoller.stop()  // Issue #81: belt-and-suspenders alongside logic.reset()
         overlayManager.hide()
         cameraState.reset()
         super.onDestroy()
@@ -226,6 +248,7 @@ class OverlayService : Service() {
         if (logic.isOverlayActive && !SessionTracker.instance.isSessionActive) {
             SessionTracker.instance.startSession()
             registerMediaObserver()
+            mediaPoller.start()  // Issue #81: safety-net poll alongside the observer
             DebugLog.log("Secure camera session started on screen off")
         }
     }
@@ -236,6 +259,7 @@ class OverlayService : Service() {
         if (SessionTracker.instance.isSessionActive) {
             SessionTracker.instance.endSession()
             unregisterMediaObserver()
+            mediaPoller.stop()  // Issue #81: stop safety-net poll on unlock
             DebugLog.log("Secure camera session ended on device unlock")
         }
     }

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -32,6 +32,13 @@ class OverlayServiceLogic(
     private val onUnregisterMediaObserver: () -> Unit,
     private val onRegisterThumbnailObserver: () -> Unit = {},
     private val onUnregisterThumbnailObserver: () -> Unit = {},
+    /**
+     * Issue #81: starts a periodic safety-net poll for new MediaStore items, paired with the
+     * media-observer lifecycle.  Needed because the system can suppress ContentObserver
+     * dispatch on a locked device.  Default no-op for tests that do not exercise polling.
+     */
+    private val onStartMediaPoll: () -> Unit = {},
+    private val onStopMediaPoll: () -> Unit = {},
     /** Called whenever the overlay visibility changes; default no-op. Used by tests and UI. */
     private val onOverlayStateChanged: (Boolean) -> Unit = {},
 ) {
@@ -164,6 +171,7 @@ class OverlayServiceLogic(
             DebugLog.log("Logic: device locked at activation — starting secure session immediately")
             sessionTracker.startSession()
             onRegisterMediaObserver()
+            onStartMediaPoll()  // Issue #81: safety-net poll alongside the observer
         }
     }
 
@@ -203,6 +211,7 @@ class OverlayServiceLogic(
             DebugLog.log("Logic: ending secure session on overlay deactivation")
             sessionTracker.endSession()
             onUnregisterMediaObserver()
+            onStopMediaPoll()  // Issue #81: stop safety-net poll when session ends
         }
     }
 
@@ -246,6 +255,7 @@ class OverlayServiceLogic(
         cancelActivationRetry()
         cancelGalleryLaunchRecheck()
         onUnregisterThumbnailObserver()
+        onStopMediaPoll()  // Issue #81: stop the safety-net poll on service teardown
         isOverlayActive = false
     }
 
@@ -358,6 +368,7 @@ class OverlayServiceLogic(
             DebugLog.log("Logic: overlay focus gained on locked device — starting secure session")
             sessionTracker.startSession()
             onRegisterMediaObserver()
+            onStartMediaPoll()  // Issue #81: safety-net poll alongside the observer
         }
     }
 }

--- a/app/src/test/java/com/gb4pc/service/MediaPollerTest.kt
+++ b/app/src/test/java/com/gb4pc/service/MediaPollerTest.kt
@@ -1,0 +1,187 @@
+package com.gb4pc.service
+
+import android.os.Handler
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+/**
+ * Unit tests for [MediaPoller].
+ *
+ * Covers the safety-net polling behaviour added for issue #81:
+ * - [start] schedules a tick every [intervalMs] until [stop] is called
+ * - [start] is idempotent (no double-scheduling)
+ * - [stop] is idempotent and cancels the in-flight tick
+ * - The poll runnable invokes [onPoll] and re-schedules itself
+ * - [onPoll] exceptions do not abort the polling loop
+ */
+class MediaPollerTest {
+
+    private lateinit var handler: Handler
+    private val intervalMs = 1500L
+
+    private var pollCount = 0
+
+    @Before
+    fun setUp() {
+        handler = mock()
+        pollCount = 0
+    }
+
+    // ── start / stop lifecycle ──────────────────────────────────────────────
+
+    @Test
+    fun `start schedules first tick after intervalMs`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+
+        poller.start()
+
+        verify(handler).postDelayed(any(), eq(intervalMs))
+        assertTrue(poller.isRunning)
+        assertEquals("onPoll must not fire on start (only after the first delay)", 0, pollCount)
+    }
+
+    @Test
+    fun `start is idempotent - second call is a no-op`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+
+        poller.start()
+        poller.start()
+        poller.start()
+
+        // Only the first call schedules a tick
+        verify(handler, times(1)).postDelayed(any(), eq(intervalMs))
+    }
+
+    @Test
+    fun `stop removes the in-flight tick and clears running flag`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+
+        poller.stop()
+
+        assertFalse(poller.isRunning)
+        verify(handler).removeCallbacks(runnableCaptor.firstValue)
+    }
+
+    @Test
+    fun `stop is idempotent when not running`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+
+        poller.stop()
+        poller.stop()
+
+        verify(handler, never()).removeCallbacks(any())
+        assertFalse(poller.isRunning)
+    }
+
+    @Test
+    fun `start after stop schedules a fresh tick`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+
+        poller.start()
+        poller.stop()
+        poller.start()
+
+        verify(handler, times(2)).postDelayed(any(), eq(intervalMs))
+        assertTrue(poller.isRunning)
+    }
+
+    // ── poll runnable behaviour ─────────────────────────────────────────────
+
+    @Test
+    fun `tick invokes onPoll exactly once`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+
+        runnableCaptor.firstValue.run()
+
+        assertEquals(1, pollCount)
+    }
+
+    @Test
+    fun `tick re-schedules itself while running`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+
+        // Fire the tick — it must schedule the next tick.
+        runnableCaptor.firstValue.run()
+
+        verify(handler, times(2)).postDelayed(any(), eq(intervalMs))
+    }
+
+    @Test
+    fun `tick does not re-schedule after stop is called from inside onPoll`() {
+        var capturedPoller: MediaPoller? = null
+        val poller = MediaPoller(
+            handler = handler,
+            onPoll = {
+                pollCount++
+                capturedPoller?.stop()
+            },
+            intervalMs = intervalMs,
+        )
+        capturedPoller = poller
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+
+        runnableCaptor.firstValue.run()
+
+        // Only the original postDelayed (from start) — onPoll's stop() prevented re-schedule.
+        verify(handler, times(1)).postDelayed(any(), eq(intervalMs))
+        assertEquals(1, pollCount)
+        assertFalse(poller.isRunning)
+    }
+
+    @Test
+    fun `onPoll exception does not abort the polling loop`() {
+        val poller = MediaPoller(
+            handler = handler,
+            onPoll = {
+                pollCount++
+                throw RuntimeException("boom")
+            },
+            intervalMs = intervalMs,
+        )
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+
+        // Fire the tick — onPoll throws but the loop must continue.
+        runnableCaptor.firstValue.run()
+
+        assertEquals(1, pollCount)
+        assertTrue(poller.isRunning)
+        // The next tick was scheduled despite the exception.
+        verify(handler, times(2)).postDelayed(any(), eq(intervalMs))
+    }
+
+    @Test
+    fun `multiple consecutive ticks each invoke onPoll`() {
+        val poller = MediaPoller(handler = handler, onPoll = { pollCount++ }, intervalMs = intervalMs)
+        poller.start()
+
+        val runnableCaptor = argumentCaptor<Runnable>()
+        // Fire three ticks, each one captured from the most recent postDelayed call.
+        for (i in 1..3) {
+            verify(handler, times(i)).postDelayed(runnableCaptor.capture(), eq(intervalMs))
+            runnableCaptor.lastValue.run()
+        }
+
+        assertEquals(3, pollCount)
+    }
+}

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -36,6 +36,9 @@ class OverlayServiceLogicTest {
     private var overlayLostCount = 0
     private var mediaObserverRegistered = false
     private var thumbnailObserverRegistered = false
+    private var mediaPollRunning = false
+    private var mediaPollStartCount = 0
+    private var mediaPollStopCount = 0
 
     // ── Subject under test ──────────────────────────────────────────────────
     private lateinit var logic: OverlayServiceLogic
@@ -55,6 +58,9 @@ class OverlayServiceLogicTest {
         overlayLostCount = 0
         mediaObserverRegistered = false
         thumbnailObserverRegistered = false
+        mediaPollRunning = false
+        mediaPollStartCount = 0
+        mediaPollStopCount = 0
 
         logic = OverlayServiceLogic(
             hasUsageStatsPermission = { usageStatsPermission },
@@ -72,6 +78,8 @@ class OverlayServiceLogicTest {
             onUnregisterMediaObserver = { mediaObserverRegistered = false },
             onRegisterThumbnailObserver = { thumbnailObserverRegistered = true },
             onUnregisterThumbnailObserver = { thumbnailObserverRegistered = false },
+            onStartMediaPoll = { mediaPollRunning = true; mediaPollStartCount++ },
+            onStopMediaPoll = { mediaPollRunning = false; mediaPollStopCount++ },
         )
     }
 
@@ -1144,5 +1152,125 @@ class OverlayServiceLogicTest {
         logicWithDebounce.reset()
 
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
+    }
+
+    // ── Issue #81 v3: media-poll lifecycle tied to media-observer lifecycle ──
+
+    /**
+     * Issue #81 v3: when the lock-screen bypass starts a secure session, the safety-net
+     * media poll must also start.  Without this, ContentObserver dispatch suppression on a
+     * locked device leaves the dispatcher's onChange path unreachable and photos go
+     * undetected.
+     */
+    @Test
+    fun `issue-81 v3 media poll starts when session starts via lock-screen bypass`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+
+        logic.evaluateForeground()
+
+        assertTrue("Media observer should be registered", mediaObserverRegistered)
+        assertTrue("Media poll must start alongside media observer (Issue #81 v3)", mediaPollRunning)
+        assertEquals(1, mediaPollStartCount)
+    }
+
+    /**
+     * Issue #81 v3: when the secure session ends (camera released, overlay torn down),
+     * the safety-net media poll must stop.
+     */
+    @Test
+    fun `issue-81 v3 media poll stops when session ends on overlay deactivation`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: media poll should be running", mediaPollRunning)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        logic.onCameraAvailable("0")
+
+        // Capture and run the deactivation runnable
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), any())
+        runnableCaptor.firstValue.run()
+
+        assertFalse("Media poll must stop when session ends (Issue #81 v3)", mediaPollRunning)
+        assertEquals(1, mediaPollStopCount)
+    }
+
+    /**
+     * Issue #81 v3: when the showOverlay() path runs while the device is unlocked, no session
+     * starts and the poll therefore must NOT start (it would be wasted work, since the
+     * ContentObserver fires reliably when the screen is on and unlocked).
+     */
+    @Test
+    fun `issue-81 v3 media poll does not start when overlay shown on unlocked device`() {
+        keyguardLocked = false
+        logic.showOverlay()
+
+        assertFalse("Media observer must not be registered when unlocked", mediaObserverRegistered)
+        assertFalse("Media poll must not start when no session exists", mediaPollRunning)
+        assertEquals(0, mediaPollStartCount)
+    }
+
+    /**
+     * Issue #81 v3: focus-gained on a locked device restarts the secure session, so the
+     * safety-net poll must also restart.  Mirrors the existing observer-restart test.
+     */
+    @Test
+    fun `issue-81 v3 media poll restarts on focus gained while locked`() {
+        // Activate via lock-screen bypass
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: media poll should be running", mediaPollRunning)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // Focus lost — poll stops alongside session teardown
+        logic.onOverlayFocusLost()
+        assertFalse("Pre-condition: media poll should be stopped after focus loss", mediaPollRunning)
+
+        // Focus regained on still-locked device — poll must restart
+        logic.onOverlayFocusGained()
+
+        assertTrue("Media poll must restart on focus gained while locked (Issue #81 v3)", mediaPollRunning)
+        assertEquals(2, mediaPollStartCount)
+    }
+
+    /**
+     * Issue #81 v3: reset() must stop the poll so a stale runnable cannot survive service
+     * teardown.
+     */
+    @Test
+    fun `issue-81 v3 reset stops media poll`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: media poll should be running", mediaPollRunning)
+
+        logic.reset()
+
+        assertFalse("Media poll must stop on reset (Issue #81 v3)", mediaPollRunning)
+        assertEquals(1, mediaPollStopCount)
+    }
+
+    /**
+     * Issue #81 v3: gallery-launched immediate-hide path must stop the poll alongside the
+     * session and observer teardown (parity with the deactivation runnable).
+     */
+    @Test
+    fun `issue-81 v3 gallery-launched immediate hide stops media poll`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: media poll should be running", mediaPollRunning)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // Gallery launched; PC is gone — immediate hide path
+        keyguardLocked = false
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn("com.google.android.apps.photos")
+        logic.onGalleryLaunched()
+
+        assertFalse("Media poll must stop on gallery-launched hide (Issue #81 v3)", mediaPollRunning)
+        assertEquals(1, mediaPollStopCount)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #81 — third attempt.  PRs #88 and #98 each tightened the
session/thumbnail dispatchers (IS_PENDING retry, fallback thumbnail
decode, all-items query, always-retry) but the issue was reopened
with the same symptoms after both: on a locked device the overlay
stays on the gallery icon and the secure-viewer filmstrip stays empty.

### Why those fixes were not enough

Both prior fixes lived inside `MediaChangeDispatcher.onMediaChanged()` /
`ThumbnailChangeDispatcher.onThumbnailChanged()`.  Those methods only
run when the registered `ContentObserver`'s `onChange` callback fires.
Field reports show that on a locked device the system can suppress
ContentObserver dispatch for our process — `onChange` never runs, the
retry runnable is never scheduled, and photos written to MediaStore
are silently missed.  No amount of work inside the dispatchers can
fix that, because the dispatchers are downstream of an unreliable
trigger.

### What this PR does

Add a periodic safety-net poll that runs alongside the ContentObserver
while a secure session is active.  Every 1500 ms it invokes the same
dispatcher entry points the observer would have invoked, so newly
captured photos are picked up within one polling interval even if no
observer callback ever arrives.  Detection on the lock screen
therefore degrades from "never" to "≤1.5 s in the worst case", which
addresses both reported symptoms (stale overlay icon, empty
filmstrip).

Notes:
- The poll re-uses the existing dispatchers, so IS_PENDING handling,
  the 500 ms retry, and `SessionTracker.addMedia` deduplication remain
  the single source of truth.  When the observer does fire, the
  duplicate poll callback is a cheap no-op.
- The poll runs only while a secure session is active (locked +
  overlay shown), so it adds no work on an unlocked device, where
  ContentObserver dispatch is reliable.
- New `MediaPoller` is a small standalone class with constructor-
  injected `Handler` + `onPoll`, exercised by 10 plain-JVM unit tests
  with no Robolectric.

## Commits

1. `Add MediaPoller — periodic safety-net poll for new MediaStore
   items` — pure addition of the new class, its constant, and 10 unit
   tests.  No wiring; not yet invoked from anywhere.
2. `Fix #81: poll MediaStore alongside the session ContentObserver` —
   wires `MediaPoller` into `OverlayServiceLogic` (paired with the
   media-observer lifecycle) and `OverlayService` (instantiated and
   plugged into the dispatchers).  6 new `OverlayServiceLogicTest`
   cases cover every start/stop edge.

## Test plan

- [x] `./gradlew test` — 227 unit tests pass (10 new in
  `MediaPollerTest`, 6 new in `OverlayServiceLogicTest`)
- [x] `./gradlew assembleDebug` — debug APK builds cleanly
- [ ] Manual: open Pixel Camera from the lock screen, take one or
  more photos.  Within ~1.5 s the overlay button must update to the
  latest photo's thumbnail.  Tapping the button must open the secure
  viewer with all session photos visible.

Fixes #81

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu9ubHwgkjUoyfdQNeiA4)_