### PR TITLE
Add Gaussian-blur noise model to ShapeMatcherTest

### DIFF
--- a/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
@@ -265,15 +265,6 @@ class ShapeMatcherTest {
             Shape.SQUIRCLE
         )
 
-    @Test fun `noisy square 64x64 still classifies as SQUARE`() =
-        assertClassifiesAs("noisy square 64x64", makeNoisy(Shape.SQUARE, 64, 64, noiseFraction = 0.02), Shape.SQUARE)
-
-    @Test fun `noisy circle 64x64 still classifies as CIRCLE`() =
-        assertClassifiesAs("noisy circle 64x64", makeNoisy(Shape.CIRCLE, 64, 64, noiseFraction = 0.02), Shape.CIRCLE)
-
-    @Test fun `noisy squircle 64x64 still classifies as SQUIRCLE`() =
-        assertClassifiesAs("noisy squircle 64x64", makeNoisy(Shape.SQUIRCLE, 64, 64, noiseFraction = 0.02), Shape.SQUIRCLE)
-
     // ── Gaussian-blurred inputs (1-pixel anti-aliasing) ───────────────────────
 
     @Test fun `blurred square 64x64 still classifies as SQUARE`() =

--- a/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/visual/ShapeMatcherTest.kt
@@ -9,8 +9,10 @@ import kotlin.random.Random
  *
  * Uses [ShapeTemplates] to generate synthetic ground-truth masks and verifies that
  * the classifier correctly identifies each shape, with sufficient IoU and margin, at
- * multiple resolutions. Also confirms robustness to ~2% random edge-pixel dropout
- * (simulating anti-aliasing / screenshot softening).
+ * multiple resolutions. Also confirms robustness to:
+ *  - ~2% random edge-pixel dropout (simulating isolated-pixel loss).
+ *  - 1-pixel Gaussian blur (simulating anti-aliasing / screenshot edge softening, as
+ *    produced by [UiAutomation.takeScreenshot] on JPEG-composited bitmaps).
  */
 class ShapeMatcherTest {
 
@@ -69,6 +71,65 @@ class ShapeMatcherTest {
     private fun isEdgePixel(bits: BooleanArray, x: Int, y: Int, w: Int, h: Int): Boolean {
         fun at(px: Int, py: Int) = if (px in 0 until w && py in 0 until h) bits[py * w + px] else false
         return !at(x - 1, y) || !at(x + 1, y) || !at(x, y - 1) || !at(x, y + 1)
+    }
+
+    /**
+     * Generates a candidate mask for [shape] at the given size, then applies a 3×3 Gaussian
+     * blur to approximate 1-pixel anti-aliasing at the shape boundary.
+     *
+     * Blur uses a standard 3×3 Gaussian kernel (weights: corner=1, edge=2, center=4, sum=16),
+     * treating `true` pixels as 1.0 and `false` pixels as 0.0. The blurred float value is
+     * re-thresholded at 0.5 to produce the output boolean mask.  Interior pixels whose 3×3
+     * neighbourhood is entirely `true` remain true; the boundary softens by at most 1 pixel.
+     *
+     * This models the specific failure mode that [UiAutomation.takeScreenshot] guards against:
+     * JPEG compression and compositing soften edges, potentially causing per-channel tolerance
+     * checks in [ColorMatch.mask] to fail for boundary pixels.
+     */
+    private fun makeBlurred(shape: Shape, w: Int, h: Int): MaskData {
+        val base = when (shape) {
+            is Shape.SQUARE   -> ShapeTemplates.square(w, h)
+            is Shape.CIRCLE   -> ShapeTemplates.circle(w, h)
+            is Shape.SQUIRCLE -> ShapeTemplates.squircle(w, h)
+        }
+
+        // 3×3 Gaussian kernel weights (unnormalized): corners=1, cardinal edges=2, center=4.
+        val kw = intArrayOf(1, 2, 1, 2, 4, 2, 1, 2, 1)
+        val kSum = 16  // sum of kw
+
+        fun at(px: Int, py: Int): Int =
+            if (px in 0 until w && py in 0 until h && base.bits[py * w + px]) 1 else 0
+
+        val bits = BooleanArray(w * h)
+        var sumX = 0L; var sumY = 0L; var count = 0
+        var minX = Int.MAX_VALUE; var maxX = Int.MIN_VALUE
+        var minY = Int.MAX_VALUE; var maxY = Int.MIN_VALUE
+
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                // Accumulate weighted sum over the 3×3 neighbourhood.
+                var acc = 0
+                var ki = 0
+                for (dy in -1..1) for (dx in -1..1) {
+                    acc += kw[ki++] * at(x + dx, y + dy)
+                }
+                val v = acc.toDouble() / kSum >= 0.5
+                bits[y * w + x] = v
+                if (v) {
+                    if (x < minX) minX = x; if (x > maxX) maxX = x
+                    if (y < minY) minY = y; if (y > maxY) maxY = y
+                    sumX += x; sumY += y; count++
+                }
+            }
+        }
+
+        if (count == 0) return MaskData.empty()
+        return MaskData(
+            bits = bits, width = w, height = h,
+            bboxLeft = minX, bboxTop = minY, bboxRight = maxX + 1, bboxBottom = maxY + 1,
+            centroidX = sumX.toFloat() / count, centroidY = sumY.toFloat() / count,
+            pixelCount = count
+        )
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -203,4 +264,42 @@ class ShapeMatcherTest {
             makeNoisy(Shape.SQUIRCLE, 256, 256, noiseFraction = 0.02),
             Shape.SQUIRCLE
         )
+
+    @Test fun `noisy square 64x64 still classifies as SQUARE`() =
+        assertClassifiesAs("noisy square 64x64", makeNoisy(Shape.SQUARE, 64, 64, noiseFraction = 0.02), Shape.SQUARE)
+
+    @Test fun `noisy circle 64x64 still classifies as CIRCLE`() =
+        assertClassifiesAs("noisy circle 64x64", makeNoisy(Shape.CIRCLE, 64, 64, noiseFraction = 0.02), Shape.CIRCLE)
+
+    @Test fun `noisy squircle 64x64 still classifies as SQUIRCLE`() =
+        assertClassifiesAs("noisy squircle 64x64", makeNoisy(Shape.SQUIRCLE, 64, 64, noiseFraction = 0.02), Shape.SQUIRCLE)
+
+    // ── Gaussian-blurred inputs (1-pixel anti-aliasing) ───────────────────────
+
+    @Test fun `blurred square 64x64 still classifies as SQUARE`() =
+        assertClassifiesAs("blurred square 64x64", makeBlurred(Shape.SQUARE, 64, 64), Shape.SQUARE)
+
+    @Test fun `blurred square 128x128 still classifies as SQUARE`() =
+        assertClassifiesAs("blurred square 128x128", makeBlurred(Shape.SQUARE, 128, 128), Shape.SQUARE)
+
+    @Test fun `blurred square 256x256 still classifies as SQUARE`() =
+        assertClassifiesAs("blurred square 256x256", makeBlurred(Shape.SQUARE, 256, 256), Shape.SQUARE)
+
+    @Test fun `blurred circle 64x64 still classifies as CIRCLE`() =
+        assertClassifiesAs("blurred circle 64x64", makeBlurred(Shape.CIRCLE, 64, 64), Shape.CIRCLE)
+
+    @Test fun `blurred circle 128x128 still classifies as CIRCLE`() =
+        assertClassifiesAs("blurred circle 128x128", makeBlurred(Shape.CIRCLE, 128, 128), Shape.CIRCLE)
+
+    @Test fun `blurred circle 256x256 still classifies as CIRCLE`() =
+        assertClassifiesAs("blurred circle 256x256", makeBlurred(Shape.CIRCLE, 256, 256), Shape.CIRCLE)
+
+    @Test fun `blurred squircle 64x64 still classifies as SQUIRCLE`() =
+        assertClassifiesAs("blurred squircle 64x64", makeBlurred(Shape.SQUIRCLE, 64, 64), Shape.SQUIRCLE)
+
+    @Test fun `blurred squircle 128x128 still classifies as SQUIRCLE`() =
+        assertClassifiesAs("blurred squircle 128x128", makeBlurred(Shape.SQUIRCLE, 128, 128), Shape.SQUIRCLE)
+
+    @Test fun `blurred squircle 256x256 still classifies as SQUIRCLE`() =
+        assertClassifiesAs("blurred squircle 256x256", makeBlurred(Shape.SQUIRCLE, 256, 256), Shape.SQUIRCLE)
 }


### PR DESCRIPTION
## Summary

Fixes #127

The plan (`PLAN_E2E_VISUAL_TESTS.md`) specifies that `ShapeMatcherTest` must guard against the screenshot path's edge softening using a Gaussian-blurred input. The existing implementation used random edge-pixel **dropout** instead, which is a different failure mode.

Changes:

- **`makeBlurred` helper**: applies a standard 3×3 Gaussian kernel (`1 2 1 / 2 4 2 / 1 2 1`, sum=16) to the boolean mask, treating `true=1`, `false=0`, then re-thresholds at 0.5. This erodes boundary pixels whose weighted neighbourhood falls below the threshold — matching how `UiAutomation.takeScreenshot()` softens edges on JPEG-composited bitmaps, where thresholding by `ColorMatch.mask` may fail for softened edge pixels.

- **Nine new `@Test` methods**: `blurred SQUARE`, `blurred CIRCLE`, and `blurred SQUIRCLE` at 64×64, 128×128, and 256×256. All pass at the same `minIoU=0.95` and margin `≥0.05` thresholds as the existing tests.

- **Existing dropout tests are untouched**: the 2% edge-pixel dropout model remains as a complementary noise model for a different failure mode (isolated pixel loss).

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all 33 `ShapeMatcherTest` tests pass (0 failures, 0 errors), including all 9 new blurred tests.

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_