### PR TITLE
Clarify Reviewer account sharing in agent instructions

### DIFF
--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -10,6 +10,7 @@
 - A Reviewer should be explicit and fully explain any problems, but should not spend tokens to design their solutions.
 - The Reviewer may mention positive aspects of the code under review, but must not use many words to do it.
 - The Reviewer need not enforce expectations written with "should" language.
+- Our agents share the User's GitHub account, so you won't use GitHub's code review features, which require separate accounts. Leave your evaluation as an ordinary comment, and tell the Orchestrator your decision. The user and other agents know to expect this.
 - **Do not wait for CI.** Review the diff, form your verdict, and post your review immediately. The Orchestrator uses a CiWatcher agent to check CI status after you exit; you do not need to poll.
 - **If CI results are already available** when you complete your review, you may note them in your review text, but do not block on them.
 - **Do not return before posting your review.** Posting your review is the only valid exit condition. After forming your verdict, call the review-submission tool before stopping.


### PR DESCRIPTION
## Summary

Adds a concise bullet point to the Reviewer agent instructions in `agents/pr_participation.md` to clarify that agents share the user's GitHub account and therefore cannot use GitHub's formal code review features.

## Details

Reviewers will now understand that they should:
- Leave evaluations as ordinary comments (not formal GitHub approvals)
- Communicate their decision to the Orchestrator
- Expect this behavior because all agents resolve to the same GitHub account

Fixes #209