### PR TITLE
Set lock-screen PIN in E2E emulator setup so keyguard engages on sleep

### DIFF
--- a/scripts/setup-e2e-emulator.sh
+++ b/scripts/setup-e2e-emulator.sh
@@ -2,8 +2,8 @@
 # setup-e2e-emulator.sh — Prepare an Android emulator for E2E tests.
 #
 # Usage:
-#   scripts/setup-e2e-emulator.sh            # Full local setup (steps 1–6)
-#   scripts/setup-e2e-emulator.sh --post-boot # CI post-boot setup only (steps 4–6)
+#   scripts/setup-e2e-emulator.sh            # Full local setup (steps 1–7)
+#   scripts/setup-e2e-emulator.sh --post-boot # CI post-boot setup only (steps 4–7)
 #
 # Full setup (local):
 #   1. Create AVD (API 35, Google APIs, x86_64, Pixel_6 skin)
@@ -12,11 +12,15 @@
 #   4. Grant GET_USAGE_STATS to GB4PC
 #   5. Grant SYSTEM_ALERT_WINDOW to GB4PC
 #   6. Disable animations
+#   7. Set lock-screen PIN (so the keyguard actually engages on sleep)
 #
 # Post-boot setup (CI): the emulator is already running and all system services
-# have been verified ready by the workflow; this script performs steps 4–6 only.
+# have been verified ready by the workflow; this script performs steps 4–7 only.
 # Mock Pixel Camera (e2e-mock-camera) is installed separately by the CI workflow
 # and by the connectedE2EAndroidTest Gradle task.
+#
+# To clear the PIN after the test run (e.g. for a clean local AVD), run:
+#   adb shell locksettings clear --old 1234
 #
 # Prerequisites:
 #   - ANDROID_HOME (or ANDROID_SDK_ROOT) must be set
@@ -135,6 +139,24 @@ echo "==> Disabling animations..."
 "$ADB" shell settings put global window_animation_scale 0
 "$ADB" shell settings put global transition_animation_scale 0
 "$ADB" shell settings put global animator_duration_scale 0
+
+# ── Step 7: Set lock-screen PIN ─────────────────────────────────────────────
+# Without a lock-screen credential the keyguard never engages on the CI
+# emulator: KEYCODE_SLEEP turns the display off but KeyguardManager.isKeyguardLocked
+# remains false, so E2EFixture.lockScreen() times out (issue #178).
+# Setting a PIN makes the keyguard secure, so it engages whenever the display
+# sleeps. The PIN itself is never entered by the tests — they only rely on the
+# keyguard being locked. Clear the PIN with `locksettings clear --old 1234`
+# if you need to remove it later (the AVD is otherwise idempotent).
+#
+# `locksettings set-pin` rejects a new PIN if one is already configured unless
+# `--old` is supplied. For idempotency across re-runs of --post-boot on a
+# persistent local AVD, try the bare form first and fall back to `--old 1234`
+# (which is a no-op when the PIN is already 1234). Either path leaves the AVD
+# with PIN=1234, which is all the keyguard needs to engage on sleep.
+echo "==> Setting lock-screen PIN (1234) so keyguard engages on sleep..."
+"$ADB" shell locksettings set-pin 1234 || \
+    "$ADB" shell locksettings set-pin --old 1234 1234
 
 echo ""
 echo "==> E2E emulator setup complete. Run E2E tests with:"

--- a/scripts/setup-e2e-emulator.sh
+++ b/scripts/setup-e2e-emulator.sh
@@ -13,9 +13,11 @@
 #   5. Grant SYSTEM_ALERT_WINDOW to GB4PC
 #   6. Disable animations
 #   7. Set lock-screen PIN (so the keyguard actually engages on sleep)
+#   8. Dismiss the keyguard (setting the PIN engages it; leaving it engaged
+#      would block activity launches from non-lockScreen tests)
 #
 # Post-boot setup (CI): the emulator is already running and all system services
-# have been verified ready by the workflow; this script performs steps 4–7 only.
+# have been verified ready by the workflow; this script performs steps 4–8 only.
 # Mock Pixel Camera (e2e-mock-camera) is installed separately by the CI workflow
 # and by the connectedE2EAndroidTest Gradle task.
 #
@@ -157,6 +159,21 @@ echo "==> Disabling animations..."
 echo "==> Setting lock-screen PIN (1234) so keyguard engages on sleep..."
 "$ADB" shell locksettings set-pin 1234 || \
     "$ADB" shell locksettings set-pin --old 1234 1234
+
+# ── Step 8: Dismiss the (now-secure) keyguard ───────────────────────────────
+# Setting a PIN engages the keyguard immediately on API 35, even with the
+# display on. If we leave it engaged here, the next `am start STILL_IMAGE_CAMERA`
+# from a test (e.g. PixelCameraOverlayE2ETest.overlayAppearsWhenViewfinderOpens)
+# is force-removed by WindowManager because the activity is launched under the
+# lock screen — the test then times out waiting for the overlay.
+# Wake the display, request keyguard dismissal, type the PIN, and submit ENTER.
+# The CI workflow's `stay_on_while_plugged_in 7` then keeps the keyguard
+# dismissed until a test explicitly calls KEYCODE_SLEEP (E2EFixture.lockScreen).
+echo "==> Dismissing keyguard so subsequent tests can launch activities..."
+"$ADB" shell input keyevent 224                 # KEYCODE_WAKEUP
+"$ADB" shell wm dismiss-keyguard
+"$ADB" shell input text 1234
+"$ADB" shell input keyevent 66                  # KEYCODE_ENTER
 
 echo ""
 echo "==> E2E emulator setup complete. Run E2E tests with:"


### PR DESCRIPTION
## Summary

Fixes #178.

`E2EFixture.lockScreen()` sends `KEYCODE_SLEEP` and polls `KeyguardManager.isKeyguardLocked` for up to 5 s. On the CI emulator (`system-images;android-35;google_apis;x86_64`) there is no lock-screen credential, so `KEYCODE_SLEEP` turns the display off but the keyguard never engages — the poll times out and `test4a_secureCameraLockedEmptyGalleryNoGreen` fails.

This PR adds a "Step 7" to `scripts/setup-e2e-emulator.sh` that runs `adb shell locksettings set-pin 1234`, which configures a PIN so the keyguard becomes secure and engages whenever the display sleeps. The step lives in the common path of the script, so it runs in both full and `--post-boot` modes. The tests never enter the PIN themselves — they only rely on `isKeyguardLocked` flipping to true.

For idempotency on persistent local AVDs, the command falls back to `locksettings set-pin --old 1234 1234` if a PIN is already configured. The header documents the corresponding `locksettings clear --old 1234` for tearing the PIN down locally.

## Why not also re-enable the E2E gate?

Issues #177 and #179 are still open and both also reference the same `continue-on-error: true` (the workflow comment lists all three issues as blockers). Removing `continue-on-error` while #177 and #179 remain unresolved would re-introduce red CI for unrelated reasons, so the gate must stay open until all three issues are fixed. This PR fixes only #178.

## Test plan

- [x] `./gradlew testDebugUnitTest --no-daemon` — BUILD SUCCESSFUL
- [x] `bash -n scripts/setup-e2e-emulator.sh` — script parses cleanly
- [ ] CI: with continue-on-error still in place, observe in the CI logs that `test4a_secureCameraLockedEmptyGalleryNoGreen` no longer times out in `lockScreen()` (it may still fail later on the green-coverage assertion if #156 is unresolved, but the keyguard-timeout symptom should be gone).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y2potcCXdQG168MVTEKYY)_