### PR TITLE
Add E2EFixture extensions for Phase 4 of the E2E visual test plan

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -1,12 +1,26 @@
 package com.gb4pc.e2e
 
+import android.app.KeyguardManager
 import android.app.UiAutomation
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.gb4pc.Constants
+import com.gb4pc.data.AspectRatioUtil
 import com.gb4pc.data.PrefsManager
 import com.gb4pc.service.OverlayService
+import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Shared setup, teardown, and Pixel-Camera shell-command helpers for E2E tests.
@@ -77,6 +91,227 @@ class E2EFixture(
             Thread.sleep(100)
         }
         return condition()
+    }
+
+    // ── Phase 4 extensions ────────────────────────────────────────────────────
+
+    /**
+     * Seeds PrefsManager with a gallery package selection and marks setup complete.
+     *
+     * Sets [PrefsManager.galleryPackage] = [pkg], [PrefsManager.isSetupCompleted] = true,
+     * and [PrefsManager.isServiceEnabled] = true. All other prefs are left untouched.
+     */
+    fun seedGalleryPrefs(pkg: String) {
+        val prefs = PrefsManager(context)
+        prefs.galleryPackage = pkg
+        prefs.isSetupCompleted = true
+        prefs.isServiceEnabled = true
+    }
+
+    /**
+     * Deletes all images from the external MediaStore and asserts the roll is empty.
+     *
+     * Uses [ContentResolver.delete] with a null predicate to remove every row from
+     * [MediaStore.Images.Media.EXTERNAL_CONTENT_URI]. On API 33+ this would throw
+     * [android.app.RecoverableSecurityException] for rows inserted by other packages;
+     * since the test suite controls all insertions in the E2E environment this should
+     * not occur. If it does, the exception propagates and fails the test loudly.
+     *
+     * After deletion a query is performed to assert 0 rows remain.
+     */
+    fun clearCameraRoll() {
+        context.contentResolver.delete(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            null,
+            null
+        )
+        val cursor = context.contentResolver.query(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            arrayOf(MediaStore.Images.Media._ID),
+            null, null, null
+        )
+        val count = cursor?.count ?: 0
+        cursor?.close()
+        assertEquals("MediaStore should be empty after clearCameraRoll()", 0, count)
+    }
+
+    /**
+     * Triggers the mock camera's shutter path and waits for the new image to appear in
+     * MediaStore.
+     *
+     * Records the current row count, sends the `ACTION_SHUTTER` broadcast to the mock
+     * camera process, and polls MediaStore until the count increments or 10 seconds elapse.
+     * Falls back to [MediaScannerConnection.scanFile] if the row does not appear promptly
+     * (e.g. if the MediaStore indexer has not picked up the new file from the filesystem).
+     *
+     * The `ACTION_SHUTTER` / `ACTION_SHUTTER_DONE` action strings are defined in
+     * `MockCameraActivity` in the `:e2e-mock-camera` module. They are referenced here as
+     * string literals because `:e2e-mock-camera` is a separate application module (not a
+     * library) and its classes are not available at test compile time.
+     *
+     * @throws AssertionError if no new image row appears within 15 seconds.
+     */
+    fun captureOnePhoto() {
+        val rowsBefore = countMediaStoreImages()
+
+        // These constants must match MockCameraActivity.ACTION_SHUTTER / ACTION_SHUTTER_DONE.
+        val actionShutter = "com.gb4pc.mockcamera.ACTION_SHUTTER"
+        val actionShutterDone = "com.gb4pc.mockcamera.ACTION_SHUTTER_DONE"
+
+        // Listen for ACTION_SHUTTER_DONE so we know the mock camera finished writing.
+        val latch = CountDownLatch(1)
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context, intent: Intent) {
+                if (intent.action == actionShutterDone) {
+                    latch.countDown()
+                }
+            }
+        }
+        val filter = IntentFilter(actionShutterDone)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            context.registerReceiver(receiver, filter)
+        }
+
+        try {
+            // Send the shutter trigger to the mock camera.
+            val shutterIntent = Intent(actionShutter).apply { setPackage(pcPackage) }
+            context.sendBroadcast(shutterIntent)
+
+            // Wait up to 10 s for the shutter-done broadcast.
+            latch.await(10, TimeUnit.SECONDS)
+        } finally {
+            context.unregisterReceiver(receiver)
+        }
+
+        // Poll until the row count increases or 10 s pass.
+        val appeared = waitForCondition(10_000L) { countMediaStoreImages() > rowsBefore }
+
+        if (!appeared) {
+            // Fall back: trigger a media scan in case the indexer hasn't picked up the file.
+            val dcimPath = Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DCIM
+            ).absolutePath
+            val scanLatch = CountDownLatch(1)
+            MediaScannerConnection.scanFile(
+                context,
+                arrayOf(dcimPath),
+                arrayOf("image/jpeg")
+            ) { _, _ -> scanLatch.countDown() }
+            scanLatch.await(5, TimeUnit.SECONDS)
+
+            val appearedAfterScan = waitForCondition(5_000L) { countMediaStoreImages() > rowsBefore }
+            if (!appearedAfterScan) {
+                fail(
+                    "captureOnePhoto(): new image row did not appear in MediaStore within 15 s " +
+                        "(even after MediaScannerConnection.scanFile fallback)"
+                )
+            }
+        }
+    }
+
+    /**
+     * Taps the overlay button at its configured screen position.
+     *
+     * Reads the active [com.gb4pc.data.OverlayPosition] from [PrefsManager], computes pixel
+     * coordinates from [android.view.WindowMetrics] (API 30+) or [android.util.DisplayMetrics]
+     * (API 26–29), then dispatches a tap via [UiDevice].
+     *
+     * If the overlay is not rendered (e.g. blocked in secure-camera mode) this call taps empty
+     * screen space and has no visible effect — the plan requires this silent behaviour for
+     * Tests 4a/5a's baseline-failure scenario.
+     */
+    fun tapOverlay() {
+        val (displayWidth, displayHeight) = displaySize()
+
+        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+        val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
+
+        val x = (pos.xPercent / 100f * displayWidth).toInt()
+        val y = (pos.yPercent / 100f * displayHeight).toInt()
+
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).click(x, y)
+    }
+
+    /**
+     * Locks the screen by sending the KEYCODE_POWER key event and then waits (up to 5 s) for
+     * [KeyguardManager.isKeyguardLocked] to return true.
+     *
+     * @throws AssertionError if the keyguard does not engage within 5 seconds.
+     */
+    fun lockScreen() {
+        uiAutomation.executeShellCommand("input keyevent 26").close()
+        val locked = waitForCondition(5_000L) {
+            (context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager).isKeyguardLocked
+        }
+        if (!locked) {
+            fail("lockScreen(): KeyguardManager.isKeyguardLocked did not become true within 5 s")
+        }
+    }
+
+    /**
+     * Launches the mock camera via the secure-camera action and asserts the keyguard is locked.
+     *
+     * Sends `am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE` then immediately
+     * checks [KeyguardManager.isKeyguardLocked]. If the keyguard is not locked the fixture
+     * fails before any screenshot is taken — a silent keyguard dismissal would make Tests
+     * 4a/5a pass for the wrong reason.
+     *
+     * Call [lockScreen] before this method to guarantee the device is locked first.
+     */
+    fun launchSecureCamera() {
+        uiAutomation.executeShellCommand(
+            "am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE"
+        ).close()
+
+        val keyguard = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        if (!keyguard.isKeyguardLocked) {
+            fail(
+                "launchSecureCamera(): KeyguardManager.isKeyguardLocked == false after launching " +
+                    "STILL_IMAGE_CAMERA_SECURE — the adb path dismissed the keyguard. " +
+                    "Call lockScreen() before launchSecureCamera() and confirm the emulator " +
+                    "honours the secure-camera launch path."
+            )
+        }
+    }
+
+    /**
+     * Pauses the current thread for [ms] milliseconds.
+     *
+     * Explicit helper for the spec's "pause N ms" steps — wraps [Thread.sleep] so test code
+     * stays readable without raw sleep calls.
+     */
+    fun pause(ms: Long) {
+        Thread.sleep(ms)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private fun countMediaStoreImages(): Int {
+        val cursor = context.contentResolver.query(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            arrayOf(MediaStore.Images.Media._ID),
+            null, null, null
+        )
+        val count = cursor?.count ?: 0
+        cursor?.close()
+        return count
+    }
+
+    private fun displaySize(): Pair<Int, Int> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val wm = context.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
+            val bounds = wm.currentWindowMetrics.bounds
+            bounds.width() to bounds.height()
+        } else {
+            val wm = context.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
+            val dm = android.util.DisplayMetrics()
+            @Suppress("DEPRECATION")
+            wm.defaultDisplay.getMetrics(dm)
+            dm.widthPixels to dm.heightPixels
+        }
     }
 
     private fun ensurePixelCameraInstalled() {


### PR DESCRIPTION
## Summary

Implements the seven `E2EFixture` helper methods specified in Phase 4 of the E2E visual test plan (`PLAN_E2E_VISUAL_TESTS.md §Phase 4`). These methods will be consumed by `GalleryButtonVisualE2ETest` (Phase 5). The `Screenshot.kt` helpers (`captureScreen` / `saveForArtifact`) referenced in Phase 4 were already complete from Phase 3.

### New methods on `E2EFixture`

- **`seedGalleryPrefs(pkg)`** — writes `galleryPackage`, `isSetupCompleted`, `isServiceEnabled` to `PrefsManager` without disturbing other prefs
- **`clearCameraRoll()`** — deletes all `MediaStore.Images` rows and asserts 0 remain; `RecoverableSecurityException` propagates loudly if foreign rows exist on API 33+, per spec
- **`captureOnePhoto()`** — broadcasts `ACTION_SHUTTER` to the mock camera, waits for `ACTION_SHUTTER_DONE`, polls `MediaStore` for up to 10 s, falls back to `MediaScannerConnection.scanFile`, fails loudly after 15 s total
- **`tapOverlay()`** — reads `OverlayPosition` from `PrefsManager`, maps `xPercent`/`yPercent` to display pixels via `WindowMetrics` (API 30+) / `DisplayMetrics` (API 26–29), dispatches a `UiDevice.click`; intentionally taps empty space if the overlay is not rendered (silent no-op for Tests 4a/5a baseline)
- **`lockScreen()`** — sends `KEYCODE_POWER` (`keyevent 26`) and polls `isKeyguardLocked` for up to 5 s; fails loudly if the keyguard does not engage
- **`launchSecureCamera()`** — fires `STILL_IMAGE_CAMERA_SECURE` then immediately asserts `isKeyguardLocked`; throws before any screenshot if the keyguard was silently dismissed (which would make Tests 4a/5a pass for the wrong reason)
- **`pause(ms)`** — named `Thread.sleep` wrapper matching the spec's "pause N ms" steps

Also adds `androidx.test.uiautomator:uiautomator:2.3.0` as an `androidTest` dependency for `UiDevice.click` used by `tapOverlay`.

### Note on ACTION_SHUTTER constants

`MockCameraActivity` lives in `:e2e-mock-camera`, which is a separate application module — its classes are not available at `:app` compile time. The `ACTION_SHUTTER` / `ACTION_SHUTTER_DONE` action strings are referenced as string literals that must match `MockCameraActivity`'s companion-object constants exactly. This is documented in the method's KDoc.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all 28 existing unit tests pass
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — new fixture code compiles cleanly
- [ ] `./gradlew connectedE2EAndroidTest` — requires device/emulator; Phase 5 will exercise these methods end-to-end

Fixes #160

https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz)_