### PR TITLE
Prefix screenshot filenames with the test name using ScreenshotTestRule

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -49,7 +49,7 @@ import kotlin.math.sqrt
 class GalleryButtonVisualE2ETest {
 
     @get:Rule
-    val screenshotOnFailure = FailureScreenshotRule()
+    val screenshotRule = ScreenshotTestRule()
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context = instrumentation.targetContext

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith
 class PixelCameraOverlayE2ETest {
 
     @get:Rule
-    val screenshotOnFailure = FailureScreenshotRule()
+    val screenshotRule = ScreenshotTestRule()
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val fixture = E2EFixture(

--- a/app/src/androidTest/java/com/gb4pc/e2e/ScreenshotTestRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/ScreenshotTestRule.kt
@@ -1,0 +1,131 @@
+package com.gb4pc.e2e
+
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.gb4pc.e2e.visual.Screenshot
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.io.File
+
+/**
+ * JUnit [TestWatcher] rule that associates every screenshot produced during a test with
+ * the test that produced it.
+ *
+ * ## Option B — deterministic prefix (primary)
+ *
+ * At the start of each test [starting] sets [Screenshot.currentTestPrefix] to
+ * `"<ClassName>_<methodName>"`. [Screenshot.saveForArtifact] reads this prefix and
+ * prepends it to every filename, so `"0-screen.png"` becomes e.g.
+ * `"GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_0-screen.png"`.
+ * The prefix is cleared in [finished] so screenshots saved outside of any test body
+ * are never mistakenly attributed.
+ *
+ * ## Option A — straggler detection (safety net)
+ *
+ * In [starting], a snapshot of all files currently in the screenshot directory is
+ * recorded. In [finished], any new files that appeared during the test but were NOT
+ * saved through [Screenshot.saveForArtifact] (i.e. already prefixed by Option B) are
+ * renamed with the test name prefix so they too carry a test association. This catches
+ * screenshots written directly by the test runner or other out-of-band paths (e.g. a
+ * crash handler).
+ *
+ * ## Failure screenshot
+ *
+ * On test failure [failed] captures a device screenshot and saves it as
+ * `"<ClassName>_<methodName>_failure.png"` in the same directory — the test name is
+ * embedded in the filename directly (no reliance on [Screenshot.currentTestPrefix]
+ * which is cleared before [failed] is called by JUnit's default watcher order).
+ *
+ * ## Usage
+ *
+ * Replace [FailureScreenshotRule] with this rule in any E2E test class:
+ * ```kotlin
+ * @get:Rule
+ * val screenshotRule = ScreenshotTestRule()
+ * ```
+ */
+class ScreenshotTestRule : TestWatcher() {
+
+    companion object {
+        private const val TAG = "ScreenshotTestRule"
+    }
+
+    /** Files present in the screenshot directory before the current test started. */
+    private var baselineFiles: Set<String> = emptySet()
+
+    override fun starting(description: Description) {
+        val prefix = testPrefix(description)
+        Screenshot.currentTestPrefix.set(prefix)
+        baselineFiles = existingScreenshotFileNames()
+    }
+
+    override fun finished(description: Description) {
+        // Clear the prefix first so that any post-test screenshot saves (by framework code)
+        // are not mistakenly attributed to this test.
+        Screenshot.currentTestPrefix.set(null)
+        renameStragglersForTest(description)
+    }
+
+    override fun failed(e: Throwable?, description: Description) {
+        val prefix = testPrefix(description)
+        val externalFilesDir = InstrumentationRegistry.getInstrumentation().targetContext
+            .getExternalFilesDir(null)
+        if (externalFilesDir == null) {
+            Log.w(TAG, "External storage unavailable; skipping failure screenshot for ${description.methodName}")
+            return
+        }
+        val dir = File(externalFilesDir, "screenshots")
+        dir.mkdirs()
+        val screenshotFile = File(dir, "${prefix}_failure.png")
+        val success = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .takeScreenshot(screenshotFile)
+        if (!success) {
+            Log.w(TAG, "Failed to write failure screenshot to ${screenshotFile.absolutePath}")
+        }
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private fun testPrefix(description: Description): String {
+        val className = description.testClass?.simpleName ?: "UnknownClass"
+        return ScreenshotNaming.buildPrefix(className, description.methodName)
+    }
+
+    private fun existingScreenshotFileNames(): Set<String> {
+        return try {
+            Screenshot.screenshotDir().listFiles()?.map { it.name }?.toSet() ?: emptySet()
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not list screenshot directory: ${e.message}")
+            emptySet()
+        }
+    }
+
+    /**
+     * Renames any new files that appeared during the test and are not already prefixed
+     * with the test name (i.e. were not saved through [Screenshot.saveForArtifact]).
+     *
+     * New files whose names already start with the test prefix are left untouched —
+     * they were already attributed by the Option B path.
+     */
+    private fun renameStragglersForTest(description: Description) {
+        val prefix = testPrefix(description)
+        val dir = try {
+            Screenshot.screenshotDir()
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not access screenshot directory for straggler rename: ${e.message}")
+            return
+        }
+        val currentFiles = dir.listFiles() ?: return
+        for (file in currentFiles) {
+            val name = file.name
+            if (name !in baselineFiles && !name.startsWith(prefix)) {
+                val newFile = File(dir, ScreenshotNaming.resolvedName(prefix, name))
+                val renamed = file.renameTo(newFile)
+                if (!renamed) {
+                    Log.w(TAG, "Could not rename straggler $name → ${newFile.name}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/gb4pc/e2e/ScreenshotTestRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/ScreenshotTestRule.kt
@@ -34,8 +34,8 @@ import java.io.File
  *
  * On test failure [failed] captures a device screenshot and saves it as
  * `"<ClassName>_<methodName>_failure.png"` in the same directory — the test name is
- * embedded in the filename directly (no reliance on [Screenshot.currentTestPrefix]
- * which is cleared before [failed] is called by JUnit's default watcher order).
+ * embedded in the filename directly. [Screenshot.currentTestPrefix] is still live when
+ * [failed] runs; it is cleared in [finished], which [TestWatcher] calls after [failed].
  *
  * ## Usage
  *
@@ -69,14 +69,12 @@ class ScreenshotTestRule : TestWatcher() {
 
     override fun failed(e: Throwable?, description: Description) {
         val prefix = testPrefix(description)
-        val externalFilesDir = InstrumentationRegistry.getInstrumentation().targetContext
-            .getExternalFilesDir(null)
-        if (externalFilesDir == null) {
+        val dir = try {
+            Screenshot.screenshotDir()
+        } catch (ex: Exception) {
             Log.w(TAG, "External storage unavailable; skipping failure screenshot for ${description.methodName}")
             return
         }
-        val dir = File(externalFilesDir, "screenshots")
-        dir.mkdirs()
         val screenshotFile = File(dir, "${prefix}_failure.png")
         val success = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
             .takeScreenshot(screenshotFile)

--- a/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/visual/Screenshot.kt
@@ -2,6 +2,7 @@ package com.gb4pc.e2e.visual
 
 import android.graphics.Bitmap
 import androidx.test.platform.app.InstrumentationRegistry
+import com.gb4pc.e2e.ScreenshotNaming
 import java.io.File
 import java.io.FileOutputStream
 
@@ -11,10 +12,34 @@ import java.io.FileOutputStream
 object Screenshot {
 
     /**
+     * Thread-local holding the current test's name prefix (e.g.
+     * `"PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens"`).
+     *
+     * Set by [com.gb4pc.e2e.ScreenshotTestRule] at the start of each test and cleared at the
+     * end. When non-null, [saveForArtifact] prepends this prefix to every filename so
+     * saved images are unambiguously associated with the producing test case.
+     */
+    internal val currentTestPrefix = ThreadLocal<String?>()
+
+    /**
      * Captures the current screen via UiAutomation and returns it as a [Bitmap].
      */
     fun captureScreen(): Bitmap =
         InstrumentationRegistry.getInstrumentation().uiAutomation.takeScreenshot()
+
+    /**
+     * Returns the resolved screenshot output directory (creating it if necessary).
+     *
+     * Extracted so [com.gb4pc.e2e.ScreenshotTestRule]'s straggler-detection logic can use the
+     * same path without duplicating the directory-resolution logic.
+     */
+    internal fun screenshotDir(): File {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val externalFilesDir = requireNotNull(ctx.getExternalFilesDir(null)) {
+            "External storage is not available — cannot access screenshot directory"
+        }
+        return File(externalFilesDir, "screenshots").also { it.mkdirs() }
+    }
 
     /**
      * Saves [bmp] as a lossless PNG to the app's external files directory under
@@ -25,15 +50,16 @@ object Screenshot {
      *
      * The directory is created if it does not exist. Intended for CI artifact pickup
      * on test failure so failures ship reviewable screenshots.
+     *
+     * If [currentTestPrefix] is set (by [com.gb4pc.e2e.ScreenshotTestRule]), the prefix is
+     * automatically prepended to [name] so the saved file is self-describing in the
+     * artifact browser — e.g. `"0-screen.png"` becomes
+     * `"GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_0-screen.png"`.
      */
     fun saveForArtifact(bmp: Bitmap, name: String) {
-        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
-        val externalFilesDir = requireNotNull(ctx.getExternalFilesDir(null)) {
-            "External storage is not available — cannot save screenshot artifact"
-        }
-        val dir = File(externalFilesDir, "screenshots")
-        dir.mkdirs()
-        FileOutputStream(File(dir, name)).use { out ->
+        val resolvedName = ScreenshotNaming.resolvedName(currentTestPrefix.get(), name)
+        val dir = screenshotDir()
+        FileOutputStream(File(dir, resolvedName)).use { out ->
             bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
         }
     }

--- a/app/src/sharedTest/java/com/gb4pc/e2e/ScreenshotNaming.kt
+++ b/app/src/sharedTest/java/com/gb4pc/e2e/ScreenshotNaming.kt
@@ -1,0 +1,42 @@
+package com.gb4pc.e2e
+
+/**
+ * Pure-logic helpers for associating screenshot filenames with their producing test.
+ *
+ * These functions contain no Android dependencies so they can be tested in the JVM
+ * unit-test environment as well as used by the Android instrumented test infrastructure.
+ *
+ * All Android-specific I/O (directory resolution, file writing) lives in
+ * [com.gb4pc.e2e.visual.Screenshot] and [ScreenshotTestRule], which delegate to this
+ * object for filename computation.
+ */
+object ScreenshotNaming {
+
+    /**
+     * Builds the canonical test-prefix string for the given class and method names.
+     *
+     * Format: `"<simpleClassName>_<methodName>"`
+     *
+     * Example: `"PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens"`
+     */
+    fun buildPrefix(simpleClassName: String, methodName: String): String =
+        "${simpleClassName}_${methodName}"
+
+    /**
+     * Returns the artifact filename for [baseName] given an optional [testPrefix].
+     *
+     * - If [testPrefix] is non-null: `"<testPrefix>_<baseName>"`
+     * - If [testPrefix] is null: `<baseName>` unchanged
+     *
+     * Examples:
+     * ```
+     * resolvedName("GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible", "0-screen.png")
+     *   // → "GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_0-screen.png"
+     *
+     * resolvedName(null, "0-screen.png")
+     *   // → "0-screen.png"
+     * ```
+     */
+    fun resolvedName(testPrefix: String?, baseName: String): String =
+        if (testPrefix != null) "${testPrefix}_$baseName" else baseName
+}

--- a/app/src/test/java/com/gb4pc/e2e/ScreenshotNamingTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/ScreenshotNamingTest.kt
@@ -1,0 +1,103 @@
+package com.gb4pc.e2e
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [ScreenshotNaming] — the pure naming-logic helpers that associate
+ * screenshot filenames with the test that produced them (issue #201).
+ */
+class ScreenshotNamingTest {
+
+    // ── buildPrefix ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `buildPrefix combines class and method name with underscore`() {
+        val prefix = ScreenshotNaming.buildPrefix(
+            simpleClassName = "PixelCameraOverlayE2ETest",
+            methodName = "overlayAppearsWhenViewfinderOpens"
+        )
+        assertEquals(
+            "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens",
+            prefix
+        )
+    }
+
+    @Test
+    fun `buildPrefix handles numbered method names`() {
+        val prefix = ScreenshotNaming.buildPrefix(
+            simpleClassName = "GalleryButtonVisualE2ETest",
+            methodName = "test0_smokeGreenFeedVisible"
+        )
+        assertEquals("GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible", prefix)
+    }
+
+    @Test
+    fun `buildPrefix handles UnknownClass placeholder`() {
+        val prefix = ScreenshotNaming.buildPrefix("UnknownClass", "someMethod")
+        assertEquals("UnknownClass_someMethod", prefix)
+    }
+
+    // ── resolvedName — with prefix ────────────────────────────────────────────
+
+    @Test
+    fun `resolvedName with prefix prepends prefix and underscore`() {
+        val name = ScreenshotNaming.resolvedName(
+            testPrefix = "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens",
+            baseName = "failure.png"
+        )
+        assertEquals(
+            "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens_failure.png",
+            name
+        )
+    }
+
+    @Test
+    fun `resolvedName with prefix matches issue example format`() {
+        // Issue #201 example: "failure_screenshot.png" →
+        //   "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens_failure_screenshot.png"
+        val name = ScreenshotNaming.resolvedName(
+            testPrefix = "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens",
+            baseName = "failure_screenshot.png"
+        )
+        assertEquals(
+            "PixelCameraOverlayE2ETest_overlayAppearsWhenViewfinderOpens_failure_screenshot.png",
+            name
+        )
+    }
+
+    @Test
+    fun `resolvedName with prefix on numbered screenshot name`() {
+        val name = ScreenshotNaming.resolvedName(
+            testPrefix = "GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible",
+            baseName = "0-screen.png"
+        )
+        assertEquals(
+            "GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_0-screen.png",
+            name
+        )
+    }
+
+    // ── resolvedName — without prefix ─────────────────────────────────────────
+
+    @Test
+    fun `resolvedName with null prefix returns base name unchanged`() {
+        val name = ScreenshotNaming.resolvedName(testPrefix = null, baseName = "0-screen.png")
+        assertEquals("0-screen.png", name)
+    }
+
+    @Test
+    fun `resolvedName with null prefix does not add underscore`() {
+        val name = ScreenshotNaming.resolvedName(testPrefix = null, baseName = "failure.png")
+        assertEquals("failure.png", name)
+    }
+
+    // ── round-trip: buildPrefix + resolvedName ────────────────────────────────
+
+    @Test
+    fun `buildPrefix then resolvedName produces fully qualified filename`() {
+        val prefix = ScreenshotNaming.buildPrefix("MyTest", "myMethod")
+        val name = ScreenshotNaming.resolvedName(prefix, "screen.png")
+        assertEquals("MyTest_myMethod_screen.png", name)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #201

Screenshots captured during a test run are now reliably associated with the specific test that produced them.

- **Option B (primary):** `ScreenshotTestRule` sets a thread-local prefix (`_`) at the start of each test. `Screenshot.saveForArtifact()` reads this prefix and prepends it to every filename. For example, `&#34;0-screen.png&#34;` becomes `&#34;GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_0-screen.png&#34;`, and the failure screenshot becomes `&#34;GalleryButtonVisualE2ETest_test0_smokeGreenFeedVisible_failure.png&#34;`.

- **Option A (safety net):** `ScreenshotTestRule` snapshots the screenshot directory before each test and, after the test completes, renames any new files that are not already prefixed with the test name. This catches screenshots written outside `saveForArtifact()` (e.g. by a crash handler or the test runner).

`ScreenshotTestRule` supersedes `FailureScreenshotRule` — both E2E test classes now use the new rule, which covers the failure-screenshot behavior plus the naming enhancements. The pure naming logic lives in `ScreenshotNaming` (sharedTest), which has no Android dependencies and is covered by JVM unit tests.

## Test plan

- [ ] `ScreenshotNamingTest` passes (JVM unit tests covering `buildPrefix`, `resolvedName`, and the combined round-trip)
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] `./gradlew :app:compileDebugAndroidTestKotlin` passes
- [ ] On a connected device/emulator: `./gradlew connectedE2EAndroidTest` produces screenshot files prefixed with the test class and method name