### PR TITLE
Add test-result pass/fail summary to CI job summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,6 +344,15 @@ jobs:
           path: /tmp/e2e-screenshots/
           retention-days: 14
 
+      - name: Write test-result summary
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        run: |
+          python3 scripts/summarize_test_results.py \
+            app/build/test-results/testDebugUnitTest \
+              --suite-label "Unit Tests" \
+            app/build/outputs/androidTest-results/connected/debug \
+              --suite-label "Instrumented Tests"
+
   # Produce a signed release-config APK on every merge to main for easy sideloading.
   # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.
   # Waits for the full test suite (unit + E2E) before producing an artifact.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,9 @@ jobs:
           echo "==> emulator -list-avds:"
           ANDROID_AVD_HOME="$AVD_HOME" $ANDROID_HOME/emulator/emulator -list-avds
 
+      - name: Run Python script unit tests
+        run: python3 -m unittest discover -s scripts -p "test_*.py" -v
+
       - name: Grant execute permission for gradlew
         if: steps.diff_check.outputs.needs_full_build == 'true'
         run: chmod +x gradlew

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Summarize JUnit XML test results as a GitHub Job Summary Markdown table.
+
+Reads TEST-*.xml files from one or more result directories, groups test cases
+by class name, and writes a pass/fail table to $GITHUB_STEP_SUMMARY (falling
+back to stdout when the env var is not set).
+
+Usage:
+    python3 scripts/summarize_test_results.py \\
+        path/to/unit-results       --suite-label "Unit Tests" \\
+        path/to/e2e-results        --suite-label "Instrumented Tests"
+
+Each directory path must be immediately followed by --suite-label <name>.
+Exit code is always 0 (display only; failures are surfaced by earlier steps).
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TestCase:
+    name: str
+    passed: bool
+
+
+@dataclass
+class TestClass:
+    name: str
+    cases: list[TestCase] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(tc.passed for tc in self.cases)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def parse_directory(directory: Path) -> dict[str, TestClass]:
+    """Parse all TEST-*.xml files in *directory* and return classes keyed by name."""
+    classes: dict[str, TestClass] = {}
+
+    xml_files = sorted(directory.glob("TEST-*.xml"))
+    for xml_path in xml_files:
+        try:
+            tree = ET.parse(xml_path)
+        except ET.ParseError as exc:
+            print(f"  Warning: could not parse {xml_path}: {exc}", file=sys.stderr)
+            continue
+
+        root = tree.getroot()
+        if root.tag == "testsuites":
+            suite_elements = root.findall("testsuite")
+        else:
+            suite_elements = [root]
+
+        for suite in suite_elements:
+            class_name = suite.get("name", xml_path.stem)
+            if class_name not in classes:
+                classes[class_name] = TestClass(name=class_name)
+
+            for tc in suite.findall("testcase"):
+                tc_name = tc.get("name", "<unknown>")
+                failed = (
+                    tc.find("failure") is not None
+                    or tc.find("error") is not None
+                )
+                classes[class_name].cases.append(
+                    TestCase(name=tc_name, passed=not failed)
+                )
+
+    return classes
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+def render_suite(label: str, classes: dict[str, TestClass]) -> list[str]:
+    """Render one suite as Markdown lines (header + table rows + totals)."""
+    lines: list[str] = []
+    lines.append(f"### {label}")
+
+    if not classes:
+        lines.append("_No test results found._")
+        lines.append("")
+        return lines
+
+    lines.append("| Status | Suite / Test |")
+    lines.append("|--------|--------------|")
+
+    total_pass = 0
+    total_fail = 0
+
+    for cls in classes.values():
+        class_icon = "✅ PASS" if cls.passed else "❌ FAIL"
+        lines.append(f"| {class_icon} | **{cls.name}** |")
+        for tc in cls.cases:
+            tc_icon = "✅ PASS" if tc.passed else "❌ FAIL"
+            lines.append(f"| {tc_icon} |     `{tc.name}` |")
+            if tc.passed:
+                total_pass += 1
+            else:
+                total_fail += 1
+
+    total = total_pass + total_fail
+    lines.append("")
+    lines.append(f"**Total: {total_pass} passed, {total_fail} failed** ({total} tests)")
+    lines.append("")
+    return lines
+
+
+def build_markdown(suite_data: list[tuple[str, dict[str, TestClass]]]) -> str:
+    """Build the full Markdown document for all suites."""
+    lines: list[str] = ["## Test Results", ""]
+    for label, classes in suite_data:
+        lines.extend(render_suite(label, classes))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_USAGE = (
+    "usage: summarize_test_results.py "
+    "<dir> --suite-label <name> [<dir> --suite-label <name> ...]"
+)
+
+
+def parse_args(argv: list[str]) -> list[tuple[Path, str]]:
+    """Parse argv into a list of (directory, label) pairs.
+
+    Expected pattern: <dir> --suite-label <name> [<dir> --suite-label <name> ...]
+
+    Raises SystemExit(2) on bad input (matching argparse convention).
+    """
+    if argv and argv[0] in ("-h", "--help"):
+        print(__doc__)
+        print(_USAGE)
+        raise SystemExit(0)
+
+    pairs: list[tuple[Path, str]] = []
+    tokens = list(argv)
+    i = 0
+    while i < len(tokens):
+        directory = tokens[i]
+        # We need tokens[i], tokens[i+1], and tokens[i+2] to all be present.
+        if i + 3 > len(tokens):
+            print(
+                f"error: expected --suite-label <name> after '{directory}'\n{_USAGE}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        flag = tokens[i + 1]
+        label = tokens[i + 2]
+        if flag != "--suite-label":
+            print(
+                f"error: expected --suite-label after '{directory}', got '{flag}'\n{_USAGE}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        pairs.append((Path(directory), label))
+        i += 3
+
+    if not pairs:
+        print(
+            f"error: at least one <directory> --suite-label <name> pair is required\n{_USAGE}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    pairs = parse_args(argv)
+
+    suite_data: list[tuple[str, dict[str, TestClass]]] = []
+    for directory, label in pairs:
+        if not directory.exists():
+            print(
+                f"Note: result directory not found, skipping: {directory}",
+                file=sys.stderr,
+            )
+            suite_data.append((label, {}))
+            continue
+        if not directory.is_dir():
+            print(
+                f"Note: path is not a directory, skipping: {directory}",
+                file=sys.stderr,
+            )
+            suite_data.append((label, {}))
+            continue
+
+        classes = parse_directory(directory)
+        if not classes:
+            print(
+                f"Note: no TEST-*.xml files found in {directory}",
+                file=sys.stderr,
+            )
+        suite_data.append((label, classes))
+
+    markdown = build_markdown(suite_data)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(markdown)
+            fh.write("\n")
+    else:
+        print(markdown)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -108,7 +108,13 @@ def render_suite(label: str, classes: dict[str, TestClass]) -> list[str]:
     total_skip = 0
 
     for cls in classes.values():
-        class_icon = "❌ FAIL" if cls.any_failed else "✅ PASS"
+        any_passed = any(tc.passed for tc in cls.cases)
+        if cls.any_failed:
+            class_icon = "❌ FAIL"
+        elif not any_passed:
+            class_icon = "⏭ SKIP"
+        else:
+            class_icon = "✅ PASS"
         lines.append(f"| {class_icon} | **{cls.name}** |")
         for tc in cls.cases:
             if tc.skipped:

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -38,10 +38,6 @@ class TestClass:
     cases: list[TestCase] = field(default_factory=list)
 
     @property
-    def passed(self) -> bool:
-        return all(tc.passed or tc.skipped for tc in self.cases)
-
-    @property
     def any_failed(self) -> bool:
         return any(not tc.passed and not tc.skipped for tc in self.cases)
 

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -29,6 +29,7 @@ from pathlib import Path
 class TestCase:
     name: str
     passed: bool
+    skipped: bool = False
 
 
 @dataclass
@@ -38,7 +39,11 @@ class TestClass:
 
     @property
     def passed(self) -> bool:
-        return all(tc.passed for tc in self.cases)
+        return all(tc.passed or tc.skipped for tc in self.cases)
+
+    @property
+    def any_failed(self) -> bool:
+        return any(not tc.passed and not tc.skipped for tc in self.cases)
 
 
 # ---------------------------------------------------------------------------
@@ -70,12 +75,16 @@ def parse_directory(directory: Path) -> dict[str, TestClass]:
 
             for tc in suite.findall("testcase"):
                 tc_name = tc.get("name", "<unknown>")
+                skipped = tc.find("skipped") is not None
                 failed = (
-                    tc.find("failure") is not None
-                    or tc.find("error") is not None
+                    not skipped
+                    and (
+                        tc.find("failure") is not None
+                        or tc.find("error") is not None
+                    )
                 )
                 classes[class_name].cases.append(
-                    TestCase(name=tc_name, passed=not failed)
+                    TestCase(name=tc_name, passed=not failed and not skipped, skipped=skipped)
                 )
 
     return classes
@@ -100,21 +109,27 @@ def render_suite(label: str, classes: dict[str, TestClass]) -> list[str]:
 
     total_pass = 0
     total_fail = 0
+    total_skip = 0
 
     for cls in classes.values():
-        class_icon = "✅ PASS" if cls.passed else "❌ FAIL"
+        class_icon = "❌ FAIL" if cls.any_failed else "✅ PASS"
         lines.append(f"| {class_icon} | **{cls.name}** |")
         for tc in cls.cases:
-            tc_icon = "✅ PASS" if tc.passed else "❌ FAIL"
-            lines.append(f"| {tc_icon} |     `{tc.name}` |")
-            if tc.passed:
+            if tc.skipped:
+                tc_icon = "⏭ SKIP"
+                total_skip += 1
+            elif tc.passed:
+                tc_icon = "✅ PASS"
                 total_pass += 1
             else:
+                tc_icon = "❌ FAIL"
                 total_fail += 1
+            lines.append(f"| {tc_icon} |     `{tc.name}` |")
 
-    total = total_pass + total_fail
+    total = total_pass + total_fail + total_skip
+    skip_str = f", {total_skip} skipped" if total_skip else ""
     lines.append("")
-    lines.append(f"**Total: {total_pass} passed, {total_fail} failed** ({total} tests)")
+    lines.append(f"**Total: {total_pass} passed, {total_fail} failed{skip_str}** ({total} tests)")
     lines.append("")
     return lines
 

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -292,8 +292,8 @@ class TestRenderSuite(unittest.TestCase):
         self.assertIn("1 passed, 1 failed, 1 skipped", combined)
         self.assertIn("(3 tests)", combined)
 
-    def test_all_skipped_class_icon_is_pass(self):
-        """A class with only skipped tests and no failures shows ✅ PASS."""
+    def test_all_skipped_class_icon_is_skip(self):
+        """A class with only skipped tests and no failures shows ⏭ SKIP."""
         classes = {
             "com.example.AllSkip": srt.TestClass(
                 name="com.example.AllSkip",
@@ -305,7 +305,8 @@ class TestRenderSuite(unittest.TestCase):
             line for line in lines
             if "com.example.AllSkip" in line and "**" in line
         )
-        self.assertIn("✅ PASS", class_row)
+        self.assertIn("⏭ SKIP", class_row)
+        self.assertNotIn("✅ PASS", class_row)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -93,7 +93,7 @@ class TestParseDirectory(unittest.TestCase):
         classes = srt.parse_directory(self.tmpdir)
         self.assertIn("com.example.FooTest", classes)
         cls = classes["com.example.FooTest"]
-        self.assertTrue(cls.passed)
+        self.assertFalse(cls.any_failed)
         self.assertEqual(len(cls.cases), 2)
         self.assertTrue(all(tc.passed for tc in cls.cases))
 
@@ -102,7 +102,7 @@ class TestParseDirectory(unittest.TestCase):
         classes = srt.parse_directory(self.tmpdir)
         self.assertIn("com.example.BarTest", classes)
         cls = classes["com.example.BarTest"]
-        self.assertFalse(cls.passed)
+        self.assertTrue(cls.any_failed)
         passed_cases = [tc for tc in cls.cases if tc.passed]
         failed_cases = [tc for tc in cls.cases if not tc.passed]
         self.assertEqual(len(passed_cases), 1)
@@ -114,8 +114,8 @@ class TestParseDirectory(unittest.TestCase):
         classes = srt.parse_directory(self.tmpdir)
         self.assertIn("com.example.AlphaTest", classes)
         self.assertIn("com.example.BetaTest", classes)
-        self.assertTrue(classes["com.example.AlphaTest"].passed)
-        self.assertFalse(classes["com.example.BetaTest"].passed)
+        self.assertFalse(classes["com.example.AlphaTest"].any_failed)
+        self.assertTrue(classes["com.example.BetaTest"].any_failed)
 
     def test_non_xml_files_ignored(self):
         (self.tmpdir / "not-a-test.txt").write_text("ignore me")
@@ -134,7 +134,7 @@ class TestParseDirectory(unittest.TestCase):
         _write_xml(self.tmpdir, "TEST-mixed.xml", MIXED_XML)
         classes = srt.parse_directory(self.tmpdir)
         # BetaTest has an <error> child — should count as failed
-        self.assertFalse(classes["com.example.BetaTest"].passed)
+        self.assertTrue(classes["com.example.BetaTest"].any_failed)
 
     def test_skipped_element_not_counted_as_pass(self):
         _write_xml(self.tmpdir, "TEST-skip.xml", SKIPPED_XML)
@@ -161,28 +161,34 @@ class TestParseDirectory(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# TestClass.passed tests
+# TestClass.any_failed tests
 # ---------------------------------------------------------------------------
 
 class TestTestClass(unittest.TestCase):
 
-    def test_all_pass(self):
+    def test_all_pass_not_any_failed(self):
         cls = srt.TestClass(name="Foo", cases=[
             srt.TestCase("a", True),
             srt.TestCase("b", True),
         ])
-        self.assertTrue(cls.passed)
+        self.assertFalse(cls.any_failed)
 
-    def test_any_fail_means_class_fails(self):
+    def test_one_failure_is_any_failed(self):
         cls = srt.TestClass(name="Foo", cases=[
             srt.TestCase("a", True),
             srt.TestCase("b", False),
         ])
-        self.assertFalse(cls.passed)
+        self.assertTrue(cls.any_failed)
 
-    def test_empty_cases_passes(self):
+    def test_empty_cases_not_any_failed(self):
         cls = srt.TestClass(name="Empty")
-        self.assertTrue(cls.passed)
+        self.assertFalse(cls.any_failed)
+
+    def test_all_skipped_not_any_failed(self):
+        cls = srt.TestClass(name="Skipped", cases=[
+            srt.TestCase("s", False, skipped=True),
+        ])
+        self.assertFalse(cls.any_failed)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -255,6 +255,52 @@ class TestRenderSuite(unittest.TestCase):
         )
         self.assertIn("❌ FAIL", class_row)
 
+    def test_skipped_case_shows_skip_icon(self):
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[
+                    srt.TestCase("pass1", True, skipped=False),
+                    srt.TestCase("skip1", False, skipped=True),
+                ],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("⏭ SKIP", combined)
+        self.assertNotIn("❌ FAIL", combined)
+
+    def test_skipped_case_counted_in_totals_not_as_pass(self):
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[
+                    srt.TestCase("pass1", True, skipped=False),
+                    srt.TestCase("skip1", False, skipped=True),
+                    srt.TestCase("fail1", False, skipped=False),
+                ],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("1 passed, 1 failed, 1 skipped", combined)
+        self.assertIn("(3 tests)", combined)
+
+    def test_all_skipped_class_icon_is_pass(self):
+        """A class with only skipped tests and no failures shows ✅ PASS."""
+        classes = {
+            "com.example.AllSkip": srt.TestClass(
+                name="com.example.AllSkip",
+                cases=[srt.TestCase("s1", False, skipped=True)],
+            )
+        }
+        lines = srt.render_suite("Suite", classes)
+        class_row = next(
+            line for line in lines
+            if "com.example.AllSkip" in line and "**" in line
+        )
+        self.assertIn("✅ PASS", class_row)
+
 
 # ---------------------------------------------------------------------------
 # build_markdown tests

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -57,6 +57,19 @@ MIXED_XML = """\
     </testsuites>
 """
 
+SKIPPED_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.SkipTest" tests="3" failures="0" skipped="1">
+      <testcase name="testPass" classname="com.example.SkipTest"/>
+      <testcase name="testSkip" classname="com.example.SkipTest">
+        <skipped/>
+      </testcase>
+      <testcase name="testFail" classname="com.example.SkipTest">
+        <failure message="AssertionError">Expected true but was false</failure>
+      </testcase>
+    </testsuite>
+"""
+
 
 # ---------------------------------------------------------------------------
 # parse_directory tests
@@ -122,6 +135,29 @@ class TestParseDirectory(unittest.TestCase):
         classes = srt.parse_directory(self.tmpdir)
         # BetaTest has an <error> child — should count as failed
         self.assertFalse(classes["com.example.BetaTest"].passed)
+
+    def test_skipped_element_not_counted_as_pass(self):
+        _write_xml(self.tmpdir, "TEST-skip.xml", SKIPPED_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        cls = classes["com.example.SkipTest"]
+        skipped_cases = [tc for tc in cls.cases if tc.skipped]
+        passed_cases = [tc for tc in cls.cases if tc.passed]
+        failed_cases = [tc for tc in cls.cases if not tc.passed and not tc.skipped]
+        self.assertEqual(len(skipped_cases), 1)
+        self.assertEqual(skipped_cases[0].name, "testSkip")
+        self.assertEqual(len(passed_cases), 1)
+        self.assertEqual(passed_cases[0].name, "testPass")
+        self.assertEqual(len(failed_cases), 1)
+        self.assertEqual(failed_cases[0].name, "testFail")
+
+    def test_skipped_cases_do_not_inflate_pass_count(self):
+        _write_xml(self.tmpdir, "TEST-skip.xml", SKIPPED_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        cls = classes["com.example.SkipTest"]
+        # A skipped test should have skipped=True and passed=False
+        skipped = next(tc for tc in cls.cases if tc.name == "testSkip")
+        self.assertTrue(skipped.skipped)
+        self.assertFalse(skipped.passed)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Unit tests for summarize_test_results.py."""
+
+import io
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import summarize_test_results as srt  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_xml(directory: Path, filename: str, content: str) -> Path:
+    """Write an XML file to *directory* and return its path."""
+    path = directory / filename
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+PASSING_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.FooTest" tests="2" failures="0" errors="0">
+      <testcase name="testA" classname="com.example.FooTest"/>
+      <testcase name="testB" classname="com.example.FooTest"/>
+    </testsuite>
+"""
+
+FAILING_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.BarTest" tests="2" failures="1" errors="0">
+      <testcase name="testC" classname="com.example.BarTest"/>
+      <testcase name="testD" classname="com.example.BarTest">
+        <failure message="AssertionError">Expected true but was false</failure>
+      </testcase>
+    </testsuite>
+"""
+
+MIXED_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+      <testsuite name="com.example.AlphaTest" tests="1" failures="0">
+        <testcase name="alpha1"/>
+      </testsuite>
+      <testsuite name="com.example.BetaTest" tests="1" failures="1">
+        <testcase name="beta1">
+          <error message="NullPointerException">NPE</error>
+        </testcase>
+      </testsuite>
+    </testsuites>
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_directory tests
+# ---------------------------------------------------------------------------
+
+class TestParseDirectory(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_empty_directory_returns_empty_dict(self):
+        result = srt.parse_directory(self.tmpdir)
+        self.assertEqual(result, {})
+
+    def test_passing_xml_all_cases_pass(self):
+        _write_xml(self.tmpdir, "TEST-com.example.FooTest.xml", PASSING_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        self.assertIn("com.example.FooTest", classes)
+        cls = classes["com.example.FooTest"]
+        self.assertTrue(cls.passed)
+        self.assertEqual(len(cls.cases), 2)
+        self.assertTrue(all(tc.passed for tc in cls.cases))
+
+    def test_failing_xml_class_fails(self):
+        _write_xml(self.tmpdir, "TEST-com.example.BarTest.xml", FAILING_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        self.assertIn("com.example.BarTest", classes)
+        cls = classes["com.example.BarTest"]
+        self.assertFalse(cls.passed)
+        passed_cases = [tc for tc in cls.cases if tc.passed]
+        failed_cases = [tc for tc in cls.cases if not tc.passed]
+        self.assertEqual(len(passed_cases), 1)
+        self.assertEqual(len(failed_cases), 1)
+        self.assertEqual(failed_cases[0].name, "testD")
+
+    def test_testsuites_wrapper_parsed(self):
+        _write_xml(self.tmpdir, "TEST-mixed.xml", MIXED_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        self.assertIn("com.example.AlphaTest", classes)
+        self.assertIn("com.example.BetaTest", classes)
+        self.assertTrue(classes["com.example.AlphaTest"].passed)
+        self.assertFalse(classes["com.example.BetaTest"].passed)
+
+    def test_non_xml_files_ignored(self):
+        (self.tmpdir / "not-a-test.txt").write_text("ignore me")
+        (self.tmpdir / "TEST-foo.xml").write_text(
+            textwrap.dedent(PASSING_XML), encoding="utf-8"
+        )
+        classes = srt.parse_directory(self.tmpdir)
+        self.assertEqual(len(classes), 1)
+
+    def test_malformed_xml_skipped_with_warning(self):
+        (self.tmpdir / "TEST-bad.xml").write_text("<not valid xml <<<")
+        result = srt.parse_directory(self.tmpdir)
+        self.assertEqual(result, {})
+
+    def test_error_element_counts_as_failure(self):
+        _write_xml(self.tmpdir, "TEST-mixed.xml", MIXED_XML)
+        classes = srt.parse_directory(self.tmpdir)
+        # BetaTest has an <error> child — should count as failed
+        self.assertFalse(classes["com.example.BetaTest"].passed)
+
+
+# ---------------------------------------------------------------------------
+# TestClass.passed tests
+# ---------------------------------------------------------------------------
+
+class TestTestClass(unittest.TestCase):
+
+    def test_all_pass(self):
+        cls = srt.TestClass(name="Foo", cases=[
+            srt.TestCase("a", True),
+            srt.TestCase("b", True),
+        ])
+        self.assertTrue(cls.passed)
+
+    def test_any_fail_means_class_fails(self):
+        cls = srt.TestClass(name="Foo", cases=[
+            srt.TestCase("a", True),
+            srt.TestCase("b", False),
+        ])
+        self.assertFalse(cls.passed)
+
+    def test_empty_cases_passes(self):
+        cls = srt.TestClass(name="Empty")
+        self.assertTrue(cls.passed)
+
+
+# ---------------------------------------------------------------------------
+# render_suite tests
+# ---------------------------------------------------------------------------
+
+class TestRenderSuite(unittest.TestCase):
+
+    def test_empty_suite_shows_no_results_note(self):
+        lines = srt.render_suite("Unit Tests", {})
+        combined = "\n".join(lines)
+        self.assertIn("No test results found", combined)
+        self.assertNotIn("| Status |", combined)
+
+    def test_passing_class_shows_green(self):
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[srt.TestCase("testA", True)],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("✅ PASS", combined)
+        self.assertNotIn("❌ FAIL", combined)
+
+    def test_failing_class_shows_red(self):
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[srt.TestCase("testA", False)],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("❌ FAIL", combined)
+
+    def test_totals_line_correct(self):
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[
+                    srt.TestCase("pass1", True),
+                    srt.TestCase("pass2", True),
+                    srt.TestCase("fail1", False),
+                ],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("2 passed, 1 failed", combined)
+        self.assertIn("(3 tests)", combined)
+
+    def test_mixed_class_icon_is_fail_when_any_case_fails(self):
+        classes = {
+            "com.example.Mixed": srt.TestClass(
+                name="com.example.Mixed",
+                cases=[
+                    srt.TestCase("ok", True),
+                    srt.TestCase("bad", False),
+                ],
+            )
+        }
+        lines = srt.render_suite("Suite", classes)
+        combined = "\n".join(lines)
+        # The class row must contain FAIL
+        class_row = next(
+            line for line in lines
+            if "com.example.Mixed" in line and "**" in line
+        )
+        self.assertIn("❌ FAIL", class_row)
+
+
+# ---------------------------------------------------------------------------
+# build_markdown tests
+# ---------------------------------------------------------------------------
+
+class TestBuildMarkdown(unittest.TestCase):
+
+    def test_starts_with_h2(self):
+        md = srt.build_markdown([])
+        self.assertTrue(md.startswith("## Test Results"))
+
+    def test_multiple_suites_appear_in_order(self):
+        suite_data = [
+            ("Unit Tests", {}),
+            ("Instrumented Tests", {}),
+        ]
+        md = srt.build_markdown(suite_data)
+        unit_pos = md.index("Unit Tests")
+        instrumented_pos = md.index("Instrumented Tests")
+        self.assertLess(unit_pos, instrumented_pos)
+
+
+# ---------------------------------------------------------------------------
+# parse_args tests
+# ---------------------------------------------------------------------------
+
+class TestParseArgs(unittest.TestCase):
+
+    def test_single_pair(self):
+        pairs = srt.parse_args(["path/to/unit", "--suite-label", "Unit Tests"])
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(pairs[0][0], Path("path/to/unit"))
+        self.assertEqual(pairs[0][1], "Unit Tests")
+
+    def test_two_pairs(self):
+        pairs = srt.parse_args([
+            "dir1", "--suite-label", "Label1",
+            "dir2", "--suite-label", "Label2",
+        ])
+        self.assertEqual(len(pairs), 2)
+        self.assertEqual(pairs[1][1], "Label2")
+
+    def test_missing_suite_label_flag_raises(self):
+        with self.assertRaises(SystemExit):
+            srt.parse_args(["dir1", "--wrong-flag", "Label"])
+
+    def test_no_args_raises(self):
+        with self.assertRaises(SystemExit):
+            srt.parse_args([])
+
+    def test_incomplete_pair_raises(self):
+        # directory without --suite-label following
+        with self.assertRaises(SystemExit):
+            srt.parse_args(["dir1"])
+
+
+# ---------------------------------------------------------------------------
+# main() integration tests
+# ---------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_exit_0_on_passing_results(self):
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        result = srt.main([str(self.tmpdir), "--suite-label", "Unit"])
+        self.assertEqual(result, 0)
+
+    def test_exit_0_on_failing_results(self):
+        """Script always exits 0 — failures are surfaced by earlier steps."""
+        _write_xml(self.tmpdir, "TEST-foo.xml", FAILING_XML)
+        result = srt.main([str(self.tmpdir), "--suite-label", "Unit"])
+        self.assertEqual(result, 0)
+
+    def test_exit_0_on_missing_directory(self):
+        missing = self.tmpdir / "nonexistent"
+        result = srt.main([str(missing), "--suite-label", "Unit"])
+        self.assertEqual(result, 0)
+
+    def test_writes_to_github_step_summary(self):
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        summary_file = self.tmpdir / "summary.md"
+        with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(summary_file)}):
+            srt.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        content = summary_file.read_text(encoding="utf-8")
+        self.assertIn("## Test Results", content)
+        self.assertIn("Unit Tests", content)
+
+    def test_falls_back_to_stdout_when_no_env_var(self):
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        env = {k: v for k, v in os.environ.items() if k != "GITHUB_STEP_SUMMARY"}
+        with patch.dict(os.environ, env, clear=True):
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                srt.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        output = captured.getvalue()
+        self.assertIn("## Test Results", output)
+
+    def test_appends_to_existing_summary_file(self):
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        summary_file = self.tmpdir / "summary.md"
+        summary_file.write_text("existing content\n", encoding="utf-8")
+        with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(summary_file)}):
+            srt.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        content = summary_file.read_text(encoding="utf-8")
+        self.assertTrue(content.startswith("existing content"))
+        self.assertIn("## Test Results", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -368,13 +368,25 @@ class TestParseArgs(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestMain(unittest.TestCase):
+    """Integration tests for main().
+
+    setUp clears GITHUB_STEP_SUMMARY from the environment so that calls to
+    srt.main() made without an explicit patch never write to the real CI job
+    summary.  Tests that specifically exercise the summary-file path restore the
+    variable themselves via patch.dict.
+    """
 
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.tmpdir = Path(self._tmpdir.name)
+        # Remove GITHUB_STEP_SUMMARY so fixture-driven main() calls do not
+        # pollute the real CI job summary with FooTest/BarTest class names.
+        self._saved_summary = os.environ.pop("GITHUB_STEP_SUMMARY", None)
 
     def tearDown(self):
         self._tmpdir.cleanup()
+        if self._saved_summary is not None:
+            os.environ["GITHUB_STEP_SUMMARY"] = self._saved_summary
 
     def test_exit_0_on_passing_results(self):
         _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
@@ -402,12 +414,12 @@ class TestMain(unittest.TestCase):
         self.assertIn("Unit Tests", content)
 
     def test_falls_back_to_stdout_when_no_env_var(self):
+        # GITHUB_STEP_SUMMARY is already absent (cleared in setUp); verify that
+        # the script falls back to stdout rather than raising or writing a file.
         _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
-        env = {k: v for k, v in os.environ.items() if k != "GITHUB_STEP_SUMMARY"}
-        with patch.dict(os.environ, env, clear=True):
-            captured = io.StringIO()
-            with patch("sys.stdout", captured):
-                srt.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            srt.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
         output = captured.getvalue()
         self.assertIn("## Test Results", output)
 
@@ -420,6 +432,16 @@ class TestMain(unittest.TestCase):
         content = summary_file.read_text(encoding="utf-8")
         self.assertTrue(content.startswith("existing content"))
         self.assertIn("## Test Results", content)
+
+    def test_main_does_not_write_to_ci_summary_when_no_summary_var(self):
+        """When GITHUB_STEP_SUMMARY is absent, main() must not write any file."""
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        files_before = set(self.tmpdir.iterdir())
+        with patch("sys.stdout", io.StringIO()):
+            srt.main([str(self.tmpdir), "--suite-label", "Unit"])
+        files_after = set(self.tmpdir.iterdir())
+        # Only the XML fixture we wrote should exist; no summary file created.
+        self.assertEqual(files_before, files_after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #195

- Adds `scripts/summarize_test_results.py`, which parses JUnit XML files from one or more result directories and writes a pass/fail Markdown table to `$GITHUB_STEP_SUMMARY` (falls back to stdout when the env var is absent).
- Adds a &#34;Write test-result summary&#34; step at the end of the `build-and-test` job that calls the script for both the unit test and instrumented test result directories.
- Adds `scripts/test_summarize_test_results.py` with 28 unit tests covering parsing, rendering, CLI argument validation, and summary-file writing.

## How it fixes the issue

CI output was too verbose to scan for failures, and the artifact-based test results required a download and unzip. The new step populates the GitHub Actions &#34;Summary&#34; tab with a compact table showing each test class and case as ✅ PASS or ❌ FAIL, plus a total line, making failures immediately visible without leaving the browser.

The step is guarded with `if: always() &amp;&amp; steps.diff_check.outputs.needs_full_build == &#39;true&#39;` so it runs even when earlier steps fail, and exits 0 always — actual failure gating remains with the existing test steps.

## Test plan

- [ ] Run `python3 -m unittest discover -s scripts -p &#34;test_summarize_test_results.py&#34;` — all 28 tests pass.
- [ ] Trigger a CI run and verify the &#34;Summary&#34; tab shows the pass/fail table.
- [ ] Confirm the step does not fail when result directories are absent (e.g. on docs-only PRs that skip the full build).