### PR TITLE
e2e: capture diagnostic screenshot on failure via shared FailureScreenshotRule

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/FailureScreenshotRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/FailureScreenshotRule.kt
@@ -1,0 +1,36 @@
+package com.gb4pc.e2e
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.io.File
+
+/**
+ * JUnit [TestWatcher] rule that captures a diagnostic screenshot whenever a test fails.
+ *
+ * The screenshot is saved to the app's external files directory under a "screenshots"
+ * subdirectory — the same location used by [com.gb4pc.e2e.visual.Screenshot.saveForArtifact] —
+ * so that CI artifact pickup collects it automatically alongside any other screenshots produced
+ * during the test.
+ *
+ * File name format: `<ClassName>-<methodName>-failure.png`
+ *
+ * Apply in any E2E test class with:
+ * ```kotlin
+ * @get:Rule
+ * val screenshotOnFailure = FailureScreenshotRule()
+ * ```
+ */
+class FailureScreenshotRule : TestWatcher() {
+    override fun failed(e: Throwable?, description: Description) {
+        val dir = File(
+            InstrumentationRegistry.getInstrumentation().targetContext
+                .getExternalFilesDir(null), "screenshots"
+        )
+        dir.mkdirs()
+        val className = description.testClass?.simpleName ?: "UnknownClass"
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .takeScreenshot(File(dir, "$className-${description.methodName}-failure.png"))
+    }
+}

--- a/app/src/androidTest/java/com/gb4pc/e2e/FailureScreenshotRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/FailureScreenshotRule.kt
@@ -1,5 +1,6 @@
 package com.gb4pc.e2e
 
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.junit.rules.TestWatcher
@@ -23,14 +24,26 @@ import java.io.File
  * ```
  */
 class FailureScreenshotRule : TestWatcher() {
+
+    companion object {
+        private const val TAG = "FailureScreenshotRule"
+    }
+
     override fun failed(e: Throwable?, description: Description) {
-        val dir = File(
-            InstrumentationRegistry.getInstrumentation().targetContext
-                .getExternalFilesDir(null), "screenshots"
-        )
+        val externalFilesDir = InstrumentationRegistry.getInstrumentation().targetContext
+            .getExternalFilesDir(null)
+        if (externalFilesDir == null) {
+            Log.w(TAG, "External storage unavailable; skipping failure screenshot for ${description.methodName}")
+            return
+        }
+        val dir = File(externalFilesDir, "screenshots")
         dir.mkdirs()
         val className = description.testClass?.simpleName ?: "UnknownClass"
-        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-            .takeScreenshot(File(dir, "$className-${description.methodName}-failure.png"))
+        val screenshotFile = File(dir, "$className-${description.methodName}-failure.png")
+        val success = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .takeScreenshot(screenshotFile)
+        if (!success) {
+            Log.w(TAG, "Failed to write failure screenshot to ${screenshotFile.absolutePath}")
+        }
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -17,6 +17,7 @@ import com.gb4pc.e2e.visual.toMaskData
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.FixMethodOrder
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
@@ -46,6 +47,9 @@ import kotlin.math.sqrt
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class GalleryButtonVisualE2ETest {
+
+    @get:Rule
+    val screenshotOnFailure = FailureScreenshotRule()
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context = instrumentation.targetContext

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -6,6 +6,7 @@ import com.gb4pc.Constants
 import com.gb4pc.service.OverlayService
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -36,6 +37,9 @@ import org.junit.runner.RunWith
 @E2ETest
 @RunWith(AndroidJUnit4::class)
 class PixelCameraOverlayE2ETest {
+
+    @get:Rule
+    val screenshotOnFailure = FailureScreenshotRule()
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val fixture = E2EFixture(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `FailureScreenshotRule` — a JUnit `TestWatcher` that automatically captures a screenshot to `/sdcard/Android/data/com.gb4pc/files/screenshots/<ClassName>-<methodName>-failure.png` whenever a test fails.
- Applies `@get:Rule val screenshotOnFailure = FailureScreenshotRule()` in both `PixelCameraOverlayE2ETest` (which previously had no screenshot capture at all) and `GalleryButtonVisualE2ETest` (where it covers failures in setup and non-visual assertions not already covered by `Screenshot.saveForArtifact`).
- The CI artifact upload step already collects the `screenshots/` directory, so failure images are automatically available as build artifacts with no CI changes needed.

Fixes #187

## How the changes fix the issue

Before this PR, a failed assertion in `PixelCameraOverlayE2ETest` left no visual artifact — there was no way to tell what was on screen when the test failed. `GalleryButtonVisualE2ETest` saved named screenshots for its own visual assertions but had no fallback for failures in `@Before` setup or non-visual assertions.

`FailureScreenshotRule` is a `TestWatcher` whose `failed()` hook fires after any test method exits with an uncaught exception or assertion failure. It captures the screen at the exact moment of failure and writes it to the directory the CI upload step already monitors. No changes to CI workflow are needed.

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all unit tests pass
- [ ] E2E: intentionally fail one test in each class on an emulator and verify `<ClassName>-<methodName>-failure.png` appears in the CI artifacts

https://claude.ai/code/session_01BSM51yns3ChLMJUsk7cLe5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSM51yns3ChLMJUsk7cLe5)_