### PR TITLE
Add CiWatcher agent and fix Reviewer CI-polling loop

### DIFF
--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -27,7 +27,7 @@ repeat up to 5 times:
   fetch PR status via mcp__github__pull_request_read
   if all checks SUCCESS or SKIPPED → exit and return Clear
   if any check FAILURE        → exit and return Blocked
-  sleep 30 seconds
+  if not the last iteration   → sleep 30 seconds
 exit and return Pending
 ```
 

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -35,7 +35,8 @@ repeat up to 5 times:
       if mergeable_state = "clean"    → return Clear
       if mergeable_state = "unstable" → return Clear   (only non-required checks failing)
       if mergeable_state = "unknown"  → CI still computing; continue polling
-      otherwise (blocked, behind, dirty, etc.) → return Infra
+      if mergeable_state = "behind" or "dirty" → return Blocked  (Author must rebase or resolve conflict)
+      otherwise → return Infra  (blocked by unresolved required status check or unknown cause)
     → return Infra  (unknown conclusion — escalate)
   if not the last iteration → run `sleep 30` via the Bash tool
 return Pending
@@ -48,7 +49,7 @@ CiWatcher delivers exactly one of the following outcomes to the Orchestrator whe
 | Outcome   | Meaning                                                  |
 |-----------|----------------------------------------------------------|
 | `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral` AND `mergeable_state` is `clean` or `unstable` (explicit whitelist; any unrecognized conclusion escalates as `Infra`).|
-| `Blocked` | Any completed run has conclusion `failure` or `action_required` (code caused the failure).|
+| `Blocked` | Any completed run has conclusion `failure` or `action_required` (code caused the failure); or `mergeable_state` is `behind` (Author must rebase onto base branch) or `dirty` (Author must resolve merge conflict).|
 | `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, `stale`, or `startup_failure`; or any unrecognized conclusion; or `mergeable_state` is `blocked` (a required status check not satisfied by `get_check_runs`, e.g. a legacy commit status) — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
 | `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
 

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -30,8 +30,13 @@ repeat up to 5 times:
   if all runs have status "completed":
     if any run has conclusion "cancelled", "timed_out", "stale", or "startup_failure" → return Infra
     if any run has conclusion "failure" or "action_required" → return Blocked
-    if all runs have conclusion "success", "skipped", or "neutral" → return Clear
-    → return Infra  (unknown conclusion — treat as infrastructure problem, escalate)
+    if all runs have conclusion "success", "skipped", or "neutral":
+      fetch PR via mcp__github__pull_request_read (method: get)
+      if mergeable_state = "clean"    → return Clear
+      if mergeable_state = "unstable" → return Clear   (only non-required checks failing)
+      if mergeable_state = "unknown"  → CI still computing; continue polling
+      otherwise (blocked, behind, dirty, etc.) → return Infra
+    → return Infra  (unknown conclusion — escalate)
   if not the last iteration → run `sleep 30` via the Bash tool
 return Pending
 ```
@@ -42,9 +47,9 @@ CiWatcher delivers exactly one of the following outcomes to the Orchestrator whe
 
 | Outcome   | Meaning                                                  |
 |-----------|----------------------------------------------------------|
-| `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral` (explicit whitelist; any unrecognized conclusion escalates as `Infra`).|
+| `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral` AND `mergeable_state` is `clean` or `unstable` (explicit whitelist; any unrecognized conclusion escalates as `Infra`).|
 | `Blocked` | Any completed run has conclusion `failure` or `action_required` (code caused the failure).|
-| `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, `stale`, or `startup_failure`; or any unrecognized conclusion — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
+| `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, `stale`, or `startup_failure`; or any unrecognized conclusion; or `mergeable_state` is `blocked` (a required status check not satisfied by `get_check_runs`, e.g. a legacy commit status) — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
 | `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
 
 ## Lifecycle

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -24,11 +24,14 @@ Poll CI for up to 2.5 minutes (5 polls, 30 seconds apart):
 
 ```
 repeat up to 5 times:
-  fetch PR status via mcp__github__pull_request_read
-  if all checks SUCCESS or SKIPPED → exit and return Clear
-  if any check FAILURE        → exit and return Blocked
-  if not the last iteration   → run `sleep 30` via the Bash tool
-exit and return Pending
+  fetch check runs via mcp__github__pull_request_read (method: get_check_runs)
+  if total_count = 0 → return Clear  (no CI configured)
+  if any run has status "in_progress" or "queued" → CI is active; continue polling
+  if all runs have status "completed":
+    if any run has conclusion "failure" or "error" → return Blocked
+    → return Clear
+  if not the last iteration → run `sleep 30` via the Bash tool
+return Pending
 ```
 
 ## Return values

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -28,9 +28,10 @@ repeat up to 5 times:
   if total_count = 0 → return Clear  (no CI configured)
   if any run has status "in_progress" or "queued" → CI is active; continue polling
   if all runs have status "completed":
-    if any run has conclusion "cancelled", "timed_out", or "stale" → return Infra
-    if any run has conclusion "failure", "error", or "action_required" → return Blocked
-    → return Clear
+    if any run has conclusion "cancelled", "timed_out", "stale", or "startup_failure" → return Infra
+    if any run has conclusion "failure" or "action_required" → return Blocked
+    if all runs have conclusion "success", "skipped", or "neutral" → return Clear
+    → return Infra  (unknown conclusion — treat as infrastructure problem, escalate)
   if not the last iteration → run `sleep 30` via the Bash tool
 return Pending
 ```
@@ -41,9 +42,9 @@ CiWatcher delivers exactly one of the following outcomes to the Orchestrator whe
 
 | Outcome   | Meaning                                                  |
 |-----------|----------------------------------------------------------|
-| `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral`.|
-| `Blocked` | Any completed run has conclusion `failure`, `error`, or `action_required` (code caused the failure).|
-| `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, or `stale` — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
+| `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral` (explicit whitelist; any unrecognized conclusion escalates as `Infra`).|
+| `Blocked` | Any completed run has conclusion `failure` or `action_required` (code caused the failure).|
+| `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, `stale`, or `startup_failure`; or any unrecognized conclusion — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
 | `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
 
 ## Lifecycle

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -28,7 +28,8 @@ repeat up to 5 times:
   if total_count = 0 → return Clear  (no CI configured)
   if any run has status "in_progress" or "queued" → CI is active; continue polling
   if all runs have status "completed":
-    if any run has conclusion other than "success" or "skipped" → return Blocked
+    if any run has conclusion "cancelled", "timed_out", or "stale" → return Infra
+    if any run has conclusion "failure", "error", or "action_required" → return Blocked
     → return Clear
   if not the last iteration → run `sleep 30` via the Bash tool
 return Pending
@@ -40,8 +41,9 @@ CiWatcher delivers exactly one of the following outcomes to the Orchestrator whe
 
 | Outcome   | Meaning                                                  |
 |-----------|----------------------------------------------------------|
-| `Clear`   | All completed runs have conclusion `success` or `skipped`.|
-| `Blocked` | Any completed run has a conclusion other than `success` or `skipped` (e.g. `failure`, `error`, `cancelled`, `timed_out`, `action_required`, `neutral`, `stale`).|
+| `Clear`   | All completed runs have conclusion `success`, `skipped`, or `neutral`.|
+| `Blocked` | Any completed run has conclusion `failure`, `error`, or `action_required` (code caused the failure).|
+| `Infra`   | Any completed run has conclusion `cancelled`, `timed_out`, or `stale` — a CI infrastructure problem unrelated to the PR's code changes; escalate to user.|
 | `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
 
 ## Lifecycle

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -27,7 +27,7 @@ repeat up to 5 times:
   fetch PR status via mcp__github__pull_request_read
   if all checks SUCCESS or SKIPPED → exit and return Clear
   if any check FAILURE        → exit and return Blocked
-  if not the last iteration   → sleep 30 seconds
+  if not the last iteration   → run `sleep 30` via the Bash tool
 exit and return Pending
 ```
 

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -1,0 +1,48 @@
+# CiWatcher
+
+## Role
+
+A *CiWatcher* is a short-lived agent created by the Orchestrator to check whether CI gates have settled on a PR after a Reviewer has posted its review. CiWatcher does not post comments or reviews to GitHub; it only reads PR status and reports its outcome to the Orchestrator on exit.
+
+**This document holds RULES for the CiWatcher, not suggestions.**
+
+## What CiWatcher may and may not do
+
+**May not:**
+- Post comments, reviews, or any content to GitHub
+- Edit or write files
+- Make git commits or push changes
+- Evaluate code quality or form its own verdict on the PR
+
+**May:**
+- Read PR status via `mcp__github__pull_request_read`
+- Sleep between polls
+
+## Polling procedure
+
+Poll CI for up to 2.5 minutes (5 polls, 30 seconds apart):
+
+```
+repeat up to 5 times:
+  fetch PR status via mcp__github__pull_request_read
+  if all checks SUCCESS or SKIPPED → exit and return Clear
+  if any check FAILURE        → exit and return Blocked
+  sleep 30 seconds
+exit and return Pending
+```
+
+## Return values
+
+CiWatcher delivers exactly one of the following outcomes to the Orchestrator when it exits:
+
+| Outcome   | Meaning                                                  |
+|-----------|----------------------------------------------------------|
+| `Clear`   | All CI checks passed (SUCCESS or SKIPPED).               |
+| `Blocked` | One or more CI checks failed.                            |
+| `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
+
+## Lifecycle
+
+- CiWatcher is spawned by the Orchestrator after a Reviewer exits.
+- CiWatcher exits as soon as it has a definitive outcome or exhausts its poll budget.
+- The Orchestrator interprets the returned outcome and decides next steps (see `dev_orchestration.md`).

--- a/agents/ci_watcher.md
+++ b/agents/ci_watcher.md
@@ -28,7 +28,7 @@ repeat up to 5 times:
   if total_count = 0 → return Clear  (no CI configured)
   if any run has status "in_progress" or "queued" → CI is active; continue polling
   if all runs have status "completed":
-    if any run has conclusion "failure" or "error" → return Blocked
+    if any run has conclusion other than "success" or "skipped" → return Blocked
     → return Clear
   if not the last iteration → run `sleep 30` via the Bash tool
 return Pending
@@ -40,8 +40,8 @@ CiWatcher delivers exactly one of the following outcomes to the Orchestrator whe
 
 | Outcome   | Meaning                                                  |
 |-----------|----------------------------------------------------------|
-| `Clear`   | All CI checks passed (SUCCESS or SKIPPED).               |
-| `Blocked` | One or more CI checks failed.                            |
+| `Clear`   | All completed runs have conclusion `success` or `skipped`.|
+| `Blocked` | Any completed run has a conclusion other than `success` or `skipped` (e.g. `failure`, `error`, `cancelled`, `timed_out`, `action_required`, `neutral`, `stale`).|
 | `Pending` | CI was still running after 2.5 minutes (5 polls × 30 s).|
 
 ## Lifecycle

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -58,9 +58,10 @@ loop:
   if Reviewer gave approval:
     Orchestrator creates a CiWatcher agent (see agents/ci_watcher.md)
     CiWatcher returns one of: Clear, Blocked, or Pending
-    if CiWatcher returned Pending → goto loop
-  if Reviewer requested changes OR CiWatcher returned Blocked → goto newAuthor
-  if CiWatcher returned Clear → PR may be merged
+    if CiWatcher returned Pending  → goto loop
+    if CiWatcher returned Blocked  → goto newAuthor
+    if CiWatcher returned Clear    → PR may be merged
+  if Reviewer requested changes → goto newAuthor
 ```
 
 - **CiWatcher** is a short-lived agent that polls CI for up to 2.5 minutes and reports back. It does not post to GitHub.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -54,14 +54,14 @@ The Orchestrator is not a Reviewer or a Programmer.
 After the Reviewer exits and delivers its decision, the Orchestrator runs the following loop:
 
 ```
-loop:
+  if Reviewer requested changes → goto newAuthor
   if Reviewer gave approval:
+loop:
     Orchestrator creates a CiWatcher agent (see agents/ci_watcher.md)
     CiWatcher returns one of: Clear, Blocked, or Pending
     if CiWatcher returned Pending  → goto loop
     if CiWatcher returned Blocked  → goto newAuthor
     if CiWatcher returned Clear    → PR may be merged
-  if Reviewer requested changes → goto newAuthor
 ```
 
 - **CiWatcher** is a short-lived agent that polls CI for up to 2.5 minutes and reports back. It does not post to GitHub.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -56,10 +56,13 @@ After the Reviewer exits and delivers its decision, the Orchestrator runs the fo
 ```
   if Reviewer requested changes → goto newAuthor
   if Reviewer gave approval:
+    record start_time
 loop:
     Orchestrator creates a CiWatcher agent (see agents/ci_watcher.md)
     CiWatcher returns one of: Clear, Blocked, or Pending
-    if CiWatcher returned Pending  → goto loop
+    if CiWatcher returned Pending:
+      if elapsed time since start_time > 30 minutes → escalate to user; stop
+      goto loop
     if CiWatcher returned Blocked  → goto newAuthor
     if CiWatcher returned Clear    → PR may be merged
 ```

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -59,10 +59,11 @@ After the Reviewer exits and delivers its decision, the Orchestrator runs the fo
     record start_time
 loop:
     Orchestrator creates a CiWatcher agent (see agents/ci_watcher.md)
-    CiWatcher returns one of: Clear, Blocked, or Pending
+    CiWatcher returns one of: Clear, Blocked, Infra, or Pending
     if CiWatcher returned Pending:
       if elapsed time since start_time > 30 minutes → escalate to user; stop
       goto loop
+    if CiWatcher returned Infra    → escalate to user; stop
     if CiWatcher returned Blocked  → goto newAuthor
     if CiWatcher returned Clear    → PR may be merged
 ```

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -47,6 +47,25 @@ The Orchestrator is not a Reviewer or a Programmer.
 - Inform the agent of its role as an expert software reviewer who ensures high quality code and adherence to development plans
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user
+- The Reviewer posts its review immediately upon completing its analysis and then exits. **Do not** instruct the Reviewer to poll CI or delay posting — CI checking is handled by the Orchestrator via a CiWatcher agent (see below).
+
+## CI checking after a Reviewer exits (CiWatcher loop)
+
+After the Reviewer exits and delivers its decision, the Orchestrator runs the following loop:
+
+```
+loop:
+  if Reviewer gave approval:
+    Orchestrator creates a CiWatcher agent (see agents/ci_watcher.md)
+    CiWatcher returns one of: Clear, Blocked, or Pending
+    if CiWatcher returned Pending → goto loop
+  if Reviewer requested changes OR CiWatcher returned Blocked → goto newAuthor
+  if CiWatcher returned Clear → PR may be merged
+```
+
+- **CiWatcher** is a short-lived agent that polls CI for up to 2.5 minutes and reports back. It does not post to GitHub.
+- The Orchestrator loops (spawning a fresh CiWatcher each iteration) until CI settles or a new Author cycle is needed.
+- Do not subscribe to PR events or delay dispatching the Reviewer while waiting for CI — the CiWatcher loop replaces that pattern.
 
 ## Delegation rules
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -10,22 +10,14 @@
 - A Reviewer should be explicit and fully explain any problems, but should not spend tokens to design their solutions.
 - The Reviewer may mention positive aspects of the code under review, but must not use many words to do it.
 - The Reviewer need not enforce expectations written with "should" language.
-- **Before approving, wait** for the CI gates (usually builds and tests) to complete. You need not wait if other required changes are outstanding, but do not send final approval unless the PR is **currently green**.
-- **If you must wait, poll** the status every 30 seconds. Do not rely on the flaky CI event hooks. Note: subagents cannot proactively send mid-task status messages to the Orchestrator — communication from subagent to Orchestrator only happens on completion. The Orchestrator will be notified when you exit; keep your polling loop running and do not exit until your review is posted.
-- **If the CI gates fail**, report this in your review. Based on the result and your expert evaluation, you may still decide to approve for a false positive.
-- **Do not return before posting your review.** Posting your review is the only valid exit condition. "Waiting for CI" is a loop body, not a final state. After your polling loop completes — whether CI is green, failed, or you hit the poll cap — you must call the review-submission tool before stopping.
+- **Do not wait for CI.** Review the diff, form your verdict, and post your review immediately. The Orchestrator uses a CiWatcher agent to check CI status after you exit; you do not need to poll.
+- **If CI results are already available** when you complete your review, you may note them in your review text, but do not block on them.
+- **Do not return before posting your review.** Posting your review is the only valid exit condition. After forming your verdict, call the review-submission tool before stopping.
 
-  Polling pattern:
+  Review pattern:
   ```
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
-  repeat up to 20 times:
-    fetch PR status via mcp__github__pull_request_read
-    if all checks SUCCESS or SKIPPED → break
-    if any check FAILURE → break
-    sleep 30 seconds
-  if any check FAILURE:
-    reconsider IsReviewApproval — set to false if the failure is caused by this PR's changes
-  post review unconditionally: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
+  post review: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```
 
 ## Author / Programmer


### PR DESCRIPTION
Fixes #143

## Summary

Reviewer subagents were failing to post reviews because they were polling CI synchronously (hitting turn-time limits) or using Monitor (which times out before emulator CI resolves at 7–12 minutes). This PR moves CI checking out of the Reviewer and into a dedicated short-lived CiWatcher agent controlled by the Orchestrator.

- **agents/pr_participation.md**: Remove the CI-polling loop from the Reviewer role. The Reviewer now posts its review immediately upon completing analysis and exits. Notes that CI results already visible may be mentioned but must not block posting.
- **agents/dev_orchestration.md**: Add the CiWatcher loop section describing how the Orchestrator spawns a CiWatcher after each Reviewer exit and loops until CI settles or a new Author cycle is needed. Clarifies that the Reviewer must not be told to poll CI.
- **agents/ci_watcher.md** (new): Defines the CiWatcher role — polls CI for up to 2.5 minutes (5 × 30 s), returns `Clear`, `Blocked`, or `Pending`, and must not post to GitHub or write any files.

https://claude.ai/code/session_016a9wdfh15nTvCdCjuphRGV

---
_Generated by [Claude Code](https://claude.ai/code/session_016a9wdfh15nTvCdCjuphRGV)_