### PR TITLE
Skip CI build for documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,18 +5,10 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
-      - 'docs/**'
-      - 'agents/**'
-      - 'AGENTS.md'
-      - 'CLAUDE.md'
   pull_request:
     branches: [main]
     paths-ignore:
       - '**/*.md'
-      - 'docs/**'
-      - 'agents/**'
-      - 'AGENTS.md'
-      - 'CLAUDE.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,20 @@ name: Build & Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'agents/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'agents/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a `paths-ignore: ['**/*.md']` filter to both the `push` and `pull_request` triggers in `.github/workflows/build.yml`. With this filter in place, CI is skipped automatically when a commit or PR only touches markdown files, avoiding unnecessary build runs for documentation-only changes.

Fixes #141