### PR TITLE
Remove always-failing PIL diagnostic from CI pre-flight failure path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,8 +226,6 @@ jobs:
 
           echo "==> Running green-feed smoke check..."
           if ! python3 scripts/check_green_feed.py preflight.png; then
-            echo "=== pre-flight failed: check_green_feed dominant color ==="
-            python3 -c "from PIL import Image; from collections import Counter; img = Image.open('preflight.png').convert('RGB'); w, h = img.size; cx, cy = w//2, h//2; region = img.crop((cx-100, cy-100, cx+100, cy+100)); pixels = list(region.getdata()); top = Counter(pixels).most_common(3); print('Top 3 colors in center 200x200:', top)" 2>/dev/null || echo "(PIL not available)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Removes the `python3 -c "from PIL import Image ..."` block from the CI pre-flight failure path in `.github/workflows/build.yml`.
- Pillow is not installed on GitHub Actions `ubuntu-*` runners, so this block always fell through to `|| echo "(PIL not available)"`, printing noise with zero diagnostic value.
- `check_green_feed.py` already prints the dominant color on failure (e.g. `FAIL: coverage 12.3% < 90%. Actual dominant color: #1A1A1A (R=26, G=26, B=26)`), making the PIL block entirely redundant.

Fixes #124

## Test plan

- [x] Confirmed the YAML file still parses correctly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` exits 0).
- [x] Diff is a pure 2-line deletion; no logic changes.

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_