### PR TITLE
Fix ANR dismiss race and input-service failure in CI pre-flight

### DIFF
--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -231,14 +231,37 @@ def main() -> int:
         # KeyEvent.KEYCODE_MENU to a foregrounded activity and can open the
         # options/overflow menu, obscuring the green view.  When the screen is
         # already unlocked the swipe is a harmless gesture over the activity.
-        subprocess.run(
+        input_service_ok = True
+        wakeup_result = subprocess.run(
             [adb_path, "shell", "input", "keyevent", "224"],
             check=False,
+            capture_output=True,
+            text=True,
         )
-        subprocess.run(
+        if wakeup_result.returncode != 0 or "Can't find service" in wakeup_result.stderr:
+            print(
+                f"WARNING: input service unavailable during KEYCODE_WAKEUP "
+                f"(attempt {attempt}); sleeping extra {RETRY_DELAY_SECONDS}s for recovery.",
+                file=sys.stderr,
+            )
+            input_service_ok = False
+            time.sleep(RETRY_DELAY_SECONDS)
+
+        swipe_result = subprocess.run(
             [adb_path, "shell", "input", "swipe", "300", "1000", "300", "300"],
             check=False,
+            capture_output=True,
+            text=True,
         )
+        if swipe_result.returncode != 0 or "Can't find service" in swipe_result.stderr:
+            if input_service_ok:
+                # Only log/sleep here if we haven't already done so for the wakeup.
+                print(
+                    f"WARNING: input service unavailable during swipe "
+                    f"(attempt {attempt}); sleeping extra {RETRY_DELAY_SECONDS}s for recovery.",
+                    file=sys.stderr,
+                )
+                time.sleep(RETRY_DELAY_SECONDS)
         # Wait for any swipe animation to settle before capturing the screen.
         time.sleep(RETRY_DELAY_SECONDS)
         with open(path, "wb") as out:

--- a/scripts/dismiss_anr.sh
+++ b/scripts/dismiss_anr.sh
@@ -127,8 +127,19 @@
     fi
 
     if [[ $idle_count -ge 2 ]]; then
-      echo "[dismiss_anr] Pixel Launcher has settled (idle_count=$idle_count) — exiting." >&2
-      exit 0
+      # Safety check: even if CPU is idle, confirm the ANR dialog is gone.
+      # The logcat trigger can miss the event if the ANR fires before the stream
+      # starts or after the CPU has already settled.  A dumpsys window check here
+      # is the fallback that catches those cases.
+      if "$ADB" shell dumpsys window 2>/dev/null | grep -q "AppNotRespondingDialog"; then
+        echo "[dismiss_anr] CPU idle but ANR dialog still present (dumpsys window) — sending KEYCODE_BACK." >&2
+        "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
+        idle_count=0
+        # Continue the loop instead of exiting.
+      else
+        echo "[dismiss_anr] Pixel Launcher has settled (idle_count=$idle_count) — exiting." >&2
+        exit 0
+      fi
     fi
 
     sleep "$POLL_INTERVAL"

--- a/scripts/dismiss_anr.sh
+++ b/scripts/dismiss_anr.sh
@@ -131,7 +131,8 @@
       # The logcat trigger can miss the event if the ANR fires before the stream
       # starts or after the CPU has already settled.  A dumpsys window check here
       # is the fallback that catches those cases.
-      if "$ADB" shell dumpsys window 2>/dev/null | grep -q "AppNotRespondingDialog"; then
+      window_dump=$("$ADB" shell dumpsys window 2>/dev/null) || true
+      if echo "$window_dump" | grep -q "AppNotRespondingDialog"; then
         echo "[dismiss_anr] CPU idle but ANR dialog still present (dumpsys window) — sending KEYCODE_BACK." >&2
         "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
         idle_count=0

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -86,11 +86,19 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         with patch.object(sys, "argv", ["check_green_feed.py"] + extra_argv):
             return cgf.main()
 
+    def _make_ok_run_result(self):
+        """Return a mock CompletedProcess with returncode=0 and empty stderr."""
+        r = MagicMock()
+        r.returncode = 0
+        r.stderr = ""
+        return r
+
     def test_succeeds_on_first_attempt(self):
         """When the image passes on the first try, main exits 0."""
         green_png = _write_png(cgf.TARGET_R, cgf.TARGET_G, cgf.TARGET_B)
         try:
-            with patch("check_green_feed.subprocess.run") as mock_run, \
+            with patch("check_green_feed.subprocess.run",
+                       return_value=self._make_ok_run_result()) as mock_run, \
                  patch("check_green_feed.time.sleep") as mock_sleep, \
                  patch("builtins.open", create=True) as mock_open:
                 # subprocess.run writes nothing; check_image reads the pre-existing file
@@ -113,7 +121,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         os.close(fd)
         try:
             side_effects = [1, 1, 0]  # fail, fail, pass
-            with patch("check_green_feed.subprocess.run"), \
+            with patch("check_green_feed.subprocess.run",
+                       return_value=self._make_ok_run_result()), \
                  patch("check_green_feed.time.sleep"), \
                  patch("builtins.open", unittest.mock.mock_open()), \
                  patch("check_green_feed.check_image", side_effect=side_effects):
@@ -127,7 +136,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
-            with patch("check_green_feed.subprocess.run"), \
+            with patch("check_green_feed.subprocess.run",
+                       return_value=self._make_ok_run_result()), \
                  patch("check_green_feed.time.sleep"), \
                  patch("builtins.open", unittest.mock.mock_open()), \
                  patch("check_green_feed.check_image", return_value=1):
@@ -142,7 +152,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
-            with patch("check_green_feed.subprocess.run"), \
+            with patch("check_green_feed.subprocess.run",
+                       return_value=self._make_ok_run_result()), \
                  patch("check_green_feed.time.sleep") as mock_sleep, \
                  patch("builtins.open", unittest.mock.mock_open()), \
                  patch("check_green_feed.check_image", return_value=1):
@@ -161,7 +172,8 @@ class TestMainAdbRetryLoop(unittest.TestCase):
             # Run two iterations (fail once, then pass) so we can check ordering
             # across multiple retry cycles.
             side_effects = [1, 0]
-            with patch("check_green_feed.subprocess.run") as mock_run, \
+            with patch("check_green_feed.subprocess.run",
+                       return_value=self._make_ok_run_result()) as mock_run, \
                  patch("check_green_feed.time.sleep"), \
                  patch("builtins.open", unittest.mock.mock_open()), \
                  patch("check_green_feed.check_image", side_effect=side_effects):
@@ -225,6 +237,10 @@ class TestMainAdbRetryLoop(unittest.TestCase):
                     call_log.append("screencap")
                 else:
                     call_log.append("other")
+                r = MagicMock()
+                r.returncode = 0
+                r.stderr = ""
+                return r
 
             def fake_sleep(seconds):
                 call_log.append(f"sleep({seconds})")
@@ -274,6 +290,164 @@ class TestMainAdbRetryLoop(unittest.TestCase):
     def test_usage_error_with_adb_but_no_image(self):
         result = self._run_main(["--adb", "/fake/adb"])
         self.assertEqual(result, 2)
+
+
+class TestInputServiceFailure(unittest.TestCase):
+    """Tests for the input-service-unavailability handling in the retry loop."""
+
+    def _run_main(self, extra_argv: list[str]) -> int:
+        with patch.object(sys, "argv", ["check_green_feed.py"] + extra_argv):
+            return cgf.main()
+
+    def _make_run_result(self, returncode=0, stderr=""):
+        """Build a mock CompletedProcess-like object."""
+        result = MagicMock()
+        result.returncode = returncode
+        result.stderr = stderr
+        return result
+
+    def test_wakeup_failure_causes_extra_sleep_and_warning(self):
+        """When KEYCODE_WAKEUP fails (non-zero exit), an extra sleep is inserted
+        and a warning is printed to stderr; the screencap still runs."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            # KEYCODE_WAKEUP fails; swipe succeeds; screencap succeeds.
+            wakeup_fail = self._make_run_result(returncode=1, stderr="")
+            swipe_ok = self._make_run_result(returncode=0, stderr="")
+            screencap_ok = self._make_run_result(returncode=0, stderr="")
+
+            run_side_effects = [wakeup_fail, swipe_ok, screencap_ok]
+
+            sleep_calls: list[float] = []
+
+            def fake_sleep(s):
+                sleep_calls.append(s)
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=run_side_effects) as mock_run, \
+                 patch("check_green_feed.time.sleep", side_effect=fake_sleep), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=0), \
+                 patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0)
+            # Extra sleep must have been inserted (more than the standard 2 per attempt).
+            self.assertGreater(len(sleep_calls), 2,
+                "Expected extra sleep when wakeup fails, but sleep count was not > 2")
+            # A warning must have been written to stderr.
+            warning_output = mock_stderr.getvalue()
+            self.assertIn("WARNING", warning_output)
+            self.assertIn("input service unavailable", warning_output)
+            # Screencap must still have been called.
+            arg_lists = [c.args[0] for c in mock_run.call_args_list if c.args]
+            screencap_calls = [a for a in arg_lists if "screencap" in a]
+            self.assertEqual(len(screencap_calls), 1, "screencap must still run despite wakeup failure")
+        finally:
+            os.unlink(path)
+
+    def test_swipe_failure_causes_extra_sleep_and_warning(self):
+        """When the swipe command stderr contains 'Can't find service', an extra
+        sleep is inserted and a warning is printed; the screencap still runs."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            wakeup_ok = self._make_run_result(returncode=0, stderr="")
+            swipe_fail = self._make_run_result(
+                returncode=1, stderr="cmd: Can't find service: input"
+            )
+            screencap_ok = self._make_run_result(returncode=0, stderr="")
+
+            run_side_effects = [wakeup_ok, swipe_fail, screencap_ok]
+
+            sleep_calls: list[float] = []
+
+            def fake_sleep(s):
+                sleep_calls.append(s)
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=run_side_effects) as mock_run, \
+                 patch("check_green_feed.time.sleep", side_effect=fake_sleep), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=0), \
+                 patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0)
+            self.assertGreater(len(sleep_calls), 2,
+                "Expected extra sleep when swipe fails, but sleep count was not > 2")
+            warning_output = mock_stderr.getvalue()
+            self.assertIn("WARNING", warning_output)
+            self.assertIn("input service unavailable", warning_output)
+            arg_lists = [c.args[0] for c in mock_run.call_args_list if c.args]
+            screencap_calls = [a for a in arg_lists if "screencap" in a]
+            self.assertEqual(len(screencap_calls), 1, "screencap must still run despite swipe failure")
+        finally:
+            os.unlink(path)
+
+    def test_input_service_failure_does_not_abort_retry_loop(self):
+        """Input service failure on every attempt does not prevent the retry loop
+        from continuing; main eventually returns 1 after MAX_ATTEMPTS."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            # Every wakeup and swipe fails; screencap always runs.
+            def make_run_result_for(args, **kwargs):
+                cmd = args
+                if "keyevent" in cmd or "swipe" in cmd:
+                    r = MagicMock()
+                    r.returncode = 1
+                    r.stderr = "cmd: Can't find service: input"
+                    return r
+                r = MagicMock()
+                r.returncode = 0
+                r.stderr = ""
+                return r
+
+            screencap_count = [0]
+
+            def counting_run(args, **kwargs):
+                if "screencap" in args:
+                    screencap_count[0] += 1
+                return make_run_result_for(args, **kwargs)
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=counting_run), \
+                 patch("check_green_feed.time.sleep"), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=1), \
+                 patch("sys.stderr", new_callable=io.StringIO):
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 1,
+                "main should return 1 when all attempts fail, not abort early")
+            self.assertEqual(screencap_count[0], cgf.MAX_ATTEMPTS,
+                f"screencap should run on every attempt; expected {cgf.MAX_ATTEMPTS}, got {screencap_count[0]}")
+        finally:
+            os.unlink(path)
+
+    def test_no_extra_sleep_when_input_service_succeeds(self):
+        """When both input calls succeed, exactly 2 sleeps occur per attempt
+        (the standard behavior is not regressed)."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            ok = self._make_run_result(returncode=0, stderr="")
+
+            with patch("check_green_feed.subprocess.run", return_value=ok), \
+                 patch("check_green_feed.time.sleep") as mock_sleep, \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=0):
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0)
+            # Exactly 2 sleeps on the first (successful) attempt: one at the top
+            # of the loop and one between swipe and screencap.
+            self.assertEqual(mock_sleep.call_count, 2,
+                f"Expected 2 sleeps when input service succeeds, got {mock_sleep.call_count}")
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/scripts/test_dismiss_anr.sh
+++ b/scripts/test_dismiss_anr.sh
@@ -280,6 +280,76 @@ else
   fail "second ANR: KEYCODE_BACK sent only $keyevent_count time(s) — expected at least 2"
 fi
 
+# ── (g) idle_count=2 but ANR dialog still present (dumpsys window fallback) ───
+echo ""
+echo "=== (g) idle_count=2 but ANR dialog still present — dumpsys window fallback ==="
+
+# Scenario: logcat never fires (CPU settled without logcat trigger), but the ANR
+# dialog is still on screen.  dumpsys window returns AppNotRespondingDialog on the
+# first idle-exit check, KEYCODE_BACK is sent, idle_count resets to 0.  On the
+# second idle-exit check dumpsys window is clean, so the script exits 0.
+# We verify that KEYCODE_BACK was sent exactly once and the script exits 0.
+
+DUMPSYS_WINDOW_CALL_COUNT_FILE="$TMPDIR_TESTS/dumpsys_window_call_count"
+echo 0 > "$DUMPSYS_WINDOW_CALL_COUNT_FILE"
+DUMPSYS_WINDOW_KEYEVENT_FILE="$TMPDIR_TESTS/dumpsys_window_keyevent"
+
+mock_adb_dumpsys_anr="$(make_mock_adb "adb_dumpsys_anr" "
+case \"\$*\" in
+  *'logcat -c'*)
+    exit 0
+    ;;
+  *'logcat'*)
+    # Hang silently — logcat never fires.
+    sleep 60
+    ;;
+  *'dumpsys cpuinfo'*)
+    # Always report low CPU so idle_count increments every iteration.
+    echo '  1% com.google.android.apps.nexuslauncher: launcher'
+    ;;
+  *'dumpsys window'*)
+    count=\$(cat '$DUMPSYS_WINDOW_CALL_COUNT_FILE')
+    count=\$((count + 1))
+    echo \$count > '$DUMPSYS_WINDOW_CALL_COUNT_FILE'
+    if [[ \$count -le 1 ]]; then
+      # First check: dialog still present.
+      echo 'AppNotRespondingDialog'
+    else
+      # Second check: dialog gone.
+      echo 'WindowState idle'
+    fi
+    ;;
+  *'input keyevent KEYCODE_BACK'*)
+    touch '$DUMPSYS_WINDOW_KEYEVENT_FILE'
+    ;;
+  *)
+    :
+    ;;
+esac
+")"
+
+bash "$DISMISS_ANR" --adb "$mock_adb_dumpsys_anr"
+dumpsys_status=$?
+
+if [[ $dumpsys_status -eq 0 ]]; then
+  pass "dumpsys window fallback: script exits 0"
+else
+  fail "dumpsys window fallback: script exited $dumpsys_status (expected 0)"
+fi
+
+if [[ -f "$DUMPSYS_WINDOW_KEYEVENT_FILE" ]]; then
+  pass "dumpsys window fallback: KEYCODE_BACK sent when ANR dialog detected via dumpsys window"
+else
+  fail "dumpsys window fallback: KEYCODE_BACK was NOT sent when ANR dialog was found via dumpsys window"
+fi
+
+dumpsys_call_count="$(cat "$DUMPSYS_WINDOW_CALL_COUNT_FILE")"
+if [[ $dumpsys_call_count -ge 2 ]]; then
+  pass "dumpsys window fallback: dumpsys window was checked more than once (got $dumpsys_call_count) — loop continued after first dialog detection"
+else
+  fail "dumpsys window fallback: dumpsys window checked only $dumpsys_call_count time(s) — loop should have continued"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed."


### PR DESCRIPTION
Fixes #194

## Problem

Two related failures were observed in CI after PR #202 was merged:

1. **`dismiss_anr.sh` exited via `idle_count=2` without dismissing the dialog.** The logcat stream started after the ANR event fired (or the CPU settled before the dialog rendered), so the logcat trigger never fired. The script exited leaving the ANR dialog on screen.

2. **`cmd: Can't find service: input` flooded the log.** With the ANR dialog still present, the Android input service was unavailable. Every `adb shell input keyevent` / `adb shell input swipe` call in `check_green_feed.py`'s retry loop failed silently. The screen was never refreshed, so all 30 retries captured the ANR dialog instead of the green view.

## Fix 1 — `scripts/dismiss_anr.sh`: `dumpsys window` safety check at idle-exit

Before exiting when `idle_count >= 2`, the script now runs:

```bash
adb shell dumpsys window | grep -q "AppNotRespondingDialog"
```

If the dialog is present: `KEYCODE_BACK` is sent, `idle_count` resets to 0, and the loop continues. If the dialog is absent, the script exits as before.

Logcat is still the fast-path (fires before the dialog renders). The `dumpsys window` check is a fallback that catches the race window where logcat missed the event.

New test **(g)** added to `test_dismiss_anr.sh`: CPU is idle (`idle_count=2`), but `dumpsys window` returns `AppNotRespondingDialog` on the first check and clean on the second — verifies `KEYCODE_BACK` is sent and the loop continues.

## Fix 2 — `scripts/check_green_feed.py`: input-service failure handling

`subprocess.run` is now called with `capture_output=True` for the `KEYCODE_WAKEUP` and `swipe` calls so the exit code and stderr are inspectable. If either returns non-zero or stderr contains `"Can't find service"`:

- A warning is printed to stderr.
- An extra `RETRY_DELAY_SECONDS` sleep is inserted to let the service recover.
- The screencap still runs on the same attempt (the screen may already be correct).
- The retry loop continues normally.

New `TestInputServiceFailure` class added to `test_check_green_feed.py` covering: wakeup failure, swipe failure (`"Can't find service"` in stderr), sustained failure does not abort the retry loop, and no extra sleep regression when the input service is healthy. Existing mocks updated to return `returncode=0` / empty `stderr` so the new check does not falsely trigger on default `MagicMock` return values.

---
_Generated by [Claude Code](https://claude.ai/code/session_018968Fyo51G78FriMNJnP1H)_