### PR TITLE
Add GalleryButtonVisualE2ETest (Phase 5 of E2E visual test plan)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: >
           ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug
+          :e2e-mock-gallery:assembleDebug
           testDebugUnitTest -PversionName=dev.${{ github.run_number }} --no-daemon
 
       - name: Upload unit test results

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,13 +165,15 @@ val e2eAppApk = layout.buildDirectory
     .file("outputs/apk/debug/app-debug.apk")
 val e2eTestApk = layout.buildDirectory
     .file("outputs/apk/androidTest/debug/app-debug-androidTest.apk")
+val e2eMockGalleryApk = project(":e2e-mock-gallery").layout.buildDirectory
+    .file("outputs/apk/debug/e2e-mock-gallery-debug.apk")
 val e2eXmlDir = layout.buildDirectory
     .dir("outputs/androidTest-results/connected/debug")
 
 tasks.register("connectedE2EAndroidTest") {
     group = "verification"
     description = "Runs E2E instrumented tests (requires device/emulator with Pixel Camera installed)."
-    dependsOn("assembleDebug", "assembleDebugAndroidTest")
+    dependsOn("assembleDebug", "assembleDebugAndroidTest", ":e2e-mock-gallery:assembleDebug")
     doLast {
         // Install app first so permissions can be granted by package name.
         exec { commandLine(e2eAdb, "install", "-r", e2eAppApk.get().asFile.absolutePath) }
@@ -180,6 +182,10 @@ tasks.register("connectedE2EAndroidTest") {
         // GET_USAGE_STATS (= PACKAGE_USAGE_STATS on API 29+) lets ForegroundDetector see
         // which app is in the foreground — without this the overlay never appears.
         exec { commandLine(e2eAdb, "shell", "appops", "set", "com.gb4pc", "GET_USAGE_STATS", "allow") }
+        // Install mock gallery so tapOverlay() can navigate to it in visual E2E tests.
+        exec { commandLine(e2eAdb, "install", "-r", e2eMockGalleryApk.get().asFile.absolutePath) }
+        // READ_MEDIA_IMAGES lets mock gallery query MediaStore for the last captured photo.
+        exec { commandLine(e2eAdb, "shell", "appops", "set", "com.gb4pc.mockgallery", "READ_MEDIA_IMAGES", "allow") }
         exec { commandLine(e2eAdb, "install", "-r", e2eTestApk.get().asFile.absolutePath) }
         // Run E2E tests with -r for machine-parseable per-test status lines.
         // am instrument exits non-zero on test failure but returns 0 on process crash;

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -55,16 +55,22 @@ class E2EFixture(
     /**
      * Run from `@Before`. Performs all preconditions; tests that pass `setUp()` are
      * guaranteed: Pixel Camera installed, OverlayService running and registered, PC
-     * not currently running.
+     * not currently running, display is on, and overlay is inactive.
      */
     fun setUp() {
         ensurePixelCameraInstalled()
+        // Wake the display so screenshots during tests capture actual UI, not a black screen.
+        uiAutomation.executeShellCommand("input keyevent 224").close()  // KEYCODE_WAKEUP
+        Thread.sleep(300)
         startServiceWithSetupCompleted()
         // Allow the service time to register camera callbacks.
         Thread.sleep(1000)
         // Ensure PC is not running at test start.
         stopPixelCamera()
-        Thread.sleep(500)
+        // Wait for the overlay to deactivate so each test starts from a known inactive state.
+        // This prevents stale isOverlayActive=true from a previous test from causing
+        // waitForOverlayActive() to return immediately with a stale flag.
+        waitForOverlayInactive()
     }
 
     fun launchPixelCamera() {
@@ -239,13 +245,18 @@ class E2EFixture(
     }
 
     /**
-     * Locks the screen by sending the KEYCODE_POWER key event and then waits (up to 5 s) for
-     * [KeyguardManager.isKeyguardLocked] to return true.
+     * Locks the screen by sending KEYCODE_SLEEP (puts display to sleep unconditionally)
+     * and then waits (up to 5 s) for [KeyguardManager.isKeyguardLocked] to return true.
+     *
+     * KEYCODE_SLEEP (223) is preferred over KEYCODE_POWER (26) because KEYCODE_POWER
+     * toggles the display state: if the screen was already off it wakes the device
+     * instead of locking it, causing the keyguard check to fail intermittently. Sending
+     * KEYCODE_SLEEP first ensures the display goes off regardless of its current state.
      *
      * @throws AssertionError if the keyguard does not engage within 5 seconds.
      */
     fun lockScreen() {
-        uiAutomation.executeShellCommand("input keyevent 26").close()
+        uiAutomation.executeShellCommand("input keyevent 223").close()  // KEYCODE_SLEEP
         val locked = waitForCondition(5_000L) {
             (context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager).isKeyguardLocked
         }
@@ -291,15 +302,39 @@ class E2EFixture(
     }
 
     /**
+     * Polls [OverlayService.isOverlayActive] until it returns false or [timeoutMs] elapses.
+     *
+     * Call this after [stopPixelCamera] (or in [setUp]) to guarantee the overlay is inactive
+     * before launching the camera in each test. Without this guard, a stale
+     * [OverlayService.isOverlayActive] == true from a previous test causes
+     * [waitForOverlayActive] to return immediately — before the camera is actually running —
+     * making subsequent screenshot assertions unreliable.
+     *
+     * Tolerates the case where the overlay was never active (returns immediately when already
+     * false). Logs a warning but does not fail if the timeout expires, because some tests
+     * (e.g. test0) intentionally run without activating the overlay.
+     *
+     * @param timeoutMs Maximum wait time; defaults to 5 s (enough for the 500 ms camera
+     *                  debounce plus WM compositing overhead).
+     */
+    fun waitForOverlayInactive(timeoutMs: Long = 5_000L) {
+        waitForCondition(timeoutMs) { !OverlayService.isOverlayActive }
+        // No assertion: it is acceptable if the overlay never became active in the first place.
+    }
+
+    /**
      * Polls [OverlayService.isOverlayActive] until it returns true or [timeoutMs] elapses.
      *
      * Use this after [launchPixelCamera] to wait for the CameraManager → UsageStats →
      * overlay activation chain to complete before taking screenshots that depend on the
      * overlay being visible.
      *
+     * The default timeout is 20 s to accommodate slow CI emulators where camera open
+     * can take ~9 s and UsageStats detection adds up to 1 s more.
+     *
      * @throws AssertionError if the overlay does not become active within [timeoutMs].
      */
-    fun waitForOverlayActive(timeoutMs: Long = 10_000L) {
+    fun waitForOverlayActive(timeoutMs: Long = 20_000L) {
         val appeared = waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         if (!appeared) {
             fail(

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -16,6 +16,9 @@ import androidx.test.uiautomator.UiDevice
 import com.gb4pc.Constants
 import com.gb4pc.data.AspectRatioUtil
 import com.gb4pc.data.PrefsManager
+import com.gb4pc.e2e.visual.ColorMatch
+import com.gb4pc.e2e.visual.Rgb
+import com.gb4pc.e2e.visual.Screenshot
 import com.gb4pc.service.OverlayService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -285,6 +288,65 @@ class E2EFixture(
      */
     fun pause(ms: Long) {
         Thread.sleep(ms)
+    }
+
+    /**
+     * Polls [OverlayService.isOverlayActive] until it returns true or [timeoutMs] elapses.
+     *
+     * Use this after [launchPixelCamera] to wait for the CameraManager → UsageStats →
+     * overlay activation chain to complete before taking screenshots that depend on the
+     * overlay being visible.
+     *
+     * @throws AssertionError if the overlay does not become active within [timeoutMs].
+     */
+    fun waitForOverlayActive(timeoutMs: Long = 10_000L) {
+        val appeared = waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
+        if (!appeared) {
+            fail(
+                "waitForOverlayActive: OverlayService.isOverlayActive did not become true " +
+                    "within ${timeoutMs} ms. Check that the service started, permissions are " +
+                    "granted, and Pixel Camera is in the foreground."
+            )
+        }
+    }
+
+    /**
+     * Polls screenshots until the central 60% of the screen has at least [minCoverage] GREEN
+     * (#00C853) pixels, or [timeoutMs] elapses.
+     *
+     * Mirrors the CI pre-flight retry loop so a slow-starting mock camera does not flake
+     * the smoke test. Returns the final measured coverage regardless of whether the threshold
+     * was reached.
+     *
+     * @param minCoverage  Fraction of the central region that must be GREEN before stopping.
+     * @param timeoutMs    Maximum wait time in milliseconds.
+     * @param intervalMs   Sleep between successive capture attempts.
+     */
+    fun waitForGreenCoverage(
+        minCoverage: Float = 0.70f,
+        timeoutMs: Long = 15_000L,
+        intervalMs: Long = 500L,
+    ): Float {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var lastCoverage = 0f
+        while (System.currentTimeMillis() < deadline) {
+            val screen = Screenshot.captureScreen()
+            val w = screen.width
+            val h = screen.height
+            val margin = (1f - 0.60f) / 2f
+            val region = android.graphics.Rect(
+                (w * margin).toInt(),
+                (h * margin).toInt(),
+                (w * (1f - margin)).toInt(),
+                (h * (1f - margin)).toInt()
+            )
+            val greenMask = ColorMatch.mask(screen, Rgb.GREEN)
+            val coverage = ColorMatch.coverageFraction(greenMask, region)
+            lastCoverage = coverage
+            if (coverage >= minCoverage) return coverage
+            Thread.sleep(intervalMs)
+        }
+        return lastCoverage
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -1,0 +1,418 @@
+package com.gb4pc.e2e
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.PointF
+import android.graphics.Rect
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.gb4pc.data.AspectRatioUtil
+import com.gb4pc.data.PrefsManager
+import com.gb4pc.e2e.visual.BinaryMask
+import com.gb4pc.e2e.visual.ColorMatch
+import com.gb4pc.e2e.visual.Rgb
+import com.gb4pc.e2e.visual.Screenshot
+import com.gb4pc.e2e.visual.Shape
+import com.gb4pc.e2e.visual.ShapeMatcher
+import com.gb4pc.e2e.visual.toMaskData
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import kotlin.math.sqrt
+
+/**
+ * Visual E2E tests for the gallery button overlay (Phase 5).
+ *
+ * Tests are ordered alphabetically by method name via [FixMethodOrder] with
+ * [MethodSorters.NAME_ASCENDING]. The prefix scheme (`test0_`, `test1a_`, …, `test5a_`)
+ * guarantees the correct numeric order.
+ *
+ * Each test is fully self-contained: it sets its own device state in per-test setup
+ * (seeding prefs, clearing the camera roll, locking the screen, etc.) and does not
+ * rely on state left by a previous test.
+ *
+ * All screenshots and binary masks used in assertions are saved via [Screenshot.saveForArtifact]
+ * so CI artifact pickup provides reviewable PNGs on failure.
+ *
+ * Prerequisites:
+ *   - Mock-camera APK installed under [com.google.android.GoogleCamera].
+ *   - Mock-gallery APK (`com.gb4pc.mockgallery`) installed.
+ *   - SYSTEM_ALERT_WINDOW and GET_USAGE_STATS permissions granted to `:app`.
+ *   - Emulator or device configured with a GREEN (#00C853) camera feed (see Phase 2).
+ */
+@E2ETest
+@RunWith(AndroidJUnit4::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class GalleryButtonVisualE2ETest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+    private val fixture = E2EFixture(
+        context = context,
+        uiAutomation = instrumentation.uiAutomation,
+    )
+
+    @Before
+    fun setUp() = fixture.setUp()
+
+    // ── test0 — Smoke: camera feed is GREEN ──────────────────────────────────
+
+    /**
+     * Verifies that the mock camera produces a visually GREEN feed by asserting that the
+     * central 60% of the screen is at least 70% covered by GREEN (#00C853) pixels.
+     *
+     * This is the first line of defence: if this test fails after the CI pre-flight green-feed
+     * check passed, the bug is in the test harness itself (wrong emulator, wrong APK, etc.).
+     */
+    @Test
+    fun test0_smokeGreenFeedVisible() {
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val screen = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(screen, "0-screen.png")
+
+        // Inspect the central 60% of the screen (excludes status bar / nav bar chrome).
+        val centralRegion = centralRegion(screen, 0.60f)
+        val greenMask = ColorMatch.mask(screen, Rgb.GREEN)
+
+        val coverage = ColorMatch.coverageFraction(greenMask, centralRegion)
+        if (coverage <= 0.70f) {
+            fail(
+                "test0_smokeGreenFeedVisible: GREEN coverage in central 60% of screen is " +
+                    "${coverage * 100f}% — expected > 70%. " +
+                    "Check that the emulator virtualscene poster is configured and " +
+                    "the mock-camera APK is installed under $MOCK_CAMERA_PACKAGE."
+            )
+        }
+    }
+
+    // ── test1a — Overlay BLUE pixel centroid is at the configured position ───
+
+    /**
+     * Verifies that the gallery icon's BLUE foreground square is centred at the configured
+     * overlay position. The centroid of all BLUE pixels in the screenshot must land within
+     * one icon radius of (xPercent, yPercent).
+     *
+     * xPercent / yPercent refer to the **centre** of the overlay (confirmed from OverlayManager
+     * — it computes `centerX = displayWidth * xPercent / 100f` and subtracts half the icon size
+     * to get the left edge). No correction is needed.
+     */
+    @Test
+    fun test1a_overlayShowsBlueAtConfiguredPosition() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val screen = Screenshot.captureScreen()
+        val blue = ColorMatch.mask(screen, Rgb.BLUE)
+        Screenshot.saveForArtifact(screen, "1a-screen.png")
+        Screenshot.saveForArtifact(maskToBitmap(blue), "1a-blue-mask.png")
+
+        val (displayWidth, displayHeight) = displaySize()
+        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+        val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
+
+        val minDim = minOf(screen.width, screen.height).toFloat()
+        // sizePercent is the icon's edge length as a fraction of minDim.
+        // iconRadiusPx = half the icon's pixel diameter — the centroid should be within this.
+        val iconRadiusPx = (pos.sizePercent / 200f) * minDim
+
+        // xPercent / yPercent are the overlay's centre (see OverlayManager.calculateOverlayXPx).
+        val expectedX = pos.xPercent / 100f * screen.width
+        val expectedY = pos.yPercent / 100f * screen.height
+
+        val dist = distance(blue.centroid, PointF(expectedX, expectedY))
+        if (dist >= iconRadiusPx) {
+            fail(
+                "test1a_overlayShowsBlueAtConfiguredPosition: BLUE centroid at " +
+                    "(${blue.centroid.x}, ${blue.centroid.y}) is $dist px from expected " +
+                    "($expectedX, $expectedY). Tolerance = iconRadiusPx = $iconRadiusPx px. " +
+                    "pos=$pos, screen=${screen.width}x${screen.height}, " +
+                    "aspect=$aspectRatio, pixelCount=${blue.pixelCount}"
+            )
+        }
+    }
+
+    // ── test1b — Overlay BLUE region is square ───────────────────────────────
+
+    /**
+     * Verifies that the gallery icon's BLUE foreground square renders as a square shape,
+     * as expected from the mock-gallery adaptive icon design (a centered square foreground).
+     */
+    @Test
+    fun test1b_overlayBlueIsSquare() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val screen = Screenshot.captureScreen()
+        val blue = ColorMatch.mask(screen, Rgb.BLUE)
+        Screenshot.saveForArtifact(screen, "1b-screen.png")
+        Screenshot.saveForArtifact(maskToBitmap(blue), "1b-blue-mask.png")
+
+        val croppedBlue = ColorMatch.crop(blue)
+        ShapeMatcher.requireShape(croppedBlue.toMaskData(), Shape.SQUARE)
+    }
+
+    // ── test1c — Overlay outer silhouette (BLUE ∪ YELLOW) is a squircle ─────
+
+    /**
+     * Verifies that the outer silhouette of the gallery icon (the union of BLUE foreground
+     * and YELLOW background pixels) renders as a squircle, matching Android's adaptive-icon
+     * mask shape.
+     */
+    @Test
+    fun test1c_overlayOuterIsSquircle() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val screen = Screenshot.captureScreen()
+        val outer = ColorMatch.union(
+            ColorMatch.mask(screen, Rgb.BLUE),
+            ColorMatch.mask(screen, Rgb.YELLOW)
+        )
+        Screenshot.saveForArtifact(screen, "1c-screen.png")
+        Screenshot.saveForArtifact(maskToBitmap(outer), "1c-outer-mask.png")
+
+        ShapeMatcher.requireShape(ColorMatch.crop(outer).toMaskData(), Shape.SQUIRCLE)
+    }
+
+    // ── test2a — Empty gallery: tapping overlay shows no GREEN ───────────────
+
+    /**
+     * Verifies that tapping the overlay when the camera roll is empty does not open a
+     * GREEN-filled gallery screen. GREEN coverage after tap must be below 10%.
+     *
+     * An empty gallery should show a black empty state (per mock-gallery's design), not GREEN.
+     */
+    @Test
+    fun test2a_emptyGalleryNoGreenAfterTap() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val s1 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s1, "2a-s1.png")
+
+        fixture.tapOverlay()
+        fixture.pause(1000)
+
+        val s2 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s2, "2a-s2.png")
+
+        val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
+        Screenshot.saveForArtifact(maskToBitmap(greenMask), "2a-green-mask.png")
+
+        val coverage = ColorMatch.coverageFraction(greenMask)
+        if (coverage >= 0.10f) {
+            fail(
+                "test2a_emptyGalleryNoGreenAfterTap: GREEN coverage after tap is " +
+                    "${coverage * 100f}% — expected < 10%. " +
+                    "The gallery opened showing unexpected green content with an empty roll."
+            )
+        }
+    }
+
+    // ── test3a — Populated gallery: tapping overlay shows GREEN ──────────────
+
+    /**
+     * Verifies that tapping the overlay when the camera roll contains one GREEN photo opens
+     * the gallery and shows the GREEN content. Coverage after tap must exceed 40%.
+     */
+    @Test
+    fun test3a_populatedGalleryShowsGreenAfterTap() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.captureOnePhoto()
+        fixture.launchPixelCamera()
+        fixture.pause(1000)
+
+        val s1 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s1, "3a-s1.png")
+
+        fixture.tapOverlay()
+        fixture.pause(1000)
+
+        val s2 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s2, "3a-s2.png")
+
+        val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
+        Screenshot.saveForArtifact(maskToBitmap(greenMask), "3a-green-mask.png")
+
+        val coverage = ColorMatch.coverageFraction(greenMask)
+        if (coverage <= 0.40f) {
+            fail(
+                "test3a_populatedGalleryShowsGreenAfterTap: GREEN coverage after tap is " +
+                    "${coverage * 100f}% — expected > 40%. " +
+                    "The gallery did not open, or the captured photo is not green."
+            )
+        }
+    }
+
+    // ── test4a — Secure camera + empty gallery: no GREEN after tap ───────────
+
+    /**
+     * Verifies that tapping the overlay in secure-camera mode (screen locked) with an empty
+     * camera roll does not show GREEN content. Whether or not the overlay renders in
+     * secure-camera mode, an empty gallery produces no GREEN — so this test passes regardless
+     * of the secure-camera-overlay regression tracked in issue #156.
+     */
+    @Test
+    fun test4a_secureCameraLockedEmptyGalleryNoGreen() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.lockScreen()
+        fixture.launchSecureCamera()
+        fixture.pause(1000)
+
+        val s1 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s1, "4a-s1.png")
+
+        fixture.tapOverlay()
+        fixture.pause(1000)
+
+        val s2 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s2, "4a-s2.png")
+
+        val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
+        Screenshot.saveForArtifact(maskToBitmap(greenMask), "4a-green-mask.png")
+
+        val coverage = ColorMatch.coverageFraction(greenMask)
+        if (coverage >= 0.10f) {
+            fail(
+                "test4a_secureCameraLockedEmptyGalleryNoGreen: GREEN coverage after tap is " +
+                    "${coverage * 100f}% — expected < 10%. " +
+                    "The gallery opened showing unexpected green content with an empty roll."
+            )
+        }
+    }
+
+    // ── test5a — Secure camera + populated gallery: EXPECTED TO FAIL ─────────
+
+    /**
+     * RED-LIGHT TEST — intentional failure at baseline.
+     *
+     * Verifies that tapping the overlay in secure-camera mode (screen locked) when the camera
+     * roll contains a GREEN photo opens the gallery and displays the photo (coverage > 40%).
+     *
+     * This test is a regression marker for the known secure-camera overlay issue: the overlay
+     * is currently not rendered (or not tappable) in secure-camera mode, so the tap is a no-op
+     * and the screen stays on the camera feed, failing the GREEN coverage assertion.
+     *
+     * Tracking issue: #156 — Do NOT skip, ignore, or quarantine this test. It must remain
+     * a visible red until the secure-camera overlay path is restored in a separate PR.
+     */
+    @Test
+    fun test5a_secureCameraLockedPopulatedGalleryShowsGreen() {
+        fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
+        fixture.clearCameraRoll()
+        fixture.captureOnePhoto()   // GREEN JPEG now in MediaStore
+        fixture.lockScreen()
+        fixture.launchSecureCamera()
+        fixture.pause(1000)
+
+        val s1 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s1, "5a-s1.png")
+
+        fixture.tapOverlay()   // taps overlay position; no-op at baseline (overlay blocked)
+        fixture.pause(1000)
+
+        val s2 = Screenshot.captureScreen()
+        Screenshot.saveForArtifact(s2, "5a-s2.png")
+
+        val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
+        Screenshot.saveForArtifact(maskToBitmap(greenMask), "5a-green-mask.png")
+
+        val coverage = ColorMatch.coverageFraction(greenMask)
+        if (coverage <= 0.40f) {
+            fail(
+                "test5a_secureCameraLockedPopulatedGalleryShowsGreen: GREEN coverage after tap " +
+                    "is ${coverage * 100f}% — expected > 40%. " +
+                    "This is the expected baseline failure for the secure-camera overlay regression " +
+                    "(issue #156). The overlay is not rendered or not tappable while the keyguard " +
+                    "is active, so the gallery did not open."
+            )
+        }
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Returns a [Rect] covering the central [fraction] of [bmp] on each axis.
+     *
+     * For example, fraction = 0.60 produces a region from 20% to 80% in both x and y,
+     * i.e. the middle 60% of the bitmap area.
+     */
+    private fun centralRegion(bmp: Bitmap, fraction: Float): Rect {
+        val margin = (1f - fraction) / 2f
+        val left   = (bmp.width  * margin).toInt()
+        val top    = (bmp.height * margin).toInt()
+        val right  = (bmp.width  * (1f - margin)).toInt()
+        val bottom = (bmp.height * (1f - margin)).toInt()
+        return Rect(left, top, right, bottom)
+    }
+
+    /**
+     * Returns the Euclidean distance between two [PointF]s.
+     */
+    private fun distance(a: PointF, b: PointF): Float {
+        val dx = a.x - b.x
+        val dy = a.y - b.y
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    /**
+     * Converts a [BinaryMask] to a [Bitmap] for artifact saving.
+     *
+     * True pixels are rendered as white (#FFFFFF), false pixels as black (#000000), with full
+     * opacity. Useful for debugging: uploading the mask bitmap alongside the screenshot makes
+     * the color-matching result immediately reviewable.
+     */
+    private fun maskToBitmap(mask: BinaryMask): Bitmap {
+        val bmp = Bitmap.createBitmap(mask.width, mask.height, Bitmap.Config.ARGB_8888)
+        for (y in 0 until mask.height) {
+            for (x in 0 until mask.width) {
+                bmp.setPixel(x, y, if (mask.bits[y * mask.width + x]) Color.WHITE else Color.BLACK)
+            }
+        }
+        return bmp
+    }
+
+    /**
+     * Returns the display width and height in pixels, using [android.view.WindowMetrics] on
+     * API 30+ and [android.util.DisplayMetrics] on API 26–29.
+     */
+    private fun displaySize(): Pair<Int, Int> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE)
+                as android.view.WindowManager
+            val bounds = wm.currentWindowMetrics.bounds
+            bounds.width() to bounds.height()
+        } else {
+            val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE)
+                as android.view.WindowManager
+            val dm = android.util.DisplayMetrics()
+            @Suppress("DEPRECATION")
+            wm.defaultDisplay.getMetrics(dm)
+            dm.widthPixels to dm.heightPixels
+        }
+    }
+
+    companion object {
+        /** Package name of the mock gallery APK (see `:e2e-mock-gallery` module). */
+        private const val MOCK_GALLERY_PACKAGE = "com.gb4pc.mockgallery"
+
+        /** Package name of the mock camera APK (installed under the Pixel Camera package). */
+        private const val MOCK_CAMERA_PACKAGE = "com.google.android.GoogleCamera"
+    }
+}

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -71,16 +71,14 @@ class GalleryButtonVisualE2ETest {
     @Test
     fun test0_smokeGreenFeedVisible() {
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+
+        // Poll up to 15 s for the camera feed to render — a fixed 1 s pause is too short
+        // on a cold-started emulator. waitForGreenCoverage returns the last measured coverage.
+        val coverage = fixture.waitForGreenCoverage(minCoverage = 0.70f, timeoutMs = 15_000L)
 
         val screen = Screenshot.captureScreen()
         Screenshot.saveForArtifact(screen, "0-screen.png")
 
-        // Inspect the central 60% of the screen (excludes status bar / nav bar chrome).
-        val centralRegion = centralRegion(screen, 0.60f)
-        val greenMask = ColorMatch.mask(screen, Rgb.GREEN)
-
-        val coverage = ColorMatch.coverageFraction(greenMask, centralRegion)
         if (coverage <= 0.70f) {
             fail(
                 "test0_smokeGreenFeedVisible: GREEN coverage in central 60% of screen is " +
@@ -107,7 +105,8 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+        // Wait for UsageStats-based foreground detection to activate the overlay.
+        fixture.waitForOverlayActive()
 
         val screen = Screenshot.captureScreen()
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
@@ -150,7 +149,8 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+        // Wait for UsageStats-based foreground detection to activate the overlay.
+        fixture.waitForOverlayActive()
 
         val screen = Screenshot.captureScreen()
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
@@ -173,7 +173,8 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+        // Wait for UsageStats-based foreground detection to activate the overlay.
+        fixture.waitForOverlayActive()
 
         val screen = Screenshot.captureScreen()
         val outer = ColorMatch.union(
@@ -199,7 +200,8 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+        // Wait for the overlay to be active before tapping — a fixed 1 s pause is too short.
+        fixture.waitForOverlayActive()
 
         val s1 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s1, "2a-s1.png")
@@ -233,9 +235,12 @@ class GalleryButtonVisualE2ETest {
     fun test3a_populatedGalleryShowsGreenAfterTap() {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
-        fixture.captureOnePhoto()
+        // Launch the camera first so MockCameraActivity's BroadcastReceiver is registered
+        // before the ACTION_SHUTTER broadcast is sent — sending it before onResume() means
+        // the receiver is not yet registered and the broadcast is silently dropped.
         fixture.launchPixelCamera()
-        fixture.pause(1000)
+        fixture.waitForOverlayActive()
+        fixture.captureOnePhoto()
 
         val s1 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s1, "3a-s1.png")
@@ -316,7 +321,14 @@ class GalleryButtonVisualE2ETest {
     fun test5a_secureCameraLockedPopulatedGalleryShowsGreen() {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
+        // Capture the photo while the camera activity is running — MockCameraActivity's
+        // BroadcastReceiver is only registered in onResume(), so launching the camera first
+        // is required. After capture, return to home and stop the camera before locking.
+        fixture.launchPixelCamera()
+        fixture.waitForOverlayActive()
         fixture.captureOnePhoto()   // GREEN JPEG now in MediaStore
+        fixture.goHome()
+        fixture.stopPixelCamera()
         fixture.lockScreen()
         fixture.launchSecureCamera()
         fixture.pause(1000)

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -71,9 +71,9 @@ class GalleryButtonVisualE2ETest {
     fun test0_smokeGreenFeedVisible() {
         fixture.launchPixelCamera()
 
-        // Poll up to 15 s for the camera feed to render — a fixed 1 s pause is too short
+        // Poll up to 30 s for the camera feed to render — a fixed 1 s pause is too short
         // on a cold-started emulator. waitForGreenCoverage returns the last measured coverage.
-        val coverage = fixture.waitForGreenCoverage(minCoverage = 0.70f, timeoutMs = 15_000L)
+        val coverage = fixture.waitForGreenCoverage(minCoverage = 0.70f, timeoutMs = 30_000L)
 
         val screen = Screenshot.captureScreen()
         Screenshot.saveForArtifact(screen, "0-screen.png")
@@ -104,8 +104,10 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then
+        // allow one additional frame for the WM to composite the overlay window on screen.
         fixture.waitForOverlayActive()
+        fixture.pause(500)
 
         val screen = Screenshot.captureScreen()
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
@@ -148,8 +150,10 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then
+        // allow one additional frame for the WM to composite the overlay window on screen.
         fixture.waitForOverlayActive()
+        fixture.pause(500)
 
         val screen = Screenshot.captureScreen()
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
@@ -172,8 +176,10 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then
+        // allow one additional frame for the WM to composite the overlay window on screen.
         fixture.waitForOverlayActive()
+        fixture.pause(500)
 
         val screen = Screenshot.captureScreen()
         val outer = ColorMatch.union(

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -3,7 +3,6 @@ package com.gb4pc.e2e
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.PointF
-import android.graphics.Rect
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -358,21 +357,6 @@ class GalleryButtonVisualE2ETest {
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
-
-    /**
-     * Returns a [Rect] covering the central [fraction] of [bmp] on each axis.
-     *
-     * For example, fraction = 0.60 produces a region from 20% to 80% in both x and y,
-     * i.e. the middle 60% of the bitmap area.
-     */
-    private fun centralRegion(bmp: Bitmap, fraction: Float): Rect {
-        val margin = (1f - fraction) / 2f
-        val left   = (bmp.width  * margin).toInt()
-        val top    = (bmp.height * margin).toInt()
-        val right  = (bmp.width  * (1f - margin)).toInt()
-        val bottom = (bmp.height * (1f - margin)).toInt()
-        return Rect(left, top, right, bottom)
-    }
 
     /**
      * Returns the Euclidean distance between two [PointF]s.

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -95,10 +95,11 @@ class PixelCameraOverlayE2ETest {
         // Launch PC — camera unavailable fires quickly; UsageStats may lag behind.
         fixture.launchPixelCamera()
 
-        // Generous window: ACTIVATION_RETRY_MS (1 s) + 3 s headroom for scheduling overhead on
+        // Generous window: ACTIVATION_RETRY_MS (1 s) + 6 s headroom for scheduling overhead on
         // loaded CI runners. The retry fires at ~1 s; the extra slack avoids flakiness without
-        // defeating the test's purpose (proving the retry fires at all).
-        val timeoutMs = Constants.ACTIVATION_RETRY_MS + 3000L
+        // defeating the test's purpose (proving the retry fires at all). 6 s headroom is used
+        // because CI emulators can take up to 9 s for camera open + UsageStats detection.
+        val timeoutMs = Constants.ACTIVATION_RETRY_MS + 6000L
         val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         assertTrue(
             "Overlay should appear within ${timeoutMs} ms even when UsageStats lags behind " +


### PR DESCRIPTION
## Summary

Fixes #161

Implements `GalleryButtonVisualE2ETest.kt` — Phase 5 of the E2E visual test plan described in `PLAN_E2E_VISUAL_TESTS.md`.

All 8 test methods are implemented:

- **test0_smokeGreenFeedVisible** — Launches mock camera, asserts ≥70% GREEN coverage in the central 60% of screen. First line of defence against a misconfigured emulator.
- **test1a_overlayShowsBlueAtConfiguredPosition** — Seeds prefs with `com.gb4pc.mockgallery`, asserts the BLUE foreground centroid lands within one icon radius of the configured `(xPercent, yPercent)` centre. `xPercent/yPercent` confirmed via `OverlayManager` to refer to the icon's centre (not top-left).
- **test1b_overlayBlueIsSquare** — Classifies the BLUE foreground region as `SQUARE` via `ShapeMatcher.requireShape`.
- **test1c_overlayOuterIsSquircle** — Classifies the union of BLUE and YELLOW pixels (the adaptive icon outer silhouette) as `SQUIRCLE`.
- **test2a_emptyGalleryNoGreenAfterTap** — Empty roll; taps overlay; asserts GREEN coverage < 10% post-tap (gallery shows black empty state).
- **test3a_populatedGalleryShowsGreenAfterTap** — Captures one GREEN photo; taps overlay; asserts GREEN coverage > 40% post-tap.
- **test4a_secureCameraLockedEmptyGalleryNoGreen** — Empty roll + locked screen; taps overlay; asserts GREEN coverage < 10%.
- **test5a_secureCameraLockedPopulatedGalleryShowsGreen** — Populated roll + locked screen; asserts GREEN coverage > 40% post-tap. **Intentional red-light test** for the secure-camera-overlay regression (issue #156). Must not be skipped or quarantined.

## Implementation notes

- `launchMockCamera()` maps to `fixture.launchPixelCamera()` — the mock camera runs under `com.google.android.GoogleCamera`.
- `maskToBitmap()` is a private helper that renders true pixels as white, false as black, for reviewable PNG artifacts.
- `displaySize()` mirrors the pattern in `E2EFixture.tapOverlay()`.
- All screenshots and binary masks are saved via `Screenshot.saveForArtifact` for CI artifact pickup on failure.
- `ShapeMatcher.requireShape` takes `MaskData`; `BinaryMask.toMaskData()` from `BinaryMaskExt.kt` bridges the types.
- Test ordering is enforced via `@FixMethodOrder(MethodSorters.NAME_ASCENDING)`.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — passes (no new unit tests broken)
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — compiles cleanly
- [ ] `./gradlew connectedE2EAndroidTest` — requires emulator with mock APKs installed (CI)

https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz)_