### PR TITLE
Enforce review-submission as the only valid exit condition for Reviewer agents

### DIFF
--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -18,7 +18,7 @@
   Polling pattern:
   ```
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
-  repeat up to 15 times:
+  repeat up to 20 times:
     fetch PR status via mcp__github__pull_request_read
     if all checks SUCCESS or SKIPPED → break
     if any check FAILURE → break

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -17,12 +17,15 @@
 
   Polling pattern:
   ```
+  (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
   repeat up to 15 times:
-    fetch PR status
-    if all checks are SUCCESS or SKIPPED → break
-    if any check is FAILURE → break
+    fetch PR status via mcp__github__pull_request_read
+    if all checks SUCCESS or SKIPPED → break
+    if any check FAILURE → break
     sleep 30 seconds
-  → post your review (APPROVE, REQUEST_CHANGES, or COMMENT noting CI still pending)
+  if any check FAILURE:
+    reconsider IsReviewApproval — set to false if the failure is caused by this PR's changes
+  post review unconditionally: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```
 
 ## Author / Programmer

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -13,6 +13,17 @@
 - **Before approving, wait** for the CI gates (usually builds and tests) to complete. You need not wait if other required changes are outstanding, but do not send final approval unless the PR is **currently green**.
 - **If you must wait, poll** the status every 30 seconds. Do not rely on the flaky CI event hooks. **Update your own status every 30 seconds too**, so the Orchestrator doesn't think you're done.
 - **If the CI gates fail**, report this in your review. Based on the result and your expert evaluation, you may still decide to approve for a false positive.
+- **Do not return before posting your review.** Posting your review is the only valid exit condition. "Waiting for CI" is a loop body, not a final state. After your polling loop completes — whether CI is green, failed, or you hit the poll cap — you must call the review-submission tool before stopping.
+
+  Polling pattern:
+  ```
+  repeat up to 15 times:
+    fetch PR status
+    if all checks are SUCCESS or SKIPPED → break
+    if any check is FAILURE → break
+    sleep 30 seconds
+  → post your review (APPROVE, REQUEST_CHANGES, or COMMENT noting CI still pending)
+  ```
 
 ## Author / Programmer
 


### PR DESCRIPTION
## Summary

- Adds an explicit **Do not return before posting your review** rule to the Reviewer section of `agents/pr_participation.md`.
- Clarifies that "waiting for CI" is a loop body, not a terminal state — the Reviewer must call the review-submission tool after the polling loop regardless of CI outcome.
- Includes a concrete pseudocode polling pattern (up to 15 iterations, break on SUCCESS/SKIPPED or FAILURE, then post APPROVE / REQUEST_CHANGES / COMMENT).

The new bullet is placed immediately after the existing CI gate policy bullets ("Before approving, wait", "If you must wait, poll", "If the CI gates fail") so it reads as a unified, coherent policy rather than an isolated afterthought.

Fixes #135

## Test plan

- [ ] Read `agents/pr_participation.md` and confirm the new bullet integrates naturally into the Reviewer section.
- [ ] Verify the markdown code block renders correctly (indented under the bullet, fenced with triple backticks).
- [ ] Confirm no unrelated sections were modified.

https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn5pP8vxJNsME7vFceawXR)_