### PR TITLE
Remove dead logcat synchronisation signal from MockCameraActivity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,8 +173,8 @@ jobs:
           # Prevent the screen from sleeping while the emulator is "plugged in"
           # (value 7 = stay on for AC/USB/wireless charging combined).
           # Without this the screen can time out between the unlock here and the
-          # `am start` in the pre-flight step, preventing onWindowFocusChanged
-          # from ever firing and causing the "MockCameraActivity ready" timeout.
+          # `am start` in the pre-flight step, preventing the activity window from
+          # appearing over the lock screen.
           "$ADB" shell settings put global stay_on_while_plugged_in 7
           "$ADB" shell settings put global window_animation_scale 0
           "$ADB" shell settings put global transition_animation_scale 0

--- a/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
+++ b/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
@@ -70,9 +70,6 @@ class MockCameraActivity : Activity() {
 
     private var cameraDevice: CameraDevice? = null
 
-    /** Ensures the "ready" log is emitted at most once per Activity instance. */
-    private var readyLogged = false
-
     // -------------------------------------------------------------------------
     // Shutter broadcast receiver
     // -------------------------------------------------------------------------
@@ -117,8 +114,8 @@ class MockCameraActivity : Activity() {
         // On API 27+ the manifest android:showWhenLocked / android:turnScreenOn attributes
         // are advisory hints that some OEM ROMs and the API-35 emulator may ignore.
         // Calling the programmatic equivalents here guarantees the window is shown over the
-        // lock screen and wakes the display, so onWindowFocusChanged(hasFocus=true) fires
-        // reliably in CI even if the screen turned off between the adb unlock and am start.
+        // lock screen and wakes the display even if the screen turned off between the
+        // adb unlock and am start.
         setShowWhenLocked(true)
         setTurnScreenOn(true)
         setContentView(R.layout.activity_mock_camera)
@@ -133,24 +130,6 @@ class MockCameraActivity : Activity() {
             IntentFilter(ACTION_SHUTTER),
             Context.RECEIVER_NOT_EXPORTED,
         )
-        // Give the View one frame to render before signalling ready.
-        // Using a 1-second delay rather than onWindowFocusChanged so the signal fires
-        // even when the display is off or focus is stolen by another window.
-        Handler(Looper.getMainLooper()).postDelayed({
-            if (!readyLogged) {
-                readyLogged = true
-                Log.d(TAG, "MockCameraActivity ready")
-            }
-        }, 1000)
-    }
-
-    /** Fallback: emit the ready log on focus if the postDelayed hasn't fired yet. */
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        if (hasFocus && !readyLogged) {
-            readyLogged = true
-            Log.d(TAG, "MockCameraActivity ready")
-        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
## Summary

Fixes #122

### Approach chosen: Option A — remove the dead signal

The `readyLogged` flag, the `Handler.postDelayed(1000ms)` in `onResume`, and the `onWindowFocusChanged` fallback were a CI synchronisation point that originally polled logcat for `"MockCameraActivity ready"`. The current CI pre-flight step (`build.yml`) uses `am start -W` + `sleep 3` and never reads logcat, so this signal was dead code that would mislead a future reader into thinking it still drove CI timing.

**Why Option A over Option B:** Option A removes code with no corresponding CI side to maintain. Option B would require writing a logcat polling loop in YAML, adding complexity to both CI and the Kotlin class for no reliability gain (the `am start -W` + `sleep 3` approach already works). Removing dead code is the simpler, lower-risk change.

### Changes

- `MockCameraActivity.kt`: Remove `readyLogged` field, the `postDelayed` ready-signal emission from `onResume`, and the `onWindowFocusChanged` override. Update the stale `onCreate` comment that referenced `onWindowFocusChanged`.
- `build.yml`: Update the stale comment in the "Wait for emulator service readiness" step that referenced the removed logcat signal and `onWindowFocusChanged`.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` passes locally (BUILD SUCCESSFUL, 31 tasks)
- [x] No existing tests deleted or disabled
- [x] CI pre-flight (`am start -W` + `sleep 3`) is unchanged — the green-feed smoke check is unaffected

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_