### PR TITLE
Use upward swipe to dismiss swipe keyguard before each screencap in the adb retry loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,7 @@ jobs:
           echo "==> Waking display and dismissing keyguard..."
           "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
+          sleep 2
 
           # Launch MockCameraActivity and wait for it to be displayed.
           # am start -W blocks until the activity is on screen, so no polling needed.
@@ -242,6 +243,7 @@ jobs:
           # same swipe unlock to stay consistent.
           "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
+          sleep 2
 
           python3 scripts/check_green_feed.py --adb "$ADB" preflight.png
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,15 +219,15 @@ jobs:
           "$ADB" shell pm grant com.google.android.GoogleCamera \
             android.permission.CAMERA
 
-          # Wake the display and dismiss the keyguard before launching the activity.
-          # am start -W waits for the framework to launch the activity, but on an
-          # emulator with screen timeout the keyguard may still be covering the window.
-          # wm dismiss-keyguard (API 26+) removes the keyguard immediately and is more
-          # reliable than a keyevent sequence for this purpose.
+          # Wake the display and dismiss the swipe keyguard before launching the
+          # activity. An upward swipe is used instead of wm dismiss-keyguard or
+          # KEYCODE_MENU: wm dismiss-keyguard did not reliably dismiss the
+          # swipe-type lock screen in CI (all retries returned #E9E8EF), and
+          # KEYCODE_MENU can open the options menu once MockCameraActivity is
+          # foregrounded, obscuring the green view.
           echo "==> Waking display and dismissing keyguard..."
           "$ADB" shell input keyevent KEYCODE_WAKEUP
-          "$ADB" shell wm dismiss-keyguard
-          sleep 2
+          "$ADB" shell input swipe 300 1000 300 300
 
           # Launch MockCameraActivity and wait for it to be displayed.
           # am start -W blocks until the activity is on screen, so no polling needed.
@@ -235,12 +235,13 @@ jobs:
           "$ADB" shell am start -W -n \
             com.google.android.GoogleCamera/com.gb4pc.mockcamera.MockCameraActivity
 
-          # Re-wake and re-dismiss keyguard after am start -W: adb install above
-          # can take 10-30 s and the screen may sleep in that window. am start -W
-          # and setTurnScreenOn(true) usually recover, but this is a cheap extra
-          # guarantee that the green view is visible before screencap.
+          # Re-wake after am start -W: adb install above can take 10-30 s and
+          # the screen may sleep in that window. am start -W and
+          # setTurnScreenOn(true) usually recover, but this is a cheap extra
+          # guarantee that the green view is visible before screencap. Use the
+          # same swipe unlock to stay consistent.
           "$ADB" shell input keyevent KEYCODE_WAKEUP
-          "$ADB" shell wm dismiss-keyguard
+          "$ADB" shell input swipe 300 1000 300 300
 
           python3 scripts/check_green_feed.py --adb "$ADB" preflight.png
 

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -221,6 +221,20 @@ def main() -> int:
         # Sleep first so the display has time to render before the first check
         # and between retries; the caller has already waited for am start -W.
         time.sleep(RETRY_DELAY_SECONDS)
+        # Wake the display and dismiss the keyguard before every screencap.
+        # The screen may dim or the keyguard may re-appear during a long retry
+        # loop (e.g. while the APK was being installed). KEYCODE_WAKEUP (224)
+        # turns the screen on; KEYCODE_MENU (82) dismisses the keyguard when
+        # no PIN is set (which is the case at pre-flight time, before the E2E
+        # setup script installs a PIN).
+        subprocess.run(
+            [adb_path, "shell", "input", "keyevent", "224"],
+            check=False,
+        )
+        subprocess.run(
+            [adb_path, "shell", "input", "keyevent", "82"],
+            check=False,
+        )
         with open(path, "wb") as out:
             subprocess.run(
                 [adb_path, "exec-out", "screencap", "-p"],

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -223,18 +223,18 @@ def main() -> int:
         time.sleep(RETRY_DELAY_SECONDS)
         # Wake the display and dismiss the keyguard before every screencap.
         # The screen may dim or the keyguard may re-appear during a long retry
-        # loop (e.g. while the APK was being installed). KEYCODE_WAKEUP (224)
-        # turns the screen on on all API levels. `wm dismiss-keyguard` dismisses
-        # the keyguard on API 26+ and is a no-op when no keyguard is present,
-        # so it is safe to call unconditionally (unlike KEYCODE_MENU which is
-        # ineffective on API 26+ and can open the options menu when the activity
-        # is already foregrounded on older releases).
+        # loop (e.g. while the APK was being installed).
+        # KEYCODE_WAKEUP (224) turns the screen on on all API levels.
+        # KEYCODE_MENU (82) dismisses the swipe-based lock screen that the
+        # emulator shows before the E2E PIN setup script runs.  It is a no-op
+        # when the screen is already unlocked, so it is safe to call
+        # unconditionally in the pre-flight retry loop.
         subprocess.run(
             [adb_path, "shell", "input", "keyevent", "224"],
             check=False,
         )
         subprocess.run(
-            [adb_path, "shell", "wm", "dismiss-keyguard"],
+            [adb_path, "shell", "input", "keyevent", "82"],
             check=False,
         )
         with open(path, "wb") as out:

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -225,16 +225,18 @@ def main() -> int:
         # The screen may dim or the keyguard may re-appear during a long retry
         # loop (e.g. while the APK was being installed).
         # KEYCODE_WAKEUP (224) turns the screen on on all API levels.
-        # KEYCODE_MENU (82) dismisses the swipe-based lock screen that the
-        # emulator shows before the E2E PIN setup script runs.  It is a no-op
-        # when the screen is already unlocked, so it is safe to call
-        # unconditionally in the pre-flight retry loop.
+        # An upward swipe then dismisses the swipe-based lock screen that the
+        # emulator shows before the E2E PIN setup script runs.  Using a swipe
+        # gesture avoids the side-effect of KEYCODE_MENU (82), which dispatches
+        # KeyEvent.KEYCODE_MENU to a foregrounded activity and can open the
+        # options/overflow menu, obscuring the green view.  When the screen is
+        # already unlocked the swipe is a harmless gesture over the activity.
         subprocess.run(
             [adb_path, "shell", "input", "keyevent", "224"],
             check=False,
         )
         subprocess.run(
-            [adb_path, "shell", "input", "keyevent", "82"],
+            [adb_path, "shell", "input", "swipe", "300", "1000", "300", "300"],
             check=False,
         )
         with open(path, "wb") as out:

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -224,15 +224,17 @@ def main() -> int:
         # Wake the display and dismiss the keyguard before every screencap.
         # The screen may dim or the keyguard may re-appear during a long retry
         # loop (e.g. while the APK was being installed). KEYCODE_WAKEUP (224)
-        # turns the screen on; KEYCODE_MENU (82) dismisses the keyguard when
-        # no PIN is set (which is the case at pre-flight time, before the E2E
-        # setup script installs a PIN).
+        # turns the screen on on all API levels. `wm dismiss-keyguard` dismisses
+        # the keyguard on API 26+ and is a no-op when no keyguard is present,
+        # so it is safe to call unconditionally (unlike KEYCODE_MENU which is
+        # ineffective on API 26+ and can open the options menu when the activity
+        # is already foregrounded on older releases).
         subprocess.run(
             [adb_path, "shell", "input", "keyevent", "224"],
             check=False,
         )
         subprocess.run(
-            [adb_path, "shell", "input", "keyevent", "82"],
+            [adb_path, "shell", "wm", "dismiss-keyguard"],
             check=False,
         )
         with open(path, "wb") as out:

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -148,8 +148,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_wakeup_and_menu_keyevent_sent_before_each_screencap(self):
-        """KEYCODE_WAKEUP (224) and KEYCODE_MENU (82) are sent before every screencap,
+    def test_wakeup_and_swipe_sent_before_each_screencap(self):
+        """KEYCODE_WAKEUP (224) and an upward swipe are sent before every screencap,
         in that order, with the screencap coming after both in each retry iteration."""
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
@@ -169,15 +169,15 @@ class TestMainAdbRetryLoop(unittest.TestCase):
             def is_wakeup(args):
                 return "keyevent" in args and "224" in args
 
-            def is_menu(args):
-                return "keyevent" in args and "82" in args
+            def is_swipe(args):
+                return "swipe" in args and "300" in args and "1000" in args
 
             def is_screencap(args):
                 return "screencap" in args
 
             # Walk the call list and verify that each screencap is immediately
-            # preceded by a KEYCODE_MENU (82) call, which is itself preceded by
-            # a KEYCODE_WAKEUP (224) call.  This confirms the ordering within
+            # preceded by a swipe (unlock gesture) call, which is itself preceded
+            # by a KEYCODE_WAKEUP (224) call.  This confirms the ordering within
             # every retry iteration, not just the presence of the calls somewhere
             # in the full list.
             screencap_indices = [i for i, a in enumerate(arg_lists) if is_screencap(a)]
@@ -185,13 +185,13 @@ class TestMainAdbRetryLoop(unittest.TestCase):
 
             for sc_idx in screencap_indices:
                 self.assertGreaterEqual(sc_idx, 2,
-                    "Not enough preceding calls before screencap to fit wakeup + menu")
-                menu_idx = sc_idx - 1
+                    "Not enough preceding calls before screencap to fit wakeup + swipe")
+                swipe_idx = sc_idx - 1
                 wakeup_idx = sc_idx - 2
                 self.assertTrue(
-                    is_menu(arg_lists[menu_idx]),
-                    f"Call immediately before screencap (index {menu_idx}) is not "
-                    f"KEYCODE_MENU (82): {arg_lists[menu_idx]}"
+                    is_swipe(arg_lists[swipe_idx]),
+                    f"Call immediately before screencap (index {swipe_idx}) is not "
+                    f"an upward swipe: {arg_lists[swipe_idx]}"
                 )
                 self.assertTrue(
                     is_wakeup(arg_lists[wakeup_idx]),

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -148,30 +148,56 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_wakeup_keyevents_sent_before_each_screencap(self):
-        """KEYCODE_WAKEUP (224) and KEYCODE_MENU (82) are sent before every screencap."""
+    def test_wakeup_and_dismiss_keyguard_sent_before_each_screencap(self):
+        """KEYCODE_WAKEUP (224) and wm dismiss-keyguard are sent before every screencap,
+        in that order, with the screencap coming after both in each retry iteration."""
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
+            # Run two iterations (fail once, then pass) so we can check ordering
+            # across multiple retry cycles.
+            side_effects = [1, 0]
             with patch("check_green_feed.subprocess.run") as mock_run, \
                  patch("check_green_feed.time.sleep"), \
                  patch("builtins.open", unittest.mock.mock_open()), \
-                 patch("check_green_feed.check_image", return_value=0):
+                 patch("check_green_feed.check_image", side_effect=side_effects):
                 self._run_main(["--adb", "/fake/adb", path])
-            # Inspect the positional-arg lists from each call.
+
+            # Build a flat list of the command argument lists from each call.
             arg_lists = [c.args[0] for c in mock_run.call_args_list if c.args]
-            # KEYCODE_WAKEUP (224) must appear in a keyevent call.
-            wakeup_found = any(
-                "keyevent" in args and "224" in args
-                for args in arg_lists
-            )
-            self.assertTrue(wakeup_found, "KEYCODE_WAKEUP (224) not sent before screencap")
-            # KEYCODE_MENU (82) must appear in a keyevent call.
-            menu_found = any(
-                "keyevent" in args and "82" in args
-                for args in arg_lists
-            )
-            self.assertTrue(menu_found, "KEYCODE_MENU (82) not sent before screencap")
+
+            def is_wakeup(args):
+                return "keyevent" in args and "224" in args
+
+            def is_dismiss_keyguard(args):
+                return "wm" in args and "dismiss-keyguard" in args
+
+            def is_screencap(args):
+                return "screencap" in args
+
+            # Walk the call list and verify that each screencap is immediately
+            # preceded by a dismiss-keyguard call, which is itself preceded by
+            # a wakeup keyevent call.  This confirms the ordering within every
+            # retry iteration, not just the presence of the calls somewhere in
+            # the full list.
+            screencap_indices = [i for i, a in enumerate(arg_lists) if is_screencap(a)]
+            self.assertGreater(len(screencap_indices), 0, "No screencap call found")
+
+            for sc_idx in screencap_indices:
+                self.assertGreaterEqual(sc_idx, 2,
+                    "Not enough preceding calls before screencap to fit wakeup + dismiss")
+                dismiss_idx = sc_idx - 1
+                wakeup_idx = sc_idx - 2
+                self.assertTrue(
+                    is_dismiss_keyguard(arg_lists[dismiss_idx]),
+                    f"Call immediately before screencap (index {dismiss_idx}) is not "
+                    f"wm dismiss-keyguard: {arg_lists[dismiss_idx]}"
+                )
+                self.assertTrue(
+                    is_wakeup(arg_lists[wakeup_idx]),
+                    f"Call two before screencap (index {wakeup_idx}) is not "
+                    f"KEYCODE_WAKEUP (224): {arg_lists[wakeup_idx]}"
+                )
         finally:
             os.unlink(path)
 

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -148,6 +148,33 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_wakeup_keyevents_sent_before_each_screencap(self):
+        """KEYCODE_WAKEUP (224) and KEYCODE_MENU (82) are sent before every screencap."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            with patch("check_green_feed.subprocess.run") as mock_run, \
+                 patch("check_green_feed.time.sleep"), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=0):
+                self._run_main(["--adb", "/fake/adb", path])
+            # Inspect the positional-arg lists from each call.
+            arg_lists = [c.args[0] for c in mock_run.call_args_list if c.args]
+            # KEYCODE_WAKEUP (224) must appear in a keyevent call.
+            wakeup_found = any(
+                "keyevent" in args and "224" in args
+                for args in arg_lists
+            )
+            self.assertTrue(wakeup_found, "KEYCODE_WAKEUP (224) not sent before screencap")
+            # KEYCODE_MENU (82) must appear in a keyevent call.
+            menu_found = any(
+                "keyevent" in args and "82" in args
+                for args in arg_lists
+            )
+            self.assertTrue(menu_found, "KEYCODE_MENU (82) not sent before screencap")
+        finally:
+            os.unlink(path)
+
     def test_single_shot_mode_without_adb_flag(self):
         """Without --adb, main calls check_image directly and returns its result."""
         path = _write_png(255, 0, 0)  # red => fail

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -148,8 +148,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_wakeup_and_dismiss_keyguard_sent_before_each_screencap(self):
-        """KEYCODE_WAKEUP (224) and wm dismiss-keyguard are sent before every screencap,
+    def test_wakeup_and_menu_keyevent_sent_before_each_screencap(self):
+        """KEYCODE_WAKEUP (224) and KEYCODE_MENU (82) are sent before every screencap,
         in that order, with the screencap coming after both in each retry iteration."""
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
@@ -169,29 +169,29 @@ class TestMainAdbRetryLoop(unittest.TestCase):
             def is_wakeup(args):
                 return "keyevent" in args and "224" in args
 
-            def is_dismiss_keyguard(args):
-                return "wm" in args and "dismiss-keyguard" in args
+            def is_menu(args):
+                return "keyevent" in args and "82" in args
 
             def is_screencap(args):
                 return "screencap" in args
 
             # Walk the call list and verify that each screencap is immediately
-            # preceded by a dismiss-keyguard call, which is itself preceded by
-            # a wakeup keyevent call.  This confirms the ordering within every
-            # retry iteration, not just the presence of the calls somewhere in
-            # the full list.
+            # preceded by a KEYCODE_MENU (82) call, which is itself preceded by
+            # a KEYCODE_WAKEUP (224) call.  This confirms the ordering within
+            # every retry iteration, not just the presence of the calls somewhere
+            # in the full list.
             screencap_indices = [i for i, a in enumerate(arg_lists) if is_screencap(a)]
             self.assertGreater(len(screencap_indices), 0, "No screencap call found")
 
             for sc_idx in screencap_indices:
                 self.assertGreaterEqual(sc_idx, 2,
-                    "Not enough preceding calls before screencap to fit wakeup + dismiss")
-                dismiss_idx = sc_idx - 1
+                    "Not enough preceding calls before screencap to fit wakeup + menu")
+                menu_idx = sc_idx - 1
                 wakeup_idx = sc_idx - 2
                 self.assertTrue(
-                    is_dismiss_keyguard(arg_lists[dismiss_idx]),
-                    f"Call immediately before screencap (index {dismiss_idx}) is not "
-                    f"wm dismiss-keyguard: {arg_lists[dismiss_idx]}"
+                    is_menu(arg_lists[menu_idx]),
+                    f"Call immediately before screencap (index {menu_idx}) is not "
+                    f"KEYCODE_MENU (82): {arg_lists[menu_idx]}"
                 )
                 self.assertTrue(
                     is_wakeup(arg_lists[wakeup_idx]),


### PR DESCRIPTION
CI logs showed every screencap in the `check_green_feed.py` pre-flight retry loop returning the lock-screen wallpaper color (#E9E8EF) instead of the expected green View color. The keyguard re-appears after the `adb install` step, so a one-time dismiss before the script runs is not enough.

## What changed and why

Both approaches tried previously have problems:

- **`wm dismiss-keyguard`**: CI evidence showed all 30 retry attempts returning the lock-screen wallpaper, meaning it did not reliably dismiss the swipe keyguard on the API-35 emulator.
- **`KEYCODE_MENU (82)`**: Once `MockCameraActivity` is in the foreground, `KEYCODE_MENU` dispatches `KeyEvent.KEYCODE_MENU` to the activity, which can open the options/overflow menu via `ActionBar`, obscuring the green view.

The fix uses `adb shell input swipe 300 1000 300 300` — an upward swipe gesture that matches what a user would do on the swipe-based emulator lock screen. This approach:

1. Reliably dismisses the swipe-type lock screen that appears before the E2E PIN setup script runs.
2. Has no side-effects on a foregrounded activity — a swipe gesture over the activity surface does not open any menus or dialogs.

The wake sequence in every retry iteration is now: `KEYCODE_WAKEUP (224)` → upward swipe → screencap.

The same change is applied to the pre-launch and post-launch wake sequence in the CI preflight step of `build.yml`, keeping both in sync.

## Tests

The unit test `test_wakeup_and_swipe_sent_before_each_screencap` verifies that every screencap call is immediately preceded by a swipe call, which is itself immediately preceded by `KEYCODE_WAKEUP`, covering the correct ordering across multiple retry iterations.