### PR TITLE
Clear commit attribution in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
     ]
   },
   "attribution": {
-    "commit": "🦀",
+    "commit": "",
     "pr": ""
   }
 }


### PR DESCRIPTION
Claude says that empty strings trigger a certain behavior. I doubt it but will try.

For #138 