### PR TITLE
Add noisy 64×64 tests to complete noise-robustness size coverage

### DIFF
--- a/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
@@ -203,4 +203,13 @@ class ShapeMatcherTest {
             makeNoisy(Shape.SQUIRCLE, 256, 256, noiseFraction = 0.02),
             Shape.SQUIRCLE
         )
+
+    @Test fun `noisy square 64x64 still classifies as SQUARE`() =
+        assertClassifiesAs("noisy square 64x64", makeNoisy(Shape.SQUARE, 64, 64, noiseFraction = 0.02), Shape.SQUARE)
+
+    @Test fun `noisy circle 64x64 still classifies as CIRCLE`() =
+        assertClassifiesAs("noisy circle 64x64", makeNoisy(Shape.CIRCLE, 64, 64, noiseFraction = 0.02), Shape.CIRCLE)
+
+    @Test fun `noisy squircle 64x64 still classifies as SQUIRCLE`() =
+        assertClassifiesAs("noisy squircle 64x64", makeNoisy(Shape.SQUIRCLE, 64, 64, noiseFraction = 0.02), Shape.SQUIRCLE)
 }

--- a/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
@@ -162,6 +162,27 @@ class ShapeMatcherTest {
 
     // ── anti-aliased / noisy inputs (2% edge dropout) ────────────────────────
 
+    @Test fun `noisy square 64x64 still classifies as SQUARE`() =
+        assertClassifiesAs(
+            "noisy square 64x64",
+            makeNoisy(Shape.SQUARE, 64, 64, noiseFraction = 0.02),
+            Shape.SQUARE
+        )
+
+    @Test fun `noisy circle 64x64 still classifies as CIRCLE`() =
+        assertClassifiesAs(
+            "noisy circle 64x64",
+            makeNoisy(Shape.CIRCLE, 64, 64, noiseFraction = 0.02),
+            Shape.CIRCLE
+        )
+
+    @Test fun `noisy squircle 64x64 still classifies as SQUIRCLE`() =
+        assertClassifiesAs(
+            "noisy squircle 64x64",
+            makeNoisy(Shape.SQUIRCLE, 64, 64, noiseFraction = 0.02),
+            Shape.SQUIRCLE
+        )
+
     @Test fun `noisy square 128x128 still classifies as SQUARE`() =
         assertClassifiesAs(
             "noisy square 128x128",
@@ -203,13 +224,4 @@ class ShapeMatcherTest {
             makeNoisy(Shape.SQUIRCLE, 256, 256, noiseFraction = 0.02),
             Shape.SQUIRCLE
         )
-
-    @Test fun `noisy square 64x64 still classifies as SQUARE`() =
-        assertClassifiesAs("noisy square 64x64", makeNoisy(Shape.SQUARE, 64, 64, noiseFraction = 0.02), Shape.SQUARE)
-
-    @Test fun `noisy circle 64x64 still classifies as CIRCLE`() =
-        assertClassifiesAs("noisy circle 64x64", makeNoisy(Shape.CIRCLE, 64, 64, noiseFraction = 0.02), Shape.CIRCLE)
-
-    @Test fun `noisy squircle 64x64 still classifies as SQUIRCLE`() =
-        assertClassifiesAs("noisy squircle 64x64", makeNoisy(Shape.SQUIRCLE, 64, 64, noiseFraction = 0.02), Shape.SQUIRCLE)
 }


### PR DESCRIPTION
## Summary

- Adds three missing test methods in `ShapeMatcherTest.kt`: noisy square, circle, and squircle at 64×64 with 2% edge-pixel dropout.
- All three tests pass at the existing `minIoU = 0.95f` threshold — no threshold relaxation or sweep-parameter widening was needed.
- This completes the noise-robustness test matrix across all three sizes (64×64, 128×128, 256×256) as required by the plan.

## Why 64×64 is noise-sensitive

At 64×64, edge pixels represent a much larger fraction of total pixels than at 128×128 or 256×256, so a 2% edge-dropout fraction was expected to be more damaging. In practice the `ShapeMatcher` sweep (±3 scale, ±8 position) is wide enough to recover the best-fit IoU even after dropout, so the existing threshold held.

## Test plan

- [x] `noisy square 64x64 still classifies as SQUARE` — passes
- [x] `noisy circle 64x64 still classifies as CIRCLE` — passes
- [x] `noisy squircle 64x64 still classifies as SQUIRCLE` — passes
- [x] All pre-existing 30 ShapeMatcherTest cases continue to pass (verified via `./gradlew :app:testDebugUnitTest`)

Fixes #128

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_