### PR TITLE
Use runtime-resolved path in Screenshot.saveForArtifact to fix scoped storage on Android 11+

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
@@ -17,17 +17,20 @@ object Screenshot {
         InstrumentationRegistry.getInstrumentation().uiAutomation.takeScreenshot()
 
     /**
-     * Saves [bmp] as a lossless PNG to:
-     *   /sdcard/Android/data/com.gb4pc/files/screenshots/<name>
+     * Saves [bmp] as a lossless PNG to the app's external files directory under
+     * a "screenshots" subdirectory. The path is resolved at runtime via the
+     * instrumentation context, which correctly targets the scoped storage directory
+     * owned by the target app's package — avoiding Permission denied errors on
+     * Android 11+ (API 30+) that occur when using a hardcoded /sdcard path.
      *
      * The directory is created if it does not exist. Intended for CI artifact pickup
      * on test failure so failures ship reviewable screenshots.
      */
     fun saveForArtifact(bmp: Bitmap, name: String) {
-        val dir = File("/sdcard/Android/data/com.gb4pc/files/screenshots")
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val dir = File(ctx.getExternalFilesDir(null), "screenshots")
         dir.mkdirs()
-        val file = File(dir, name)
-        FileOutputStream(file).use { out ->
+        FileOutputStream(File(dir, name)).use { out ->
             bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
         }
     }

--- a/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
@@ -28,7 +28,10 @@ object Screenshot {
      */
     fun saveForArtifact(bmp: Bitmap, name: String) {
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext
-        val dir = File(ctx.getExternalFilesDir(null), "screenshots")
+        val externalFilesDir = requireNotNull(ctx.getExternalFilesDir(null)) {
+            "External storage is not available — cannot save screenshot artifact"
+        }
+        val dir = File(externalFilesDir, "screenshots")
         dir.mkdirs()
         FileOutputStream(File(dir, name)).use { out ->
             bmp.compress(Bitmap.CompressFormat.PNG, 100, out)


### PR DESCRIPTION
## Summary

- Fixes #126
- Replace the hardcoded `/sdcard/Android/data/com.gb4pc/files/screenshots` path in `Screenshot.saveForArtifact` with a runtime-resolved path via `Context.getExternalFilesDir(null)`.

## What changed and why

**Problem:** On Android 11+ (API 30+), `/sdcard/Android/data/<pkg>/` is scoped storage owned by `<pkg>`. The instrumented test process runs under a different package (e.g. `com.gb4pc.app.test`), not `com.gb4pc`, so a `FileOutputStream` targeting the hardcoded path throws `java.io.IOException: Permission denied` at runtime.

**Fix:** Retrieve the instrumentation target context via `InstrumentationRegistry.getInstrumentation().targetContext` and call `ctx.getExternalFilesDir(null)` to get the runtime-correct external files directory for the target app. This resolves to the right scoped-storage path for the actual package being tested and requires no additional permissions on API 29+.

The `InstrumentationRegistry` import was already present in the file (used by `captureScreen()`), so no new dependencies were added.

## Test plan

- [ ] Verify no existing unit tests are broken (`./gradlew :app:testDebugUnitTest`)
- [ ] Deploy to an Android 11+ device/emulator and confirm screenshots are saved without `Permission denied`

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_