### PR TITLE
E2E: increase overlayAppearsWhenViewfinderOpens timeout to 30 s

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -58,8 +58,8 @@ class PixelCameraOverlayE2ETest {
     fun overlayAppearsWhenViewfinderOpens() {
         fixture.launchPixelCamera()
 
-        val appeared = fixture.waitForCondition(timeoutMs = 10000L) { OverlayService.isOverlayActive }
-        assertTrue("Overlay should appear within 10 s of launching Pixel Camera viewfinder", appeared)
+        val appeared = fixture.waitForCondition(timeoutMs = 30000L) { OverlayService.isOverlayActive }
+        assertTrue("Overlay should appear within 30 s of launching Pixel Camera viewfinder", appeared)
     }
 
     /**


### PR DESCRIPTION
## Summary

- The `overlayAppearsWhenViewfinderOpens` test was using a 10 s timeout to wait for the overlay after launching Pixel Camera.
- On the API-35 CI emulator, camera open + UsageStats detection can take ~9–10 s, making 10 s too tight and causing intermittent assertion failures.
- Raised the timeout to 30 s, matching the headroom philosophy of `E2EFixture.waitForOverlayActive()` (default 20 s) and giving a comfortable margin above the observed worst-case on slow emulators.

## Test plan

- [ ] Confirm `overlayAppearsWhenViewfinderOpens` no longer flakes on the API-35 CI emulator.
- [ ] Confirm the other two tests in the suite (`overlayAppearsAfterUsageStatsLag`, `overlayDisappearsWhenViewfinderCloses`) still pass unchanged.
- [ ] Unit tests pass: `./gradlew testDebugUnitTest` (verified locally — BUILD SUCCESSFUL).

Fixes #186

https://claude.ai/code/session_01BSM51yns3ChLMJUsk7cLe5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSM51yns3ChLMJUsk7cLe5)_