### PR TITLE
Export shutter receiver and drop setPackage to unblock cross-UID broadcast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,9 +292,9 @@ jobs:
           }
 
       - name: Run GalleryButtonVisualE2ETest
-        # Known failures tracked in #177 (RECEIVER_NOT_EXPORTED), #178 (emulator
-        # keyguard not engaging), #179 (adaptive-icon colour/shape). continue-on-error
-        # keeps the job green until those are fixed.
+        # Known failures tracked in #178 (emulator keyguard not engaging) and
+        # #179 (adaptive-icon colour/shape). continue-on-error keeps the job
+        # green until those are fixed.
         if: steps.diff_check.outputs.needs_full_build == 'true'
         continue-on-error: true
         run: |

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -178,7 +178,16 @@ class E2EFixture(
         }
         val filter = IntentFilter(actionShutterDone)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            // RECEIVER_EXPORTED is required so MockCameraActivity (running under the
+            // Pixel Camera UID, com.google.android.GoogleCamera) can deliver
+            // ACTION_SHUTTER_DONE across UIDs back into this test process (com.gb4pc).
+            // On API 33+ RECEIVER_NOT_EXPORTED silently drops cross-UID broadcasts,
+            // which would cause the latch to time out and the test to fall back to
+            // MediaStore/MediaScanner polling — defeating the intent of the
+            // ACTION_SHUTTER_DONE handshake. The receiver is only registered inside
+            // the instrumented E2E test process and ACTION_SHUTTER_DONE is a private
+            // action string, so exporting the receiver carries no production risk.
+            context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
         } else {
             @Suppress("UnspecifiedRegisterReceiverFlag")
             context.registerReceiver(receiver, filter)

--- a/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
+++ b/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
@@ -125,10 +125,15 @@ class MockCameraActivity : Activity() {
         super.onResume()
         startCameraThread()
         openCamera()
+        // RECEIVER_EXPORTED is required so the E2E test process (com.gb4pc UID) can
+        // deliver ACTION_SHUTTER across UIDs into this activity (com.google.android.GoogleCamera).
+        // On API 33+ RECEIVER_NOT_EXPORTED silently drops cross-UID broadcasts. This APK is
+        // installed only on test emulators and ACTION_SHUTTER is a private action string, so
+        // exporting the receiver carries no production risk.
         registerReceiver(
             shutterReceiver,
             IntentFilter(ACTION_SHUTTER),
-            Context.RECEIVER_NOT_EXPORTED,
+            Context.RECEIVER_EXPORTED,
         )
     }
 
@@ -253,8 +258,10 @@ class MockCameraActivity : Activity() {
     }
 
     private fun broadcastShutterDone(uri: Uri?) {
+        // Intentionally do NOT call setPackage(packageName): the listener is the E2E test
+        // process (com.gb4pc), not this APK. setPackage(com.google.android.GoogleCamera)
+        // would restrict delivery to this package and starve the test's latch receiver.
         val intent = Intent(ACTION_SHUTTER_DONE).apply {
-            setPackage(packageName)
             if (uri != null) putExtra(EXTRA_IMAGE_URI, uri)
         }
         sendBroadcast(intent)

--- a/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
+++ b/e2e-mock-camera/src/main/java/com/gb4pc/mockcamera/MockCameraActivity.kt
@@ -82,6 +82,13 @@ class MockCameraActivity : Activity() {
         }
     }
 
+    /**
+     * True only after a successful [registerReceiver]. Tracked so [onPause] does not call
+     * [unregisterReceiver] when registration threw, which would itself throw
+     * `IllegalArgumentException: Receiver not registered` and mask the original error.
+     */
+    private var shutterReceiverRegistered = false
+
     // -------------------------------------------------------------------------
     // CameraDevice state callback
     // -------------------------------------------------------------------------
@@ -130,16 +137,33 @@ class MockCameraActivity : Activity() {
         // On API 33+ RECEIVER_NOT_EXPORTED silently drops cross-UID broadcasts. This APK is
         // installed only on test emulators and ACTION_SHUTTER is a private action string, so
         // exporting the receiver carries no production risk.
-        registerReceiver(
-            shutterReceiver,
-            IntentFilter(ACTION_SHUTTER),
-            Context.RECEIVER_EXPORTED,
-        )
+        //
+        // The registration is wrapped in try/catch because an uncaught exception here would
+        // bubble out of onResume() and crash the activity *after* the window has been
+        // created but *before* the green View has been composed to the surface, leaving
+        // the CI pre-flight smoke check (and the rest of the E2E suite) staring at the
+        // system default window background instead of #00C853. The shutter handshake is
+        // only needed by the capture tests; the smoke check and the
+        // ForegroundDetector/overlay path do not depend on it, so a failed registration
+        // must not prevent the activity from rendering.
+        try {
+            registerReceiver(
+                shutterReceiver,
+                IntentFilter(ACTION_SHUTTER),
+                Context.RECEIVER_EXPORTED,
+            )
+            shutterReceiverRegistered = true
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "onResume: shutter receiver registration failed: ${e.message}", e)
+        }
     }
 
     override fun onPause() {
         super.onPause()
-        unregisterReceiver(shutterReceiver)
+        if (shutterReceiverRegistered) {
+            unregisterReceiver(shutterReceiver)
+            shutterReceiverRegistered = false
+        }
         closeCamera()
         stopCameraThread()
     }


### PR DESCRIPTION
## Summary

Fixes #177.

`E2EFixture.captureOnePhoto()` (running in the `com.gb4pc` test UID) sends `ACTION_SHUTTER` to `MockCameraActivity` (running in `com.google.android.GoogleCamera`). On API 33+ the receiver was registered with `Context.RECEIVER_NOT_EXPORTED`, so the broadcast was silently dropped across the UID boundary; the activity never wrote a photo to MediaStore and the test stalled until its 15 s timeout.

The reverse direction had the mirror-image problem: `MockCameraActivity.broadcastShutterDone()` called `setPackage(packageName)`, restricting `ACTION_SHUTTER_DONE` delivery to the mock-camera package — the test's latch receiver in `com.gb4pc` never fired.

This PR applies fix options 1 + 2 from the issue:

1. Register the `ACTION_SHUTTER` receiver with `Context.RECEIVER_EXPORTED` so the test process can deliver shutter triggers across UIDs.
2. Drop the `setPackage(packageName)` call from `broadcastShutterDone()` so the completion broadcast can reach a receiver in another package.

This APK is only installed on test emulators and the action strings are private, so exporting the receiver carries no production risk.

A follow-up commit removes the resolved `#177` reference from the `Run GalleryButtonVisualE2ETest` workflow comment. `continue-on-error: true` stays in place because #178 and #179 are still open.

## Test plan

- [x] `./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug :e2e-mock-gallery:assembleDebug testDebugUnitTest` — passes locally.
- [ ] CI runs `test3a_populatedGalleryShowsGreenAfterTap` and `test5a_secureCameraLockedPopulatedGalleryShowsGreen` against an API-35 emulator and they complete within their 15 s captureOnePhoto budget instead of timing out.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Y2potcCXdQG168MVTEKYY)_