### PR TITLE
Clarify agent exit/resume model in orchestration docs

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -55,7 +55,10 @@ The Orchestrator is not a Reviewer or a Programmer.
 - **Dispatch in parallel** for independent issues (unless otherwise instructed). Parallel independent issues must each have their own branch.
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - **If a system hook or event signals uncommitted work, a test failure, or an error**, **pause 45 seconds**, then evaluate whether the agent or CI system is still actively working. If the agent was recently active (not idle or waiting for input), **or** the CI gates are in progress, **do not intervene** and continue waiting.
-- If an agent has failed to complete its work, and shows no sign of continued effort, assign a replacement to finish the job.
+- **Agent completion and exit are the same event.** When a background subagent finishes its turn you receive a task-notification. There is no idle/suspended state between "completed" and "exited" — these terms refer to the same transition.
+- **If an agent has exited without completing its task**, prefer resuming it over spawning a replacement. Use SendMessage with the original agent's ID to resume it with its full prior context intact — no reconstruction needed. Only spawn a replacement if the original agent's ID is unavailable or resumption fails.
+  - *Caveat — time window:* the backend may only keep a completed agent's session alive for a limited time after exit. Attempt resumption promptly.
+  - *Caveat — ID availability:* background agent IDs are returned at launch but are not persisted across Orchestrator context resets. If the ID is no longer available, fall back to spawning a replacement and reconstructing context from available sources (PR, issue, prior comments).
 
 ## When to abort
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -11,7 +11,7 @@
 - The Reviewer may mention positive aspects of the code under review, but must not use many words to do it.
 - The Reviewer need not enforce expectations written with "should" language.
 - **Before approving, wait** for the CI gates (usually builds and tests) to complete. You need not wait if other required changes are outstanding, but do not send final approval unless the PR is **currently green**.
-- **If you must wait, poll** the status every 30 seconds. Do not rely on the flaky CI event hooks. **Update your own status every 30 seconds too**, so the Orchestrator doesn't think you're done.
+- **If you must wait, poll** the status every 30 seconds. Do not rely on the flaky CI event hooks. Note: subagents cannot proactively send mid-task status messages to the Orchestrator — communication from subagent to Orchestrator only happens on completion. The Orchestrator will be notified when you exit; keep your polling loop running and do not exit until your review is posted.
 - **If the CI gates fail**, report this in your review. Based on the result and your expert evaluation, you may still decide to approve for a false positive.
 - **Do not return before posting your review.** Posting your review is the only valid exit condition. "Waiting for CI" is a loop body, not a final state. After your polling loop completes — whether CI is green, failed, or you hit the poll cap — you must call the review-submission tool before stopping.
 


### PR DESCRIPTION
## Summary

- Documents that agent completion and exit are the same event — there is no intermediate suspended/idle state.
- Instructs Orchestrators to prefer resuming a recently-exited agent via SendMessage (which preserves its full prior context) over spawning a replacement, with explicit caveats about time-window limits and agent-ID availability.
- Removes the unimplementable "update your own status every 30 seconds" heartbeat instruction from `pr_participation.md`; replaces it with an accurate note that subagent-to-Orchestrator communication is one-directional and only occurs on completion.

Fixes #137

## Test plan

- [ ] Read `agents/dev_orchestration.md` — confirm the new bullets appear in the Delegation rules section and accurately describe the exit/resume model.
- [ ] Read `agents/pr_participation.md` — confirm the heartbeat instruction is gone and replaced with a factually correct description of the one-directional communication model.
- [ ] Confirm no other content was restructured or removed.

https://claude.ai/code/session_01FRLuiHomGSJRWtJJ9k9uTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRLuiHomGSJRWtJJ9k9uTZ)_