### PR TITLE
Fix late-ANR race with per-retry dismiss and comprehensive diagnostics

### DIFF
--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -152,6 +152,11 @@ def dominant_color(pixels_region: list[tuple[int, int, int]]) -> tuple[int, int,
 
 
 _ANR_DISMISS_MAX_RETRIES = 5
+# Intentionally separate from RETRY_DELAY_SECONDS: this poll interval governs how
+# long to wait between each KEYCODE_BACK send and the subsequent dumpsys window
+# confirmation inside _dismiss_anr_if_present(), while RETRY_DELAY_SECONDS controls
+# the outer green-feed retry loop.  They happen to share the same value today but
+# may diverge if one needs tuning independently of the other.
 _ANR_DISMISS_POLL_SECONDS = 2
 
 

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -151,6 +151,10 @@ def dominant_color(pixels_region: list[tuple[int, int, int]]) -> tuple[int, int,
     return (avg_r, avg_g, avg_b)
 
 
+_ANR_DISMISS_MAX_RETRIES = 5
+_ANR_DISMISS_POLL_SECONDS = 2
+
+
 def _dismiss_anr_if_present(adb: str) -> None:
     """Check for the Pixel Launcher ANR dialog and dismiss it if present.
 
@@ -159,6 +163,12 @@ def _dismiss_anr_if_present(adb: str) -> None:
     dialog can appear during or after the `am start -W` call (which takes 3+ s),
     after the watcher has already exited.  By checking here we ensure the retry
     loop is self-defending against late-appearing ANR dialogs.
+
+    After sending KEYCODE_BACK, polls dumpsys window to confirm the dialog has
+    actually disappeared before returning, retrying up to _ANR_DISMISS_MAX_RETRIES
+    times.  This guards against cases where KEYCODE_BACK is dispatched but the
+    dialog does not dismiss immediately (e.g. slow emulator rendering, focus
+    stolen by another window).
     """
     try:
         window_dump = subprocess.run(
@@ -167,11 +177,15 @@ def _dismiss_anr_if_present(adb: str) -> None:
             text=True,
             timeout=10,
         )
-        if "Application Not Responding" in window_dump.stdout:
-            print(
-                "[check_green_feed] ANR dialog detected before screencap — sending KEYCODE_BACK.",
-                file=sys.stderr,
-            )
+        if "Application Not Responding" not in window_dump.stdout:
+            return
+
+        ts = time.strftime("%H:%M:%S")
+        print(
+            f"[check_green_feed] {ts} ANR dialog detected before screencap — sending KEYCODE_BACK.",
+            file=sys.stderr,
+        )
+        for attempt in range(1, _ANR_DISMISS_MAX_RETRIES + 1):
             subprocess.run(
                 [adb, "shell", "input", "keyevent", "KEYCODE_BACK"],
                 check=False,
@@ -179,7 +193,29 @@ def _dismiss_anr_if_present(adb: str) -> None:
                 text=True,
                 timeout=10,
             )
-            time.sleep(RETRY_DELAY_SECONDS)
+            time.sleep(_ANR_DISMISS_POLL_SECONDS)
+            ts = time.strftime("%H:%M:%S")
+            confirm = subprocess.run(
+                [adb, "shell", "dumpsys", "window"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if "Application Not Responding" not in confirm.stdout:
+                print(
+                    f"[check_green_feed] {ts} ANR dialog dismissed after {attempt} KEYCODE_BACK(s).",
+                    file=sys.stderr,
+                )
+                return
+            print(
+                f"[check_green_feed] {ts} ANR dialog still present after KEYCODE_BACK #{attempt}.",
+                file=sys.stderr,
+            )
+        print(
+            f"[check_green_feed] {time.strftime('%H:%M:%S')} ANR dialog persisted after "
+            f"{_ANR_DISMISS_MAX_RETRIES} KEYCODE_BACK sends — proceeding to screencap anyway.",
+            file=sys.stderr,
+        )
     except Exception as exc:  # noqa: BLE001
         print(
             f"[check_green_feed] ANR pre-screencap check failed (ignored): {exc}",

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -167,7 +167,7 @@ def _dismiss_anr_if_present(adb: str) -> None:
             text=True,
             timeout=10,
         )
-        if "AppNotRespondingDialog" in window_dump.stdout:
+        if "Application Not Responding" in window_dump.stdout:
             print(
                 "[check_green_feed] ANR dialog detected before screencap — sending KEYCODE_BACK.",
                 file=sys.stderr,

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -35,6 +35,9 @@ MIN_COVERAGE = 0.90
 MAX_ATTEMPTS = 30
 RETRY_DELAY_SECONDS = 2
 
+# Directory for diagnostic screencap saves (relative to cwd, created on demand).
+DIAG_SCREENCAP_DIR = "ci_diag_screencaps"
+
 
 def decode_png_to_rgb(path: str) -> tuple[list[list[tuple[int, int, int]]], int, int]:
     """Decode a PNG file to a 2D list of (r, g, b) tuples."""
@@ -146,6 +149,88 @@ def dominant_color(pixels_region: list[tuple[int, int, int]]) -> tuple[int, int,
     return (avg_r, avg_g, avg_b)
 
 
+def _dump_first_failure_diagnostics(
+    adb: str, screencap_path: str, attempt: int, start_time: float
+) -> None:
+    """Emit diagnostics to stderr on the first retry-loop failure.
+
+    Logs the elapsed time, dumps window focus state and recent ANR events from
+    logcat, and saves the current screencap to a dedicated diagnostics file so CI
+    artifact collectors can retrieve it.  This runs only once (on the first
+    failure) to avoid filling logs with repetitive output on later retries.
+    """
+    elapsed = time.monotonic() - start_time
+    ts = time.strftime("%H:%M:%S")
+    print(
+        f"[check_green_feed] {ts} FIRST FAILURE DIAGNOSTICS "
+        f"(attempt={attempt}, elapsed={elapsed:.1f}s)",
+        file=sys.stderr,
+    )
+
+    # Dump window focus / dialog state — filtered for the most relevant lines.
+    try:
+        window_result = subprocess.run(
+            [adb, "shell", "dumpsys", "window"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        relevant_lines = [
+            line
+            for line in window_result.stdout.splitlines()
+            if any(kw in line for kw in ("Dialog", "Focused", "mCurrentFocus"))
+        ]
+        print(
+            f"[check_green_feed] {ts} dumpsys window (Dialog/Focused/mCurrentFocus lines):",
+            file=sys.stderr,
+        )
+        for line in relevant_lines:
+            print(f"  {line}", file=sys.stderr)
+        if not relevant_lines:
+            print("  (no matching lines)", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[check_green_feed] dumpsys window failed: {exc}", file=sys.stderr)
+
+    # Dump the last 20 lines of recent ActivityManager errors from logcat.
+    try:
+        logcat_result = subprocess.run(
+            [adb, "shell", "logcat", "-d", "-t", "100", "ActivityManager:E", "*:S"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        logcat_lines = logcat_result.stdout.splitlines()[-20:]
+        print(
+            f"[check_green_feed] {ts} logcat ActivityManager:E (last 20 lines):",
+            file=sys.stderr,
+        )
+        for line in logcat_lines:
+            print(f"  {line}", file=sys.stderr)
+        if not logcat_lines:
+            print("  (no output)", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[check_green_feed] logcat dump failed: {exc}", file=sys.stderr)
+
+    # Save the screencap to a dedicated diagnostics file.
+    import os
+
+    os.makedirs(DIAG_SCREENCAP_DIR, exist_ok=True)
+    diag_path = os.path.join(DIAG_SCREENCAP_DIR, f"failure_attempt_{attempt:03d}.png")
+    try:
+        import shutil
+
+        shutil.copy2(screencap_path, diag_path)
+        print(
+            f"[check_green_feed] {ts} Diagnostic screencap saved: {diag_path}",
+            file=sys.stderr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[check_green_feed] Failed to save diagnostic screencap: {exc}",
+            file=sys.stderr,
+        )
+
+
 def check_image(path: str) -> int:
     """Check a single PNG image. Returns 0 on pass, 1 on fail, 2 on error."""
     try:
@@ -217,6 +302,8 @@ def main() -> int:
         return check_image(path)
 
     # Retry-loop mode: capture a fresh screencap on each attempt.
+    start_time = time.monotonic()
+    first_failure_diagnosed = False
     for attempt in range(1, MAX_ATTEMPTS + 1):
         # Sleep first so the display has time to render before the first check
         # and between retries; the caller has already waited for am start -W.
@@ -273,6 +360,9 @@ def main() -> int:
         result = check_image(path)
         if result == 0:
             return 0
+        if not first_failure_diagnosed:
+            first_failure_diagnosed = True
+            _dump_first_failure_diagnostics(adb_path, path, attempt, start_time)
         if attempt < MAX_ATTEMPTS:
             print(f"Attempt {attempt} failed, retrying...")
     print(f"ERROR: pre-flight failed after {MAX_ATTEMPTS} attempts")

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -149,6 +149,42 @@ def dominant_color(pixels_region: list[tuple[int, int, int]]) -> tuple[int, int,
     return (avg_r, avg_g, avg_b)
 
 
+def _dismiss_anr_if_present(adb: str) -> None:
+    """Check for the Pixel Launcher ANR dialog and dismiss it if present.
+
+    This is a lightweight guard that runs before every screencap in the retry
+    loop.  dismiss_anr.sh exits as soon as Launcher CPU goes idle, but the ANR
+    dialog can appear during or after the `am start -W` call (which takes 3+ s),
+    after the watcher has already exited.  By checking here we ensure the retry
+    loop is self-defending against late-appearing ANR dialogs.
+    """
+    try:
+        window_dump = subprocess.run(
+            [adb, "shell", "dumpsys", "window"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if "AppNotRespondingDialog" in window_dump.stdout:
+            print(
+                "[check_green_feed] ANR dialog detected before screencap — sending KEYCODE_BACK.",
+                file=sys.stderr,
+            )
+            subprocess.run(
+                [adb, "shell", "input", "keyevent", "KEYCODE_BACK"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            time.sleep(RETRY_DELAY_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[check_green_feed] ANR pre-screencap check failed (ignored): {exc}",
+            file=sys.stderr,
+        )
+
+
 def _dump_first_failure_diagnostics(
     adb: str, screencap_path: str, attempt: int, start_time: float
 ) -> None:
@@ -351,6 +387,11 @@ def main() -> int:
                 time.sleep(RETRY_DELAY_SECONDS)
         # Wait for any swipe animation to settle before capturing the screen.
         time.sleep(RETRY_DELAY_SECONDS)
+        # Per-retry ANR check: if the Pixel Launcher ANR dialog appeared after
+        # dismiss_anr.sh exited (which can happen because the watcher exits as
+        # soon as CPU goes idle, before am start -W completes), dismiss it now
+        # rather than capturing a screencap that is obscured by the dialog.
+        _dismiss_anr_if_present(adb_path)
         with open(path, "wb") as out:
             subprocess.run(
                 [adb_path, "exec-out", "screencap", "-p"],

--- a/scripts/check_green_feed.py
+++ b/scripts/check_green_feed.py
@@ -16,6 +16,8 @@ Usage:
 Exits 0 on success, non-zero on failure (prints actual dominant color).
 """
 
+import os
+import shutil
 import struct
 import subprocess
 import sys
@@ -248,13 +250,9 @@ def _dump_first_failure_diagnostics(
         print(f"[check_green_feed] logcat dump failed: {exc}", file=sys.stderr)
 
     # Save the screencap to a dedicated diagnostics file.
-    import os
-
     os.makedirs(DIAG_SCREENCAP_DIR, exist_ok=True)
     diag_path = os.path.join(DIAG_SCREENCAP_DIR, f"failure_attempt_{attempt:03d}.png")
     try:
-        import shutil
-
         shutil.copy2(screencap_path, diag_path)
         print(
             f"[check_green_feed] {ts} Diagnostic screencap saved: {diag_path}",

--- a/scripts/dismiss_anr.sh
+++ b/scripts/dismiss_anr.sh
@@ -94,9 +94,9 @@
     kill "$ADB_LOGCAT_PID" 2>/dev/null || true
     kill "$LOGCAT_PID" 2>/dev/null || true
     rm -f "$ANR_FLAG" "$ADB_LOGCAT_PID_FILE" "$LOGCAT_FIFO"
-    echo "[dismiss_anr] '"$(date '+%H:%M:%S.%3N')"' EXIT trap: cleanup complete (elapsed ${_elapsed_ms}ms)." >&2
-    echo "[dismiss_anr] '"$(date '+%H:%M:%S.%3N')"' Last ActivityManager errors:" >&2
-    '"$ADB"' shell logcat -d ActivityManager:E '"'"'*:S'"'"' 2>/dev/null | tail -10 >&2 || true
+    echo "[dismiss_anr] [$(_ts)] EXIT trap: cleanup complete (elapsed ${_elapsed_ms}ms)." >&2
+    echo "[dismiss_anr] [$(_ts)] Last ActivityManager errors:" >&2
+    "$ADB" shell logcat -d ActivityManager:E '"'"'*:S'"'"' 2>/dev/null | tail -10 >&2 || true
   ' EXIT
 
   # ── Poll loop ────────────────────────────────────────────────────────────────
@@ -116,10 +116,8 @@
     if [ -f "$ANR_FLAG" ]; then
       rm -f "$ANR_FLAG"
       echo "[dismiss_anr] $(_ts) Logcat ANR trigger fired — waiting ${SLEEP_AFTER_ANR_DETECTED}s for dialog to render." >&2
-      echo "[dismiss_anr] ANR detected via logcat — waiting ${SLEEP_AFTER_ANR_DETECTED}s for dialog to render." >&2
       sleep "$SLEEP_AFTER_ANR_DETECTED"
       echo "[dismiss_anr] $(_ts) Sending KEYCODE_BACK to dismiss ANR dialog." >&2
-      echo "[dismiss_anr] Sending KEYCODE_BACK to dismiss ANR dialog." >&2
       "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
       idle_count=0
       # Fall through to the CPU check on this same iteration.
@@ -152,13 +150,11 @@
       window_dump=$("$ADB" shell dumpsys window 2>/dev/null) || true
       if echo "$window_dump" | grep -q "AppNotRespondingDialog"; then
         echo "[dismiss_anr] $(_ts) dumpsys window safety check: AppNotRespondingDialog found — sending KEYCODE_BACK." >&2
-        echo "[dismiss_anr] CPU idle but ANR dialog still present (dumpsys window) — sending KEYCODE_BACK." >&2
         "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
         idle_count=0
         # Continue the loop instead of exiting.
       else
         echo "[dismiss_anr] $(_ts) dumpsys window safety check: no AppNotRespondingDialog found." >&2
-        echo "[dismiss_anr] Pixel Launcher has settled (idle_count=$idle_count) — exiting." >&2
         exit 0
       fi
     fi
@@ -168,6 +164,5 @@
   done
 
   echo "[dismiss_anr] $(_ts) Timeout after ${TIMEOUT}s — proceeding anyway." >&2
-  echo "[dismiss_anr] Timeout after ${TIMEOUT}s — proceeding anyway." >&2
   exit 0
 ) || true

--- a/scripts/dismiss_anr.sh
+++ b/scripts/dismiss_anr.sh
@@ -29,6 +29,9 @@
 (
   set -euo pipefail
 
+  # ── Timestamp helper ─────────────────────────────────────────────────────────
+  _ts() { date '+%H:%M:%S.%3N'; }
+
   # ── Resolve adb ─────────────────────────────────────────────────────────────
   ADB=""
   while [[ $# -gt 0 ]]; do
@@ -46,6 +49,9 @@
   if [[ -z "$ADB" ]]; then
     ADB="${ANDROID_HOME:-}/platform-tools/adb"
   fi
+
+  SCRIPT_START_TS="$(date +%s%3N)"
+  echo "[dismiss_anr] $(_ts) Script started (adb=$ADB)." >&2
 
   # ── Phase 1: logcat trigger ──────────────────────────────────────────────────
   # Clear the logcat buffer and start a background stream that sets a flag file
@@ -71,6 +77,7 @@
   # Start adb logcat in the background, feeding a named pipe.
   "$ADB" logcat ActivityManager:E '*:S' 2>/dev/null > "$LOGCAT_FIFO" &
   echo $! > "$ADB_LOGCAT_PID_FILE"
+  echo "[dismiss_anr] $(_ts) Logcat stream started (pid=$(cat "$ADB_LOGCAT_PID_FILE"))." >&2
 
   # Consumer subshell: reads from the fifo and touches ANR_FLAG on every match.
   ( while IFS= read -r line; do
@@ -82,10 +89,14 @@
   LOGCAT_PID=$!
 
   trap '
+    _elapsed_ms=$(( $(date +%s%3N) - SCRIPT_START_TS ))
     ADB_LOGCAT_PID="$(cat "$ADB_LOGCAT_PID_FILE" 2>/dev/null || true)"
     kill "$ADB_LOGCAT_PID" 2>/dev/null || true
     kill "$LOGCAT_PID" 2>/dev/null || true
     rm -f "$ANR_FLAG" "$ADB_LOGCAT_PID_FILE" "$LOGCAT_FIFO"
+    echo "[dismiss_anr] '"$(date '+%H:%M:%S.%3N')"' EXIT trap: cleanup complete (elapsed ${_elapsed_ms}ms)." >&2
+    echo "[dismiss_anr] '"$(date '+%H:%M:%S.%3N')"' Last ActivityManager errors:" >&2
+    '"$ADB"' shell logcat -d ActivityManager:E '"'"'*:S'"'"' 2>/dev/null | tail -10 >&2 || true
   ' EXIT
 
   # ── Poll loop ────────────────────────────────────────────────────────────────
@@ -96,13 +107,18 @@
   SLEEP_AFTER_ANR_DETECTED="${SLEEP_AFTER_ANR_DETECTED:-7}"
   elapsed=0
   idle_count=0
+  poll_n=0
 
   while [[ $elapsed -lt $TIMEOUT ]]; do
+    poll_n=$((poll_n + 1))
+
     # Phase 2: if the logcat background job flagged an ANR, dismiss it.
     if [ -f "$ANR_FLAG" ]; then
       rm -f "$ANR_FLAG"
+      echo "[dismiss_anr] $(_ts) Logcat ANR trigger fired — waiting ${SLEEP_AFTER_ANR_DETECTED}s for dialog to render." >&2
       echo "[dismiss_anr] ANR detected via logcat — waiting ${SLEEP_AFTER_ANR_DETECTED}s for dialog to render." >&2
       sleep "$SLEEP_AFTER_ANR_DETECTED"
+      echo "[dismiss_anr] $(_ts) Sending KEYCODE_BACK to dismiss ANR dialog." >&2
       echo "[dismiss_anr] Sending KEYCODE_BACK to dismiss ANR dialog." >&2
       "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
       idle_count=0
@@ -116,6 +132,7 @@
     if [[ -z "$launcher_line" ]]; then
       # Launcher process not present — treat as idle.
       idle_count=$((idle_count + 1))
+      echo "[dismiss_anr] $(_ts) [t=${elapsed}s poll=${poll_n}] idle_count=${idle_count} cpu=absent" >&2
     else
       # Extract the leading integer percentage (e.g. "  12% com.google.android.apps...")
       pct="$(echo "$launcher_line" | grep -oE '^[[:space:]]*[0-9]+' | tr -d ' ' || true)"
@@ -124,6 +141,7 @@
       else
         idle_count=0
       fi
+      echo "[dismiss_anr] $(_ts) [t=${elapsed}s poll=${poll_n}] idle_count=${idle_count} cpu=${pct:-(unknown)}%" >&2
     fi
 
     if [[ $idle_count -ge 2 ]]; then
@@ -133,11 +151,13 @@
       # is the fallback that catches those cases.
       window_dump=$("$ADB" shell dumpsys window 2>/dev/null) || true
       if echo "$window_dump" | grep -q "AppNotRespondingDialog"; then
+        echo "[dismiss_anr] $(_ts) dumpsys window safety check: AppNotRespondingDialog found — sending KEYCODE_BACK." >&2
         echo "[dismiss_anr] CPU idle but ANR dialog still present (dumpsys window) — sending KEYCODE_BACK." >&2
         "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
         idle_count=0
         # Continue the loop instead of exiting.
       else
+        echo "[dismiss_anr] $(_ts) dumpsys window safety check: no AppNotRespondingDialog found." >&2
         echo "[dismiss_anr] Pixel Launcher has settled (idle_count=$idle_count) — exiting." >&2
         exit 0
       fi
@@ -147,6 +167,7 @@
     elapsed=$((elapsed + POLL_INTERVAL))
   done
 
+  echo "[dismiss_anr] $(_ts) Timeout after ${TIMEOUT}s — proceeding anyway." >&2
   echo "[dismiss_anr] Timeout after ${TIMEOUT}s — proceeding anyway." >&2
   exit 0
 ) || true

--- a/scripts/dismiss_anr.sh
+++ b/scripts/dismiss_anr.sh
@@ -148,13 +148,13 @@
       # starts or after the CPU has already settled.  A dumpsys window check here
       # is the fallback that catches those cases.
       window_dump=$("$ADB" shell dumpsys window 2>/dev/null) || true
-      if echo "$window_dump" | grep -q "AppNotRespondingDialog"; then
-        echo "[dismiss_anr] $(_ts) dumpsys window safety check: AppNotRespondingDialog found — sending KEYCODE_BACK." >&2
+      if echo "$window_dump" | grep -q "Application Not Responding"; then
+        echo "[dismiss_anr] $(_ts) dumpsys window safety check: ANR dialog found — sending KEYCODE_BACK." >&2
         "$ADB" shell input keyevent KEYCODE_BACK 2>/dev/null || true
         idle_count=0
         # Continue the loop instead of exiting.
       else
-        echo "[dismiss_anr] $(_ts) dumpsys window safety check: no AppNotRespondingDialog found." >&2
+        echo "[dismiss_anr] $(_ts) dumpsys window safety check: no ANR dialog found." >&2
         exit 0
       fi
     fi

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -165,7 +165,12 @@ class TestMainAdbRetryLoop(unittest.TestCase):
 
     def test_wakeup_and_swipe_sent_before_each_screencap(self):
         """KEYCODE_WAKEUP (224) and an upward swipe are sent before every screencap,
-        in that order, with the screencap coming after both in each retry iteration."""
+        in that order, with the screencap coming after both in each retry iteration.
+
+        The per-retry ANR check (dumpsys window) runs between the swipe and the
+        screencap, so the ordering within a single iteration is:
+          wakeup → swipe → [sleep] → dumpsys-window → screencap
+        """
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
@@ -191,27 +196,35 @@ class TestMainAdbRetryLoop(unittest.TestCase):
             def is_screencap(args):
                 return "screencap" in args
 
-            # Walk the call list and verify that each screencap is immediately
-            # preceded by a swipe (unlock gesture) call, which is itself preceded
-            # by a KEYCODE_WAKEUP (224) call.  This confirms the ordering within
-            # every retry iteration, not just the presence of the calls somewhere
-            # in the full list.
+            def is_dumpsys_window(args):
+                return "dumpsys" in args and "window" in args
+
+            # Walk the call list and verify the ordering within every retry
+            # iteration: wakeup precedes swipe, which precedes the screencap
+            # (there is now a dumpsys-window call between swipe and screencap).
             screencap_indices = [i for i, a in enumerate(arg_lists) if is_screencap(a)]
             self.assertGreater(len(screencap_indices), 0, "No screencap call found")
 
             for sc_idx in screencap_indices:
-                self.assertGreaterEqual(sc_idx, 2,
-                    "Not enough preceding calls before screencap to fit wakeup + swipe")
-                swipe_idx = sc_idx - 1
-                wakeup_idx = sc_idx - 2
+                self.assertGreaterEqual(sc_idx, 3,
+                    "Not enough preceding calls before screencap to fit "
+                    "wakeup + swipe + dumpsys-window")
+                dumpsys_idx = sc_idx - 1
+                swipe_idx = sc_idx - 2
+                wakeup_idx = sc_idx - 3
+                self.assertTrue(
+                    is_dumpsys_window(arg_lists[dumpsys_idx]),
+                    f"Call immediately before screencap (index {dumpsys_idx}) is not "
+                    f"a dumpsys window call: {arg_lists[dumpsys_idx]}"
+                )
                 self.assertTrue(
                     is_swipe(arg_lists[swipe_idx]),
-                    f"Call immediately before screencap (index {swipe_idx}) is not "
+                    f"Call two before screencap (index {swipe_idx}) is not "
                     f"an upward swipe: {arg_lists[swipe_idx]}"
                 )
                 self.assertTrue(
                     is_wakeup(arg_lists[wakeup_idx]),
-                    f"Call two before screencap (index {wakeup_idx}) is not "
+                    f"Call three before screencap (index {wakeup_idx}) is not "
                     f"KEYCODE_WAKEUP (224): {arg_lists[wakeup_idx]}"
                 )
         finally:
@@ -219,7 +232,12 @@ class TestMainAdbRetryLoop(unittest.TestCase):
 
     def test_sleep_between_swipe_and_screencap(self):
         """A sleep call must appear between the swipe and every screencap so that
-        any swipe animation has settled before the screen is captured."""
+        any swipe animation has settled before the screen is captured.
+
+        The per-retry ANR check (dumpsys window) runs after the sleep but before
+        the screencap, so the ordering within a single iteration is:
+          swipe → sleep → other(dumpsys-window) → screencap
+        """
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
@@ -251,25 +269,33 @@ class TestMainAdbRetryLoop(unittest.TestCase):
                  patch("check_green_feed.check_image", side_effect=side_effects):
                 self._run_main(["--adb", "/fake/adb", path])
 
-            # Find every screencap in the log and assert that a sleep immediately
-            # precedes it and a swipe immediately precedes that sleep.
+            # Find every screencap in the log and assert the expected ordering:
+            #   swipe → sleep → other(dumpsys-window) → screencap
+            # The per-retry ANR check (dumpsys-window) sits between the sleep and
+            # the screencap, so the sleep is now two positions before screencap.
             screencap_positions = [i for i, e in enumerate(call_log) if e == "screencap"]
             self.assertGreater(len(screencap_positions), 0, "No screencap logged")
 
             for sc_pos in screencap_positions:
-                self.assertGreaterEqual(sc_pos, 2,
+                self.assertGreaterEqual(sc_pos, 3,
                     "Not enough preceding log entries before screencap")
+                self.assertEqual(
+                    call_log[sc_pos - 1],
+                    "other",
+                    f"Entry immediately before screencap (index {sc_pos - 1}) is not "
+                    f"the ANR check (other): {call_log[sc_pos - 1]}"
+                )
                 self.assertIn(
                     "sleep",
-                    call_log[sc_pos - 1],
-                    f"Entry immediately before screencap (index {sc_pos - 1}) is not "
-                    f"a sleep call: {call_log[sc_pos - 1]}"
+                    call_log[sc_pos - 2],
+                    f"Entry two before screencap (index {sc_pos - 2}) is not "
+                    f"a sleep call: {call_log[sc_pos - 2]}"
                 )
                 self.assertEqual(
-                    call_log[sc_pos - 2],
+                    call_log[sc_pos - 3],
                     "swipe",
-                    f"Entry two before screencap (index {sc_pos - 2}) is not "
-                    f"a swipe call: {call_log[sc_pos - 2]}"
+                    f"Entry three before screencap (index {sc_pos - 3}) is not "
+                    f"a swipe call: {call_log[sc_pos - 3]}"
                 )
         finally:
             os.unlink(path)
@@ -312,12 +338,14 @@ class TestInputServiceFailure(unittest.TestCase):
         fd, path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         try:
-            # KEYCODE_WAKEUP fails; swipe succeeds; screencap succeeds.
+            # KEYCODE_WAKEUP fails; swipe succeeds; dumpsys window (ANR check)
+            # succeeds; screencap succeeds.
             wakeup_fail = self._make_run_result(returncode=1, stderr="")
             swipe_ok = self._make_run_result(returncode=0, stderr="")
+            dumpsys_ok = self._make_run_result(returncode=0, stderr="")
             screencap_ok = self._make_run_result(returncode=0, stderr="")
 
-            run_side_effects = [wakeup_fail, swipe_ok, screencap_ok]
+            run_side_effects = [wakeup_fail, swipe_ok, dumpsys_ok, screencap_ok]
 
             sleep_calls: list[float] = []
 
@@ -357,9 +385,10 @@ class TestInputServiceFailure(unittest.TestCase):
             swipe_fail = self._make_run_result(
                 returncode=1, stderr="cmd: Can't find service: input"
             )
+            dumpsys_ok = self._make_run_result(returncode=0, stderr="")
             screencap_ok = self._make_run_result(returncode=0, stderr="")
 
-            run_side_effects = [wakeup_ok, swipe_fail, screencap_ok]
+            run_side_effects = [wakeup_ok, swipe_fail, dumpsys_ok, screencap_ok]
 
             sleep_calls: list[float] = []
 
@@ -446,6 +475,186 @@ class TestInputServiceFailure(unittest.TestCase):
             # of the loop and one between swipe and screencap.
             self.assertEqual(mock_sleep.call_count, 2,
                 f"Expected 2 sleeps when input service succeeds, got {mock_sleep.call_count}")
+        finally:
+            os.unlink(path)
+
+
+class TestPerRetryAnrDismiss(unittest.TestCase):
+    """Tests for the per-retry ANR dialog check + dismiss in the retry loop."""
+
+    def _run_main(self, extra_argv: list[str]) -> int:
+        with patch.object(sys, "argv", ["check_green_feed.py"] + extra_argv):
+            return cgf.main()
+
+    def _make_run_result(self, returncode=0, stderr="", stdout=""):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stderr = stderr
+        result.stdout = stdout
+        return result
+
+    def test_anr_dialog_on_first_attempt_is_dismissed_before_screencap(self):
+        """When dumpsys window reports AppNotRespondingDialog before the first
+        screencap, KEYCODE_BACK is sent and an extra sleep follows.  The screencap
+        still runs and the retry loop continues normally.
+
+        _dump_first_failure_diagnostics is patched out so that its own subprocess
+        calls do not interfere with the accounting of ANR-check calls.
+        """
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            anr_window = self._make_run_result(
+                returncode=0, stdout="AppNotRespondingDialog"
+            )
+            clear_window = self._make_run_result(returncode=0, stdout="WindowState idle")
+            keyevent_ok = self._make_run_result(returncode=0)
+            screencap_ok = self._make_run_result(returncode=0)
+
+            # Attempt 1: wakeup → swipe → dumpsys-window(ANR present) →
+            #             KEYCODE_BACK → [sleep inside dismiss] → screencap(fails)
+            # Attempt 2: wakeup → swipe → dumpsys-window(clear) → screencap(passes)
+            run_side_effects = [
+                # attempt 1
+                self._make_run_result(),   # wakeup keyevent 224
+                self._make_run_result(),   # swipe
+                anr_window,                # dumpsys window → ANR present
+                keyevent_ok,               # KEYCODE_BACK dismiss
+                screencap_ok,              # screencap (written to file)
+                # attempt 2
+                self._make_run_result(),   # wakeup keyevent 224
+                self._make_run_result(),   # swipe
+                clear_window,              # dumpsys window → clear
+                screencap_ok,              # screencap (written to file)
+            ]
+
+            keyback_calls: list[list[str]] = []
+            dumpsys_calls: list[list[str]] = []
+
+            def tracking_run(args, **kwargs):
+                if "KEYCODE_BACK" in args:
+                    keyback_calls.append(list(args))
+                if "dumpsys" in args and "window" in args:
+                    dumpsys_calls.append(list(args))
+                return run_side_effects.pop(0)
+
+            sleep_calls: list[float] = []
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=tracking_run), \
+                 patch("check_green_feed.time.sleep",
+                       side_effect=lambda s: sleep_calls.append(s)), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed._dump_first_failure_diagnostics"), \
+                 patch("check_green_feed.check_image", side_effect=[1, 0]):
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0, "main should succeed on the second attempt")
+
+            # dumpsys window must be called before every screencap (2 attempts).
+            self.assertEqual(
+                len(dumpsys_calls), 2,
+                f"Expected 2 dumpsys window calls (one per attempt), got {len(dumpsys_calls)}"
+            )
+
+            # KEYCODE_BACK must be sent exactly once (for the first-attempt ANR).
+            keyback_back_calls = [c for c in keyback_calls if "KEYCODE_BACK" in c]
+            self.assertEqual(
+                len(keyback_back_calls), 1,
+                f"Expected 1 KEYCODE_BACK for ANR dismiss, got {len(keyback_back_calls)}"
+            )
+
+            # An extra sleep must follow the KEYCODE_BACK dismiss.
+            # Standard sleeps per attempt: 2 (top-of-loop + swipe-settle).
+            # Attempt 1 also has the ANR dismiss sleep → total > 2 * 1 = 2 for
+            # the first attempt, i.e. total sleep count across both attempts > 4.
+            self.assertGreater(
+                len(sleep_calls), 4,
+                f"Expected extra sleep after ANR dismiss; got {len(sleep_calls)} total sleeps"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_no_anr_dialog_means_no_keycode_back(self):
+        """When dumpsys window reports no ANR dialog, KEYCODE_BACK is not sent
+        and the screencap proceeds immediately (no extra sleep)."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            clear_window = self._make_run_result(returncode=0, stdout="WindowState idle")
+
+            keyback_calls: list = []
+
+            def tracking_run(args, **kwargs):
+                if "KEYCODE_BACK" in args:
+                    keyback_calls.append(args)
+                r = MagicMock()
+                r.returncode = 0
+                r.stderr = ""
+                r.stdout = clear_window.stdout
+                return r
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=tracking_run), \
+                 patch("check_green_feed.time.sleep"), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed.check_image", return_value=0):
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                len(keyback_calls), 0,
+                f"KEYCODE_BACK must not be sent when there is no ANR dialog; "
+                f"got {len(keyback_calls)} call(s)"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_anr_check_runs_before_every_screencap(self):
+        """dumpsys window is called before every screencap attempt, not just the
+        first, so the retry loop remains self-defending throughout.
+
+        _dump_first_failure_diagnostics is patched out so that its own dumpsys
+        window call does not inflate the count for the per-retry ANR check.
+        """
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            screencap_count = [0]
+            dumpsys_count = [0]
+
+            def tracking_run(args, **kwargs):
+                if "dumpsys" in args and "window" in args:
+                    dumpsys_count[0] += 1
+                elif "screencap" in args:
+                    screencap_count[0] += 1
+                r = MagicMock()
+                r.returncode = 0
+                r.stderr = ""
+                r.stdout = ""
+                return r
+
+            attempts = 3
+            check_results = [1] * (attempts - 1) + [0]
+
+            with patch("check_green_feed.subprocess.run",
+                       side_effect=tracking_run), \
+                 patch("check_green_feed.time.sleep"), \
+                 patch("builtins.open", unittest.mock.mock_open()), \
+                 patch("check_green_feed._dump_first_failure_diagnostics"), \
+                 patch("check_green_feed.check_image", side_effect=check_results):
+                result = self._run_main(["--adb", "/fake/adb", path])
+
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                screencap_count[0], attempts,
+                f"Expected {attempts} screencaps, got {screencap_count[0]}"
+            )
+            self.assertEqual(
+                dumpsys_count[0], attempts,
+                f"Expected {attempts} dumpsys window calls (one per attempt, "
+                f"from the per-retry ANR check), got {dumpsys_count[0]}"
+            )
         finally:
             os.unlink(path)
 

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -495,8 +495,10 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
 
     def test_anr_dialog_on_first_attempt_is_dismissed_before_screencap(self):
         """When dumpsys window reports 'Application Not Responding' before the
-        first screencap, KEYCODE_BACK is sent and an extra sleep follows.  The
-        screencap still runs and the retry loop continues normally.
+        first screencap, KEYCODE_BACK is sent and an extra sleep follows.  After
+        sending KEYCODE_BACK the dismiss function polls dumpsys window again to
+        confirm the dialog is gone before returning.  The screencap still runs
+        and the retry loop continues normally.
 
         _dump_first_failure_diagnostics is patched out so that its own subprocess
         calls do not interfere with the accounting of ANR-check calls.
@@ -512,20 +514,24 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
             keyevent_ok = self._make_run_result(returncode=0)
             screencap_ok = self._make_run_result(returncode=0)
 
-            # Attempt 1: wakeup → swipe → dumpsys-window(ANR present) →
-            #             KEYCODE_BACK → [sleep inside dismiss] → screencap(fails)
-            # Attempt 2: wakeup → swipe → dumpsys-window(clear) → screencap(passes)
+            # Attempt 1:
+            #   wakeup → swipe → dumpsys-window(ANR present) →
+            #   KEYCODE_BACK → [sleep] → dumpsys-window(confirm: clear) →
+            #   screencap(fails)
+            # Attempt 2:
+            #   wakeup → swipe → dumpsys-window(detect: clear) → screencap(passes)
             run_side_effects = [
                 # attempt 1
                 self._make_run_result(),   # wakeup keyevent 224
                 self._make_run_result(),   # swipe
-                anr_window,                # dumpsys window → ANR present
+                anr_window,                # dumpsys window → ANR detected
                 keyevent_ok,               # KEYCODE_BACK dismiss
+                clear_window,              # dumpsys window → confirm dismissed
                 screencap_ok,              # screencap (written to file)
                 # attempt 2
                 self._make_run_result(),   # wakeup keyevent 224
                 self._make_run_result(),   # swipe
-                clear_window,              # dumpsys window → clear
+                clear_window,              # dumpsys window → detect: clear
                 screencap_ok,              # screencap (written to file)
             ]
 
@@ -552,10 +558,12 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
 
             self.assertEqual(result, 0, "main should succeed on the second attempt")
 
-            # dumpsys window must be called before every screencap (2 attempts).
+            # Attempt 1 has 2 dumpsys calls (detect + confirm-after-dismiss);
+            # attempt 2 has 1 (detect only, no ANR found).  Total = 3.
             self.assertEqual(
-                len(dumpsys_calls), 2,
-                f"Expected 2 dumpsys window calls (one per attempt), got {len(dumpsys_calls)}"
+                len(dumpsys_calls), 3,
+                f"Expected 3 dumpsys window calls (2 for attempt-1 ANR dismiss + 1 for attempt-2 detect), "
+                f"got {len(dumpsys_calls)}"
             )
 
             # KEYCODE_BACK must be sent exactly once (for the first-attempt ANR).
@@ -567,7 +575,7 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
 
             # An extra sleep must follow the KEYCODE_BACK dismiss.
             # Standard sleeps per attempt: 2 (top-of-loop + swipe-settle).
-            # Attempt 1 also has the ANR dismiss sleep → total > 2 * 1 = 2 for
+            # Attempt 1 also has the ANR dismiss poll sleep → total > 2 * 1 = 2 for
             # the first attempt, i.e. total sleep count across both attempts > 4.
             self.assertGreater(
                 len(sleep_calls), 4,

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -494,9 +494,9 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
         return result
 
     def test_anr_dialog_on_first_attempt_is_dismissed_before_screencap(self):
-        """When dumpsys window reports AppNotRespondingDialog before the first
-        screencap, KEYCODE_BACK is sent and an extra sleep follows.  The screencap
-        still runs and the retry loop continues normally.
+        """When dumpsys window reports 'Application Not Responding' before the
+        first screencap, KEYCODE_BACK is sent and an extra sleep follows.  The
+        screencap still runs and the retry loop continues normally.
 
         _dump_first_failure_diagnostics is patched out so that its own subprocess
         calls do not interfere with the accounting of ANR-check calls.
@@ -505,7 +505,8 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
         os.close(fd)
         try:
             anr_window = self._make_run_result(
-                returncode=0, stdout="AppNotRespondingDialog"
+                returncode=0,
+                stdout="  mCurrentFocus=Window{... u0 Application Not Responding: com.google.android.apps.nexuslauncher}",
             )
             clear_window = self._make_run_result(returncode=0, stdout="WindowState idle")
             keyevent_ok = self._make_run_result(returncode=0)

--- a/scripts/test_check_green_feed.py
+++ b/scripts/test_check_green_feed.py
@@ -668,5 +668,68 @@ class TestPerRetryAnrDismiss(unittest.TestCase):
             os.unlink(path)
 
 
+class TestDismissAnrIfPresent(unittest.TestCase):
+    """Unit tests for _dismiss_anr_if_present() called directly."""
+
+    def _make_run_result(self, returncode=0, stderr="", stdout=""):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stderr = stderr
+        result.stdout = stdout
+        return result
+
+    def test_all_retries_exhausted_returns_without_raising(self):
+        """When dumpsys window always reports 'Application Not Responding' the
+        function sends KEYCODE_BACK exactly _ANR_DISMISS_MAX_RETRIES times and
+        then returns (does not raise) so the outer retry loop can keep going.
+        The final log message must mention that the dialog persisted after N retries.
+        """
+        anr_window = self._make_run_result(
+            stdout="Application Not Responding: com.google.android.apps.nexuslauncher"
+        )
+
+        keyback_calls: list[list] = []
+        run_side_effects: list = []
+        # Initial detect: ANR present.
+        run_side_effects.append(anr_window)
+        # For each retry: KEYCODE_BACK + confirm dumpsys (always shows ANR).
+        for _ in range(cgf._ANR_DISMISS_MAX_RETRIES):
+            run_side_effects.append(self._make_run_result())  # KEYCODE_BACK
+            run_side_effects.append(anr_window)               # confirm dumpsys
+
+        def tracking_run(args, **kwargs):
+            if "KEYCODE_BACK" in args:
+                keyback_calls.append(list(args))
+            return run_side_effects.pop(0)
+
+        stderr_buf = io.StringIO()
+        with patch("check_green_feed.subprocess.run", side_effect=tracking_run), \
+             patch("check_green_feed.time.sleep"), \
+             patch("sys.stderr", stderr_buf):
+            # Must return, not raise.
+            cgf._dismiss_anr_if_present("/fake/adb")
+
+        # Exactly _ANR_DISMISS_MAX_RETRIES KEYCODE_BACK calls.
+        self.assertEqual(
+            len(keyback_calls),
+            cgf._ANR_DISMISS_MAX_RETRIES,
+            f"Expected {cgf._ANR_DISMISS_MAX_RETRIES} KEYCODE_BACK sends when all retries "
+            f"are exhausted, got {len(keyback_calls)}"
+        )
+
+        # The exhaustion log line must be present.
+        log_output = stderr_buf.getvalue()
+        self.assertIn(
+            "persisted after",
+            log_output,
+            f"Expected 'persisted after' in stderr log when all retries exhausted; got: {log_output!r}"
+        )
+        self.assertIn(
+            str(cgf._ANR_DISMISS_MAX_RETRIES),
+            log_output,
+            f"Expected retry count {cgf._ANR_DISMISS_MAX_RETRIES} in stderr log; got: {log_output!r}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_dismiss_anr.sh
+++ b/scripts/test_dismiss_anr.sh
@@ -285,7 +285,7 @@ echo ""
 echo "=== (g) idle_count=2 but ANR dialog still present — dumpsys window fallback ==="
 
 # Scenario: logcat never fires (CPU settled without logcat trigger), but the ANR
-# dialog is still on screen.  dumpsys window returns AppNotRespondingDialog on the
+# dialog is still on screen.  dumpsys window returns the ANR window title on the
 # first idle-exit check, KEYCODE_BACK is sent, idle_count resets to 0.  On the
 # second idle-exit check dumpsys window is clean, so the script exits 0.
 # We verify that KEYCODE_BACK was sent exactly once and the script exits 0.
@@ -313,7 +313,7 @@ case \"\$*\" in
     echo \$count > '$DUMPSYS_WINDOW_CALL_COUNT_FILE'
     if [[ \$count -le 1 ]]; then
       # First check: dialog still present.
-      echo 'AppNotRespondingDialog'
+      echo '  mCurrentFocus=Window{... u0 Application Not Responding: com.google.android.apps.nexuslauncher}'
     else
       # Second check: dialog gone.
       echo 'WindowState idle'


### PR DESCRIPTION
Fixes #194

## Root cause

`dismiss_anr.sh` exits as soon as Pixel Launcher CPU goes idle (two consecutive readings below 5%). The ANR dialog can appear **during or after** `am start -W`, which itself takes 3+ seconds. By that point the watcher has already exited and nothing catches the dialog. The green-feed retry loop then spends all 30 attempts photographing the ANR overlay instead of MockCameraActivity.

## Fix (commit 3)

Before every screencap in the `check_green_feed.py` retry loop, run a lightweight `dumpsys window` check and send `KEYCODE_BACK` if `AppNotRespondingDialog` is present. This makes the retry loop self-defending against late-appearing ANR dialogs without relying on the background watcher.

```python
window_dump = subprocess.run([adb, "shell", "dumpsys", "window"], ...)
if "AppNotRespondingDialog" in window_dump.stdout:
    subprocess.run([adb, "shell", "input", "keyevent", "KEYCODE_BACK"], ...)
    time.sleep(RETRY_DELAY_SECONDS)
```

## Diagnostics (commits 1 and 2)

To make future failures self-explanatory in CI logs without requiring a re-run:

**`dismiss_anr.sh`** now emits timestamped (`HH:MM:SS.mmm`) log lines for:
- Script start and logcat stream PID
- Each poll iteration: `[t=Xs poll=N] idle_count=K cpu=P%`
- Logcat ANR trigger firing and KEYCODE_BACK sends
- `dumpsys window` safety check result (found / not found)
- Exit reason (idle, dismissed, timeout) with total elapsed ms
- EXIT trap dumps the last 10 lines of `logcat ActivityManager:E` so the log captures what happened during the watch window even after the script exits

**`check_green_feed.py`** dumps diagnostics to stderr on the **first** failed attempt only:
- Timestamp and elapsed time since script start
- `dumpsys window` lines containing `Dialog`, `Focused`, or `mCurrentFocus` — shows what was on screen
- Last 20 lines of `logcat ActivityManager:E` — captures recent ANR events
- Saves the screencap to `ci_diag_screencaps/failure_attempt_NNN.png` for CI artifact collection

## Tests

- `bash scripts/test_dismiss_anr.sh`: 13 passed, 0 failed (new diagnostic log lines do not affect behavior assertions)
- `python3 -m pytest scripts/ -v`: 54 passed, 0 failed
  - 3 new tests in `TestPerRetryAnrDismiss`: ANR present → dismissed, no ANR → no KEYCODE_BACK, check runs before every screencap
  - 4 existing ordering tests updated to account for the new `dumpsys window` call that now sits between the swipe and the screencap

---
_Generated by [Claude Code](https://claude.ai/code/session_018968Fyo51G78FriMNJnP1H)_