### PR TITLE
ci: upload E2E screenshots as artifact when build-and-test fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,22 @@ jobs:
             exit 1
           }
 
+      - name: Pull E2E screenshots from emulator
+        if: failure() && steps.diff_check.outputs.needs_full_build == 'true'
+        run: |
+          mkdir -p e2e-screenshots
+          $ANDROID_HOME/platform-tools/adb pull \
+            /sdcard/Android/data/com.gb4pc/files/screenshots/ \
+            e2e-screenshots/ || true
+
+      - name: Upload E2E screenshots on failure
+        if: failure() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots-failure
+          path: e2e-screenshots/
+          retention-days: 14
+
       - name: Kill emulator
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         run: |


### PR DESCRIPTION
## Summary

Fixes #168

- Adds a **Pull E2E screenshots from emulator** step that runs `adb pull /sdcard/Android/data/com.gb4pc/files/screenshots/` into a local `e2e-screenshots/` directory whenever the `build-and-test` job fails.
- Adds an **Upload E2E screenshots on failure** step that uploads that directory as the `e2e-screenshots-failure` artifact (retained 14 days), consistent with the path specified in `PLAN_E2E_VISUAL_TESTS.md` Phase 6.
- Both steps use `if: failure() && steps.diff_check.outputs.needs_full_build == 'true'` — they fire only on job failure and only when there are non-docs code changes, matching the gate used by every other expensive step in the job.
- The pull step is placed **before Kill emulator** so the emulator is still reachable when the screenshots are fetched.

## Test plan

- [ ] Confirm YAML is valid: `python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)" < .github/workflows/build.yml`
- [ ] On a PR that causes an E2E test failure, verify the `e2e-screenshots-failure` artifact appears in the Actions run summary.
- [ ] On a passing run, verify the artifact is not uploaded (step is skipped).
- [ ] On a docs-only PR (`needs_full_build == false`), verify neither step runs.

https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsAPS3ti9ru8te84FTGAFz)_