### PR TITLE
Fix E2E screenshot upload by using step outcomes instead of job failure status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
         # Known failures tracked in #178 (emulator keyguard not engaging) and
         # #179 (adaptive-icon colour/shape). continue-on-error keeps the job
         # green until those are fixed.
-        id: run_gallery_visual_e2e
+        id: run_gallery_e2e
         if: steps.diff_check.outputs.needs_full_build == 'true'
         continue-on-error: true
         run: |
@@ -326,7 +326,7 @@ jobs:
 
       - name: Pull and upload E2E screenshots on failure
         id: pull_e2e_screenshots
-        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_visual_e2e.outcome == 'failure')
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure')
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p /tmp/e2e-screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,6 +310,15 @@ jobs:
             exit 1
           }
 
+      - name: Pull and upload E2E screenshots on failure
+        id: pull_e2e_screenshots
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure')
+        run: |
+          ADB="$ANDROID_HOME/platform-tools/adb"
+          mkdir -p /tmp/e2e-screenshots
+          "$ADB" pull /sdcard/Android/data/com.gb4pc/files/screenshots/ \
+            /tmp/e2e-screenshots/ || echo "No screenshots to pull (directory may not exist)"
+
       - name: Kill emulator
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         run: |
@@ -324,14 +333,6 @@ jobs:
           path: app/build/outputs/androidTest-results/
           retention-days: 14
 
-      - name: Pull and upload E2E screenshots on failure
-        id: pull_e2e_screenshots
-        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure')
-        run: |
-          ADB="$ANDROID_HOME/platform-tools/adb"
-          mkdir -p /tmp/e2e-screenshots
-          "$ADB" pull /sdcard/Android/data/com.gb4pc/files/screenshots/ \
-            /tmp/e2e-screenshots/ || echo "No screenshots to pull (directory may not exist)"
       - name: Upload E2E screenshots on failure
         if: always() && steps.pull_e2e_screenshots.outcome == 'success'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,7 @@ jobs:
         # Known failures tracked in #178 (emulator keyguard not engaging) and
         # #179 (adaptive-icon colour/shape). continue-on-error keeps the job
         # green until those are fixed.
+        id: run_gallery_visual_e2e
         if: steps.diff_check.outputs.needs_full_build == 'true'
         continue-on-error: true
         run: |
@@ -323,14 +324,14 @@ jobs:
           retention-days: 14
 
       - name: Pull and upload E2E screenshots on failure
-        if: failure() && steps.diff_check.outputs.needs_full_build == 'true'
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (failure() || steps.run_gallery_visual_e2e.outcome == 'failure')
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p /tmp/e2e-screenshots
           "$ADB" pull /sdcard/Android/data/com.gb4pc/files/screenshots/ \
             /tmp/e2e-screenshots/ || echo "No screenshots to pull (directory may not exist)"
       - name: Upload E2E screenshots on failure
-        if: failure() && steps.diff_check.outputs.needs_full_build == 'true'
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (failure() || steps.run_gallery_visual_e2e.outcome == 'failure')
         uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,7 @@ jobs:
             -p com.google.android.GoogleCamera 2>/dev/null || true
 
       - name: Run PixelCameraOverlayE2ETest
+        id: run_overlay_e2e
         if: steps.diff_check.outputs.needs_full_build == 'true'
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
@@ -324,14 +325,15 @@ jobs:
           retention-days: 14
 
       - name: Pull and upload E2E screenshots on failure
-        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (failure() || steps.run_gallery_visual_e2e.outcome == 'failure')
+        id: pull_e2e_screenshots
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_visual_e2e.outcome == 'failure')
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p /tmp/e2e-screenshots
           "$ADB" pull /sdcard/Android/data/com.gb4pc/files/screenshots/ \
             /tmp/e2e-screenshots/ || echo "No screenshots to pull (directory may not exist)"
       - name: Upload E2E screenshots on failure
-        if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (failure() || steps.run_gallery_visual_e2e.outcome == 'failure')
+        if: always() && steps.pull_e2e_screenshots.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots


### PR DESCRIPTION
Fixes #183

## Problem

The E2E screenshot upload steps used `if: failure()` to detect test failures, but the E2E test steps have `continue-on-error: true`. This keeps the job status green even when tests fail, so `failure()` never fires and screenshots are never uploaded.

## Solution

Instead of relying on job-level failure status, the steps now check individual step outcomes directly:

1. Added `id: run_overlay_e2e` to the `Run PixelCameraOverlayE2ETest` step.
2. Added `id: run_gallery_e2e` to the `Run GalleryButtonVisualE2ETest` step.
3. Updated the `Pull and upload E2E screenshots on failure` step (given `id: pull_e2e_screenshots`) to use `if: always() && ... && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure')` so it runs whenever either E2E test step actually failed, regardless of overall job status.
4. Updated the `Upload E2E screenshots on failure` step to use `if: always() && steps.pull_e2e_screenshots.outcome == 'success'`, gating on whether the pull step ran successfully rather than on job failure status.

This ensures screenshots are captured and uploaded exactly when E2E tests fail, even though `continue-on-error: true` keeps the job green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzHszQvykWCQyCWDfpG8po)_