### PR TITLE
Auto-file one GitHub issue per failed test in CI

### DIFF
--- a/.github/workflows/file-test-failure-issues.yml
+++ b/.github/workflows/file-test-failure-issues.yml
@@ -1,0 +1,40 @@
+name: File Test Failure Issues
+
+on:
+  workflow_run:
+    workflows: ["Build & Test"]
+    types: [completed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  file-issues:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: downloaded-artifacts
+
+      - name: File issues for failed tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          python3 scripts/file_test_failure_issues.py \
+            downloaded-artifacts/unit-test-results \
+              --suite-label "Unit Tests" \
+            downloaded-artifacts/e2e-test-results \
+              --suite-label "Instrumented Tests"

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""File a GitHub issue for each failed test found in JUnit XML results.
+
+Reads TEST-*.xml files from one or more result directories and creates (or
+comments on) a GitHub issue for every failing test case.
+
+Usage:
+    python3 scripts/file_test_failure_issues.py \\
+        path/to/unit-results       --suite-label "Unit Tests" \\
+        path/to/e2e-results        --suite-label "Instrumented Tests"
+
+Each directory path must be immediately followed by --suite-label <name>.
+Exit code is always 0 — API failures are logged but do not fail the CI run.
+
+Required environment variables:
+    GITHUB_TOKEN        Personal access token or Actions secret with issues: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+
+Optional environment variables (populated automatically by GitHub Actions):
+    GITHUB_SERVER_URL   Default: https://github.com
+    GITHUB_RUN_ID       Workflow run ID (for CI run link)
+    WORKFLOW_RUN_SHA    Commit SHA of the triggering workflow run
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    requests = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FailedTest:
+    class_name: str
+    method_name: str
+    failure_message: str
+    stack_trace: str
+    suite_label: str
+    artifact_name: str
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def parse_failures(directory: Path, suite_label: str, artifact_name: str) -> list[FailedTest]:
+    """Return one FailedTest for every failing test case found in *directory*."""
+    failures: list[FailedTest] = []
+
+    xml_files = sorted(directory.glob("TEST-*.xml"))
+    for xml_path in xml_files:
+        try:
+            tree = ET.parse(xml_path)
+        except ET.ParseError as exc:
+            print(f"  Warning: could not parse {xml_path}: {exc}", file=sys.stderr)
+            continue
+
+        root = tree.getroot()
+        if root.tag == "testsuites":
+            suite_elements = root.findall("testsuite")
+        else:
+            suite_elements = [root]
+
+        for suite in suite_elements:
+            class_name = suite.get("name", xml_path.stem)
+
+            for tc in suite.findall("testcase"):
+                method_name = tc.get("name", "<unknown>")
+
+                failure_el = tc.find("failure")
+                error_el = tc.find("error")
+                skipped_el = tc.find("skipped")
+
+                if skipped_el is not None:
+                    continue  # not a failure
+
+                problem_el = failure_el if failure_el is not None else error_el
+                if problem_el is None:
+                    continue  # passed
+
+                failure_message = problem_el.get("message", "")
+                stack_trace = (problem_el.text or "").strip()
+
+                failures.append(FailedTest(
+                    class_name=class_name,
+                    method_name=method_name,
+                    failure_message=failure_message,
+                    stack_trace=stack_trace,
+                    suite_label=suite_label,
+                    artifact_name=artifact_name,
+                ))
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Title / body construction
+# ---------------------------------------------------------------------------
+
+_STACK_TRACE_LIMIT = 2000
+
+
+def make_issue_title(class_name: str, method_name: str, timestamp: datetime, sha: str) -> str:
+    """Return the issue title string.
+
+    Format: [Test Failure] <ClassName>.<methodName> @ <yyMMdd-hhmm>-<gitsha7>
+    """
+    ts = timestamp.strftime("%y%m%d-%H%M")
+    short_sha = sha[:7] if sha else "unknown"
+    return f"[Test Failure] {class_name}.{method_name} @ {ts}-{short_sha}"
+
+
+def _find_ocr_text(directory: Path, class_name: str, method_name: str) -> str | None:
+    """Return OCR text from a companion .ocr.txt file matching the test, or None."""
+    # Match by class name (last component) + method name prefix in filename.
+    short_class = class_name.split(".")[-1]
+    prefix = f"{short_class}_{method_name}"
+    for ocr_path in directory.glob("*.ocr.txt"):
+        if ocr_path.stem.startswith(prefix) or prefix in ocr_path.stem:
+            try:
+                return ocr_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+    return None
+
+
+def make_issue_body(
+    failure: FailedTest,
+    directory: Path,
+    timestamp: datetime,
+    sha: str,
+    github_server_url: str,
+    github_repository: str,
+    github_run_id: str,
+    workflow_run_branch: str,
+) -> str:
+    """Build the Markdown body for a test-failure issue."""
+    ts_str = timestamp.strftime("%Y-%m-%d %H:%M UTC")
+    short_sha = sha[:7] if sha else "unknown"
+
+    run_url = (
+        f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"
+        if github_run_id
+        else "_CI run ID not available_"
+    )
+
+    artifact_url = (
+        f"{run_url}#artifacts"
+        if github_run_id
+        else "_not available_"
+    )
+
+    stack_excerpt = failure.stack_trace
+    if len(stack_excerpt) > _STACK_TRACE_LIMIT:
+        stack_excerpt = stack_excerpt[:_STACK_TRACE_LIMIT] + "\n... (truncated)"
+
+    ocr_text = _find_ocr_text(directory, failure.class_name, failure.method_name)
+    ocr_section = ""
+    if ocr_text:
+        ocr_section = f"\n### OCR text from screenshot\n\n```\n{ocr_text}\n```\n"
+
+    branch_info = f"`{workflow_run_branch}`" if workflow_run_branch else "_unknown_"
+
+    body = f"""\
+## Test Failure
+
+| Field | Value |
+|-------|-------|
+| Suite | {failure.suite_label} |
+| Class | `{failure.class_name}` |
+| Method | `{failure.method_name}` |
+| Branch | {branch_info} |
+| Commit | `{short_sha}` |
+| Detected at | {ts_str} |
+
+### Failure message
+
+```
+{failure.failure_message}
+```
+
+### Stack trace
+
+```
+{stack_excerpt}
+```
+
+### Links
+
+- [CI run]({run_url})
+- [Test artifact: {failure.artifact_name}]({artifact_url})
+{ocr_section}
+---
+_Filed automatically by CI on failure of `{failure.class_name}.{failure.method_name}`._
+"""
+    return body
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+def _github_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+LABELS = ["test-failure", "ci", "for ai to do"]
+
+
+def find_existing_issue(
+    token: str,
+    repository: str,
+    class_name: str,
+    method_name: str,
+) -> int | None:
+    """Search open issues for an existing failure report.
+
+    Returns the issue number if found, else None.
+    """
+    if requests is None:
+        print("  Error: 'requests' library not available.", file=sys.stderr)
+        return None
+
+    query = f'repo:{repository} is:issue is:open label:test-failure "{class_name}.{method_name}" in:title'
+    url = "https://api.github.com/search/issues"
+    try:
+        resp = requests.get(
+            url,
+            headers=_github_headers(token),
+            params={"q": query, "per_page": 1},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        items = data.get("items", [])
+        if items:
+            return items[0]["number"]
+    except Exception as exc:  # noqa: BLE001
+        print(f"  Warning: issue search failed: {exc}", file=sys.stderr)
+    return None
+
+
+def create_issue(
+    token: str,
+    repository: str,
+    title: str,
+    body: str,
+) -> int | None:
+    """Create a new GitHub issue.  Returns the issue number or None on failure."""
+    if requests is None:
+        print("  Error: 'requests' library not available.", file=sys.stderr)
+        return None
+
+    url = f"https://api.github.com/repos/{repository}/issues"
+    payload = {"title": title, "body": body, "labels": LABELS}
+    try:
+        resp = requests.post(url, headers=_github_headers(token), json=payload, timeout=30)
+        resp.raise_for_status()
+        return resp.json()["number"]
+    except Exception as exc:  # noqa: BLE001
+        print(f"  Warning: failed to create issue '{title}': {exc}", file=sys.stderr)
+    return None
+
+
+def add_issue_comment(
+    token: str,
+    repository: str,
+    issue_number: int,
+    body: str,
+) -> bool:
+    """Append a comment to an existing issue.  Returns True on success."""
+    if requests is None:
+        print("  Error: 'requests' library not available.", file=sys.stderr)
+        return False
+
+    url = f"https://api.github.com/repos/{repository}/issues/{issue_number}/comments"
+    try:
+        resp = requests.post(url, headers=_github_headers(token), json={"body": body}, timeout=30)
+        resp.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"  Warning: failed to comment on issue #{issue_number}: {exc}", file=sys.stderr)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def process_failure(
+    failure: FailedTest,
+    directory: Path,
+    token: str,
+    repository: str,
+    timestamp: datetime,
+    sha: str,
+    github_server_url: str,
+    github_run_id: str,
+    workflow_run_branch: str,
+) -> None:
+    """File or update a GitHub issue for a single test failure."""
+    title = make_issue_title(failure.class_name, failure.method_name, timestamp, sha)
+    body = make_issue_body(
+        failure=failure,
+        directory=directory,
+        timestamp=timestamp,
+        sha=sha,
+        github_server_url=github_server_url,
+        github_repository=repository,
+        github_run_id=github_run_id,
+        workflow_run_branch=workflow_run_branch,
+    )
+
+    existing = find_existing_issue(token, repository, failure.class_name, failure.method_name)
+    if existing is not None:
+        print(
+            f"  Duplicate found: #{existing} — appending comment for "
+            f"{failure.class_name}.{failure.method_name}",
+            file=sys.stderr,
+        )
+        comment_body = f"### Recurrence detected\n\n{body}"
+        add_issue_comment(token, repository, existing, comment_body)
+    else:
+        issue_num = create_issue(token, repository, title, body)
+        if issue_num is not None:
+            print(f"  Created issue #{issue_num}: {title}", file=sys.stderr)
+        else:
+            print(f"  Failed to create issue for: {title}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_USAGE = (
+    "usage: file_test_failure_issues.py "
+    "<dir> --suite-label <name> [<dir> --suite-label <name> ...]"
+)
+
+
+def parse_args(argv: list[str]) -> list[tuple[Path, str]]:
+    """Parse argv into a list of (directory, label) pairs.
+
+    Expected pattern: <dir> --suite-label <name> [<dir> --suite-label <name> ...]
+
+    Raises SystemExit(2) on bad input (matching argparse convention).
+    """
+    if argv and argv[0] in ("-h", "--help"):
+        print(__doc__)
+        print(_USAGE)
+        raise SystemExit(0)
+
+    pairs: list[tuple[Path, str]] = []
+    tokens = list(argv)
+    i = 0
+    while i < len(tokens):
+        directory = tokens[i]
+        if i + 3 > len(tokens):
+            print(
+                f"error: expected --suite-label <name> after '{directory}'\n{_USAGE}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        flag = tokens[i + 1]
+        label = tokens[i + 2]
+        if flag != "--suite-label":
+            print(
+                f"error: expected --suite-label after '{directory}', got '{flag}'\n{_USAGE}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        pairs.append((Path(directory), label))
+        i += 3
+
+    if not pairs:
+        print(
+            f"error: at least one <directory> --suite-label <name> pair is required\n{_USAGE}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    return pairs
+
+
+def _artifact_name_for_label(label: str) -> str:
+    """Derive the artifact name from the suite label."""
+    label_lower = label.lower()
+    if "unit" in label_lower:
+        return "unit-test-results"
+    if "instrumented" in label_lower or "e2e" in label_lower:
+        return "e2e-test-results"
+    return label.lower().replace(" ", "-")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    pairs = parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    github_server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    github_run_id = os.environ.get("GITHUB_RUN_ID", "")
+    sha = os.environ.get("WORKFLOW_RUN_SHA", "")
+    workflow_run_branch = os.environ.get("WORKFLOW_RUN_BRANCH", "")
+
+    if not token:
+        print("Warning: GITHUB_TOKEN not set — skipping issue filing.", file=sys.stderr)
+        return 0
+    if not repository:
+        print("Warning: GITHUB_REPOSITORY not set — skipping issue filing.", file=sys.stderr)
+        return 0
+
+    timestamp = datetime.now(tz=timezone.utc)
+
+    for directory, label in pairs:
+        artifact_name = _artifact_name_for_label(label)
+
+        if not directory.exists():
+            print(
+                f"Note: result directory not found, skipping: {directory}",
+                file=sys.stderr,
+            )
+            continue
+        if not directory.is_dir():
+            print(
+                f"Note: path is not a directory, skipping: {directory}",
+                file=sys.stderr,
+            )
+            continue
+
+        failures = parse_failures(directory, label, artifact_name)
+        if not failures:
+            print(f"Note: no test failures found in {directory}", file=sys.stderr)
+            continue
+
+        print(f"Processing {len(failures)} failure(s) from {label}...", file=sys.stderr)
+        for failure in failures:
+            try:
+                process_failure(
+                    failure=failure,
+                    directory=directory,
+                    token=token,
+                    repository=repository,
+                    timestamp=timestamp,
+                    sha=sha,
+                    github_server_url=github_server_url,
+                    github_run_id=github_run_id,
+                    workflow_run_branch=workflow_run_branch,
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"  Error processing {failure.class_name}.{failure.method_name}: {exc}",
+                    file=sys.stderr,
+                )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -126,7 +126,7 @@ def _find_ocr_text(directory: Path, class_name: str, method_name: str) -> str | 
     short_class = class_name.split(".")[-1]
     prefix = f"{short_class}_{method_name}"
     for ocr_path in directory.glob("*.ocr.txt"):
-        if ocr_path.stem.startswith(prefix) or prefix in ocr_path.stem:
+        if ocr_path.stem == prefix or ocr_path.stem.startswith(prefix + "_"):
             try:
                 return ocr_path.read_text(encoding="utf-8").strip()
             except OSError:

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Unit tests for file_test_failure_issues.py."""
+
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import file_test_failure_issues as ftfi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_xml(directory: Path, filename: str, content: str) -> Path:
+    """Write an XML file to *directory* and return its path."""
+    path = directory / filename
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+PASSING_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.FooTest" tests="2" failures="0" errors="0">
+      <testcase name="testA" classname="com.example.FooTest"/>
+      <testcase name="testB" classname="com.example.FooTest"/>
+    </testsuite>
+"""
+
+FAILING_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.BarTest" tests="2" failures="1" errors="0">
+      <testcase name="testC" classname="com.example.BarTest"/>
+      <testcase name="testD" classname="com.example.BarTest">
+        <failure message="AssertionError: Expected true">Expected true but was false&#10;at com.example.BarTest.testD(BarTest.java:42)</failure>
+      </testcase>
+    </testsuite>
+"""
+
+ERROR_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.BazTest" tests="1" failures="0" errors="1">
+      <testcase name="testE" classname="com.example.BazTest">
+        <error message="NullPointerException">java.lang.NullPointerException&#10;at com.example.BazTest.testE(BazTest.java:10)</error>
+      </testcase>
+    </testsuite>
+"""
+
+SKIPPED_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="com.example.SkipTest" tests="2" failures="0" skipped="1">
+      <testcase name="testPass" classname="com.example.SkipTest"/>
+      <testcase name="testSkip" classname="com.example.SkipTest">
+        <skipped/>
+      </testcase>
+    </testsuite>
+"""
+
+MIXED_XML = """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+      <testsuite name="com.example.AlphaTest" tests="1" failures="0">
+        <testcase name="alpha1"/>
+      </testsuite>
+      <testsuite name="com.example.BetaTest" tests="1" failures="1">
+        <testcase name="beta1">
+          <failure message="AssertionError">beta failed</failure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+"""
+
+_FIXED_TS = datetime(2026, 5, 25, 6, 29, 0, tzinfo=timezone.utc)
+_FIXED_SHA = "a1b2c3d4e5f6789"
+
+
+# ---------------------------------------------------------------------------
+# parse_failures tests
+# ---------------------------------------------------------------------------
+
+class TestParseFailures(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_empty_directory_returns_empty_list(self):
+        result = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(result, [])
+
+    def test_passing_xml_returns_no_failures(self):
+        _write_xml(self.tmpdir, "TEST-FooTest.xml", PASSING_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(failures, [])
+
+    def test_failing_xml_returns_one_failure(self):
+        _write_xml(self.tmpdir, "TEST-BarTest.xml", FAILING_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(len(failures), 1)
+        f = failures[0]
+        self.assertEqual(f.class_name, "com.example.BarTest")
+        self.assertEqual(f.method_name, "testD")
+        self.assertEqual(f.suite_label, "Unit Tests")
+        self.assertEqual(f.artifact_name, "unit-test-results")
+
+    def test_error_element_counts_as_failure(self):
+        _write_xml(self.tmpdir, "TEST-BazTest.xml", ERROR_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].method_name, "testE")
+
+    def test_skipped_not_counted_as_failure(self):
+        _write_xml(self.tmpdir, "TEST-SkipTest.xml", SKIPPED_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(failures, [])
+
+    def test_testsuites_wrapper_parsed(self):
+        _write_xml(self.tmpdir, "TEST-mixed.xml", MIXED_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].class_name, "com.example.BetaTest")
+        self.assertEqual(failures[0].method_name, "beta1")
+
+    def test_malformed_xml_skipped_with_warning(self):
+        (self.tmpdir / "TEST-bad.xml").write_text("<not valid xml <<<", encoding="utf-8")
+        result = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(result, [])
+
+    def test_failure_message_and_stack_trace_captured(self):
+        _write_xml(self.tmpdir, "TEST-BarTest.xml", FAILING_XML)
+        failures = ftfi.parse_failures(self.tmpdir, "Unit Tests", "unit-test-results")
+        self.assertEqual(len(failures), 1)
+        f = failures[0]
+        self.assertEqual(f.failure_message, "AssertionError: Expected true")
+        self.assertIn("Expected true but was false", f.stack_trace)
+        self.assertIn("BarTest.java:42", f.stack_trace)
+
+
+# ---------------------------------------------------------------------------
+# make_issue_title tests
+# ---------------------------------------------------------------------------
+
+class TestMakeIssueTitle(unittest.TestCase):
+
+    def test_format_matches_spec(self):
+        title = ftfi.make_issue_title(
+            "PrefsManagerTest", "readDefaultReturnsNull",
+            _FIXED_TS, "a1b2c3d",
+        )
+        self.assertEqual(
+            title,
+            "[Test Failure] PrefsManagerTest.readDefaultReturnsNull @ 260525-0629-a1b2c3d",
+        )
+
+    def test_sha_truncated_to_7_chars(self):
+        title = ftfi.make_issue_title(
+            "com.example.Foo", "testBar",
+            _FIXED_TS, _FIXED_SHA,
+        )
+        # Only first 7 chars of _FIXED_SHA = "a1b2c3d"
+        self.assertIn("a1b2c3d", title)
+        self.assertNotIn(_FIXED_SHA[7:], title)
+
+    def test_empty_sha_uses_unknown(self):
+        title = ftfi.make_issue_title("Foo", "bar", _FIXED_TS, "")
+        self.assertIn("unknown", title)
+
+    def test_timestamp_format(self):
+        # 2026-05-25 06:29 UTC → yyMMdd-hhmm = 260525-0629
+        title = ftfi.make_issue_title("Foo", "bar", _FIXED_TS, "abc1234")
+        self.assertIn("260525-0629", title)
+
+    def test_includes_class_and_method(self):
+        title = ftfi.make_issue_title("MyClass", "myMethod", _FIXED_TS, "abc1234")
+        self.assertIn("MyClass.myMethod", title)
+
+
+# ---------------------------------------------------------------------------
+# make_issue_body tests
+# ---------------------------------------------------------------------------
+
+class TestMakeIssueBody(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+        self.failure = ftfi.FailedTest(
+            class_name="com.example.BarTest",
+            method_name="testD",
+            failure_message="AssertionError: Expected true",
+            stack_trace="Expected true but was false\nat com.example.BarTest.testD(BarTest.java:42)",
+            suite_label="Unit Tests",
+            artifact_name="unit-test-results",
+        )
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_body(self, **kwargs):
+        defaults = dict(
+            failure=self.failure,
+            directory=self.tmpdir,
+            timestamp=_FIXED_TS,
+            sha=_FIXED_SHA,
+            github_server_url="https://github.com",
+            github_repository="aunger/gallery-button-for-pixel-camera",
+            github_run_id="12345",
+            workflow_run_branch="main",
+        )
+        defaults.update(kwargs)
+        return ftfi.make_issue_body(**defaults)
+
+    def test_body_contains_suite_label(self):
+        body = self._make_body()
+        self.assertIn("Unit Tests", body)
+
+    def test_body_contains_class_name(self):
+        body = self._make_body()
+        self.assertIn("com.example.BarTest", body)
+
+    def test_body_contains_method_name(self):
+        body = self._make_body()
+        self.assertIn("testD", body)
+
+    def test_body_contains_failure_message(self):
+        body = self._make_body()
+        self.assertIn("AssertionError: Expected true", body)
+
+    def test_body_contains_stack_trace(self):
+        body = self._make_body()
+        self.assertIn("BarTest.java:42", body)
+
+    def test_body_contains_ci_run_link(self):
+        body = self._make_body()
+        self.assertIn(
+            "https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/12345",
+            body,
+        )
+
+    def test_body_contains_artifact_link(self):
+        body = self._make_body()
+        self.assertIn("unit-test-results", body)
+
+    def test_stack_trace_truncated_at_2000_chars(self):
+        long_trace = "x" * 3000
+        self.failure = ftfi.FailedTest(
+            class_name="com.example.LongTest",
+            method_name="testLong",
+            failure_message="msg",
+            stack_trace=long_trace,
+            suite_label="Unit Tests",
+            artifact_name="unit-test-results",
+        )
+        body = self._make_body(failure=self.failure)
+        # The truncated excerpt should be at most 2000 chars plus the "(truncated)" suffix
+        self.assertIn("... (truncated)", body)
+        # The full 3000-char trace should not appear verbatim
+        self.assertNotIn("x" * 2001, body)
+
+    def test_stack_trace_not_truncated_when_short(self):
+        short_trace = "short trace"
+        self.failure = ftfi.FailedTest(
+            class_name="com.example.ShortTest",
+            method_name="testShort",
+            failure_message="msg",
+            stack_trace=short_trace,
+            suite_label="Unit Tests",
+            artifact_name="unit-test-results",
+        )
+        body = self._make_body(failure=self.failure)
+        self.assertIn(short_trace, body)
+        self.assertNotIn("... (truncated)", body)
+
+    def test_branch_shown_in_body(self):
+        body = self._make_body(workflow_run_branch="feature/foo")
+        self.assertIn("feature/foo", body)
+
+    def test_no_run_id_shows_unavailable(self):
+        body = self._make_body(github_run_id="")
+        self.assertIn("not available", body)
+
+    def test_ocr_text_inlined_when_present(self):
+        """OCR companion file matching class+method prefix is inlined."""
+        ocr_file = self.tmpdir / "BarTest_testD_screenshot.ocr.txt"
+        ocr_file.write_text("OCR content here", encoding="utf-8")
+        body = self._make_body()
+        self.assertIn("OCR text from screenshot", body)
+        self.assertIn("OCR content here", body)
+
+    def test_ocr_section_absent_when_no_file(self):
+        """No OCR section when no companion .ocr.txt file exists."""
+        body = self._make_body()
+        self.assertNotIn("OCR text from screenshot", body)
+
+
+# ---------------------------------------------------------------------------
+# _find_ocr_text tests
+# ---------------------------------------------------------------------------
+
+class TestFindOcrText(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_returns_none_when_no_ocr_files(self):
+        result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
+        self.assertIsNone(result)
+
+    def test_matches_short_class_and_method_prefix(self):
+        (self.tmpdir / "Foo_testBar_001.ocr.txt").write_text("screen text", encoding="utf-8")
+        result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
+        self.assertEqual(result, "screen text")
+
+    def test_returns_none_when_no_prefix_match(self):
+        (self.tmpdir / "Other_testBaz_001.ocr.txt").write_text("irrelevant", encoding="utf-8")
+        result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
+        self.assertIsNone(result)
+
+    def test_strips_whitespace_from_ocr_text(self):
+        (self.tmpdir / "Foo_testBar_001.ocr.txt").write_text("  trimmed  \n", encoding="utf-8")
+        result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
+        self.assertEqual(result, "trimmed")
+
+
+# ---------------------------------------------------------------------------
+# Duplicate suppression tests
+# ---------------------------------------------------------------------------
+
+class TestFindExistingIssue(unittest.TestCase):
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_issue_number_when_found(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"items": [{"number": 42}]}
+        mock_requests.get.return_value = mock_resp
+        result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
+        self.assertEqual(result, 42)
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_none_when_not_found(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"items": []}
+        mock_requests.get.return_value = mock_resp
+        result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
+        self.assertIsNone(result)
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_none_on_api_error(self, mock_requests):
+        mock_requests.get.side_effect = Exception("network error")
+        result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
+        self.assertIsNone(result)
+
+    def test_returns_none_when_requests_unavailable(self):
+        with patch.object(ftfi, "requests", None):
+            result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
+        self.assertIsNone(result)
+
+
+class TestCreateIssue(unittest.TestCase):
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_issue_number_on_success(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"number": 99}
+        mock_requests.post.return_value = mock_resp
+        result = ftfi.create_issue("token", "owner/repo", "Title", "Body")
+        self.assertEqual(result, 99)
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_none_on_api_error(self, mock_requests):
+        mock_requests.post.side_effect = Exception("server error")
+        result = ftfi.create_issue("token", "owner/repo", "Title", "Body")
+        self.assertIsNone(result)
+
+    def test_returns_none_when_requests_unavailable(self):
+        with patch.object(ftfi, "requests", None):
+            result = ftfi.create_issue("token", "owner/repo", "Title", "Body")
+        self.assertIsNone(result)
+
+    @patch("file_test_failure_issues.requests")
+    def test_sends_correct_labels(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"number": 1}
+        mock_requests.post.return_value = mock_resp
+        ftfi.create_issue("token", "owner/repo", "Title", "Body")
+        call_kwargs = mock_requests.post.call_args
+        payload = call_kwargs[1]["json"]
+        self.assertIn("test-failure", payload["labels"])
+        self.assertIn("ci", payload["labels"])
+        self.assertIn("for ai to do", payload["labels"])
+
+
+class TestAddIssueComment(unittest.TestCase):
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_true_on_success(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_requests.post.return_value = mock_resp
+        result = ftfi.add_issue_comment("token", "owner/repo", 42, "Comment body")
+        self.assertTrue(result)
+
+    @patch("file_test_failure_issues.requests")
+    def test_returns_false_on_api_error(self, mock_requests):
+        mock_requests.post.side_effect = Exception("network error")
+        result = ftfi.add_issue_comment("token", "owner/repo", 42, "Comment body")
+        self.assertFalse(result)
+
+    def test_returns_false_when_requests_unavailable(self):
+        with patch.object(ftfi, "requests", None):
+            result = ftfi.add_issue_comment("token", "owner/repo", 42, "Comment body")
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# process_failure tests (duplicate suppression)
+# ---------------------------------------------------------------------------
+
+class TestProcessFailure(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+        self.failure = ftfi.FailedTest(
+            class_name="com.example.FooTest",
+            method_name="testBar",
+            failure_message="msg",
+            stack_trace="trace",
+            suite_label="Unit Tests",
+            artifact_name="unit-test-results",
+        )
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    @patch("file_test_failure_issues.add_issue_comment")
+    @patch("file_test_failure_issues.create_issue")
+    @patch("file_test_failure_issues.find_existing_issue")
+    def test_comments_on_existing_issue_instead_of_creating(
+        self, mock_find, mock_create, mock_comment
+    ):
+        mock_find.return_value = 55  # existing issue found
+        ftfi.process_failure(
+            failure=self.failure,
+            directory=self.tmpdir,
+            token="tok",
+            repository="owner/repo",
+            timestamp=_FIXED_TS,
+            sha=_FIXED_SHA,
+            github_server_url="https://github.com",
+            github_run_id="1",
+            workflow_run_branch="main",
+        )
+        mock_comment.assert_called_once()
+        mock_create.assert_not_called()
+        # Comment is posted to the existing issue number
+        self.assertEqual(mock_comment.call_args[0][2], 55)
+
+    @patch("file_test_failure_issues.add_issue_comment")
+    @patch("file_test_failure_issues.create_issue")
+    @patch("file_test_failure_issues.find_existing_issue")
+    def test_creates_issue_when_no_duplicate(
+        self, mock_find, mock_create, mock_comment
+    ):
+        mock_find.return_value = None  # no existing issue
+        mock_create.return_value = 77
+        ftfi.process_failure(
+            failure=self.failure,
+            directory=self.tmpdir,
+            token="tok",
+            repository="owner/repo",
+            timestamp=_FIXED_TS,
+            sha=_FIXED_SHA,
+            github_server_url="https://github.com",
+            github_run_id="1",
+            workflow_run_branch="main",
+        )
+        mock_create.assert_called_once()
+        mock_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main() exit-0 tests
+# ---------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmpdir.name)
+        self._env_patch = patch.dict(os.environ, {
+            "GITHUB_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_RUN_ID": "42",
+            "WORKFLOW_RUN_SHA": "abc1234",
+            "WORKFLOW_RUN_BRANCH": "main",
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+        self._tmpdir.cleanup()
+
+    def test_exit_0_with_no_failures(self):
+        _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)
+        result = ftfi.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_directory_missing(self):
+        missing = self.tmpdir / "nonexistent"
+        result = ftfi.main([str(missing), "--suite-label", "Unit Tests"])
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            result = ftfi.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            result = ftfi.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        self.assertEqual(result, 0)
+
+    @patch("file_test_failure_issues.process_failure")
+    def test_exit_0_even_when_api_raises(self, mock_process):
+        """main() must return 0 even if process_failure raises an exception."""
+        mock_process.side_effect = Exception("API is down")
+        _write_xml(self.tmpdir, "TEST-bar.xml", FAILING_XML)
+        result = ftfi.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        self.assertEqual(result, 0)
+
+    @patch("file_test_failure_issues.process_failure")
+    def test_processes_each_failure(self, mock_process):
+        """One process_failure call per failed test case."""
+        _write_xml(self.tmpdir, "TEST-bar.xml", FAILING_XML)
+        ftfi.main([str(self.tmpdir), "--suite-label", "Unit Tests"])
+        self.assertEqual(mock_process.call_count, 1)
+
+    @patch("file_test_failure_issues.process_failure")
+    def test_multiple_suites_processed(self, mock_process):
+        """Failures from all suite directories are processed."""
+        dir2 = Path(self._tmpdir.name) / "e2e"
+        dir2.mkdir()
+        _write_xml(self.tmpdir, "TEST-bar.xml", FAILING_XML)
+        _write_xml(dir2, "TEST-baz.xml", ERROR_XML)
+        result = ftfi.main([
+            str(self.tmpdir), "--suite-label", "Unit Tests",
+            str(dir2), "--suite-label", "Instrumented Tests",
+        ])
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_process.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# parse_args tests
+# ---------------------------------------------------------------------------
+
+class TestParseArgs(unittest.TestCase):
+
+    def test_single_pair(self):
+        pairs = ftfi.parse_args(["path/to/unit", "--suite-label", "Unit Tests"])
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(pairs[0][0], Path("path/to/unit"))
+        self.assertEqual(pairs[0][1], "Unit Tests")
+
+    def test_two_pairs(self):
+        pairs = ftfi.parse_args([
+            "dir1", "--suite-label", "Label1",
+            "dir2", "--suite-label", "Label2",
+        ])
+        self.assertEqual(len(pairs), 2)
+        self.assertEqual(pairs[1][1], "Label2")
+
+    def test_missing_suite_label_flag_raises(self):
+        with self.assertRaises(SystemExit):
+            ftfi.parse_args(["dir1", "--wrong-flag", "Label"])
+
+    def test_no_args_raises(self):
+        with self.assertRaises(SystemExit):
+            ftfi.parse_args([])
+
+    def test_incomplete_pair_raises(self):
+        with self.assertRaises(SystemExit):
+            ftfi.parse_args(["dir1"])
+
+
+# ---------------------------------------------------------------------------
+# _artifact_name_for_label tests
+# ---------------------------------------------------------------------------
+
+class TestArtifactNameForLabel(unittest.TestCase):
+
+    def test_unit_label_maps_to_unit_test_results(self):
+        self.assertEqual(ftfi._artifact_name_for_label("Unit Tests"), "unit-test-results")
+
+    def test_instrumented_label_maps_to_e2e(self):
+        self.assertEqual(
+            ftfi._artifact_name_for_label("Instrumented Tests"), "e2e-test-results"
+        )
+
+    def test_e2e_label_maps_to_e2e(self):
+        self.assertEqual(ftfi._artifact_name_for_label("E2E Tests"), "e2e-test-results")
+
+    def test_unknown_label_slugified(self):
+        self.assertEqual(
+            ftfi._artifact_name_for_label("My Custom Suite"), "my-custom-suite"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -334,6 +334,12 @@ class TestFindOcrText(unittest.TestCase):
         result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
         self.assertEqual(result, "trimmed")
 
+    def test_does_not_match_when_prefix_is_substring_of_another_test(self):
+        """Foo_testBar should NOT match Foo_testBarBaz.ocr.txt (startswith, not contains)."""
+        (self.tmpdir / "Foo_testBarBaz_001.ocr.txt").write_text("wrong match", encoding="utf-8")
+        result = ftfi._find_ocr_text(self.tmpdir, "com.example.Foo", "testBar")
+        self.assertIsNone(result)
+
 
 # ---------------------------------------------------------------------------
 # Duplicate suppression tests


### PR DESCRIPTION
Fixes #208

## What this adds

### `scripts/file_test_failure_issues.py`

A new script that reads JUnit XML from one or more result directories (same ` --suite-label ` argument pattern as `summarize_test_results.py`) and creates one GitHub issue per failing test case via the REST API.

- **Title format:** `[Test Failure] . @ -`
- **Body** includes: suite label, full class name, method name, failure message, stack trace excerpt (truncated at ~2000 chars), link to the CI run, link to the relevant test artifact, and optional inline OCR text from any matching `.ocr.txt` companion file alongside screenshots.
- **Labels applied:** `test-failure`, `ci`, `for ai to do`
- **Duplicate suppression:** searches open issues with label `test-failure` and `.` in the title; appends a comment to the existing issue rather than opening a new one.
- **Always exits 0** — API failures are logged to stderr but do not fail the CI run.

### `.github/workflows/file-test-failure-issues.yml`

Triggers on `workflow_run` completion of the &#34;Build &amp; Test&#34; workflow. When that run concluded with `failure`, the workflow downloads the `unit-test-results` and `e2e-test-results` artifacts and calls the script above.

Permissions are scoped to `issues: write` and `contents: read`. `build.yml` is not modified.

### `scripts/test_file_test_failure_issues.py`

59 unit tests covering:
- JUnit XML parsing (pass, fail, error, skip, `` wrapper, malformed XML)
- Issue title formatting (timestamp, 7-char SHA truncation, empty SHA)
- Body construction (all fields present, stack trace truncated at 2000 chars, OCR section present/absent)
- Duplicate suppression (existing issue → comment; no existing issue → create)
- GitHub API helpers (correct labels sent, exit 0 on network error, behaviour when `requests` is unavailable)
- `main()` exit-0 in all error conditions

## Note on `test-failure` label

The `test-failure` label (color `#b60205`) must be created in the repository before the workflow can apply it to new issues. This requires label write permission which is not available in this automation context — please create it manually via the GitHub UI or with `gh label create &#34;test-failure&#34; --color &#34;b60205&#34; --description &#34;Automatically filed by CI for a failing test&#34;`.