### PR TITLE
Add daily workflow to archive stale test-failure issues

### DIFF
--- a/.github/workflows/archive-stale-test-failures.yml
+++ b/.github/workflows/archive-stale-test-failures.yml
@@ -1,0 +1,22 @@
+name: Archive Stale Test-Failure Issues
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # daily at 04:00 UTC
+
+permissions:
+  issues: write
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Archive stale test-failure issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STALE_DAYS: '21'
+        run: python3 scripts/archive_stale_test_failures.py

--- a/scripts/archive_stale_test_failures.py
+++ b/scripts/archive_stale_test_failures.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Archive stale test-failure GitHub issues.
+
+Finds all open issues labelled ``test-failure`` whose ``updated_at``
+timestamp is older than STALE_DAYS (default 21).  For each such issue
+the ``test-failure`` label is removed and ``test-failure-archive`` is
+added, so it falls out of the Phase 4 dedup search scope.
+
+Usage:
+    python3 scripts/archive_stale_test_failures.py
+
+Exit code is always 0 — API failures are logged but do not fail the
+CI run.
+
+Required environment variables:
+    GITHUB_TOKEN        Personal access token or Actions secret with
+                        issues: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+
+Optional environment variables:
+    STALE_DAYS          Number of inactivity days before an issue is
+                        archived (default: 21)
+"""
+
+import datetime
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helper
+# ---------------------------------------------------------------------------
+
+def gh_api(path: str, token: str, method: str = "GET", body: object = None) -> object:
+    """Make a GitHub API request and return the parsed JSON response.
+
+    Raises ``urllib.error.HTTPError`` or ``urllib.error.URLError`` on
+    failure so callers can handle errors explicitly.
+    """
+    url = f"https://api.github.com/{path}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if body is not None:
+        data = json.dumps(body).encode()
+        req.add_header("Content-Type", "application/json")
+    else:
+        data = None
+    with urllib.request.urlopen(req, data) as r:
+        return json.loads(r.read())
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def fetch_stale_issues(repo: str, token: str, cutoff: datetime.datetime) -> list[dict]:
+    """Return all open test-failure issues last updated before *cutoff*.
+
+    Paginates through all pages automatically.
+    """
+    issues: list[dict] = []
+    page = 1
+    while True:
+        batch = gh_api(
+            f"repos/{repo}/issues?state=open&labels=test-failure&per_page=100&page={page}",
+            token=token,
+        )
+        if not batch:
+            break
+        issues.extend(batch)
+        page += 1
+
+    stale = []
+    for issue in issues:
+        updated_at = datetime.datetime.fromisoformat(
+            issue["updated_at"].replace("Z", "+00:00")
+        )
+        if updated_at < cutoff:
+            stale.append(issue)
+    return stale
+
+
+def archive_issue(issue: dict, repo: str, token: str) -> None:
+    """Swap labels on *issue*: remove test-failure, add test-failure-archive."""
+    n = issue["number"]
+    current_labels = [
+        label["name"]
+        for label in issue["labels"]
+        if label["name"] != "test-failure"
+    ]
+    current_labels.append("test-failure-archive")
+    gh_api(
+        f"repos/{repo}/issues/{n}",
+        token=token,
+        method="PATCH",
+        body={"labels": current_labels},
+    )
+    print(f"Archived issue #{n}: {issue['title']}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    stale_days = int(os.environ.get("STALE_DAYS", "21"))
+
+    if not token:
+        print("Warning: GITHUB_TOKEN not set — skipping archival.", file=sys.stderr)
+        return 0
+    if not repo:
+        print("Warning: GITHUB_REPOSITORY not set — skipping archival.", file=sys.stderr)
+        return 0
+
+    cutoff = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(days=stale_days)
+    )
+
+    try:
+        stale = fetch_stale_issues(repo, token, cutoff)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching issues: {exc}", file=sys.stderr)
+        return 0
+
+    archived = 0
+    for issue in stale:
+        try:
+            archive_issue(issue, repo, token)
+            archived += 1
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"Error archiving issue #{issue['number']}: {exc}",
+                file=sys.stderr,
+            )
+
+    print(f"Done. Archived {archived} issue(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_archive_stale_test_failures.py
+++ b/scripts/test_archive_stale_test_failures.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Unit tests for archive_stale_test_failures.py."""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import archive_stale_test_failures as astf  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 5, 25, 4, 0, 0, tzinfo=timezone.utc)
+_CUTOFF = _NOW - timedelta(days=21)  # 2026-05-04T04:00:00+00:00
+
+
+def _make_issue(number: int, title: str, updated_at: datetime, labels: list[str]) -> dict:
+    """Build a minimal GitHub issue dict as returned by the API."""
+    return {
+        "number": number,
+        "title": title,
+        "updated_at": updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "labels": [{"name": lbl} for lbl in labels],
+    }
+
+
+# ---------------------------------------------------------------------------
+# gh_api tests
+# ---------------------------------------------------------------------------
+
+class TestGhApi(unittest.TestCase):
+
+    @patch("archive_stale_test_failures.urllib.request.urlopen")
+    def test_get_request_sets_correct_headers(self, mock_urlopen):
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cm)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_cm.read.return_value = b'[]'
+        mock_urlopen.return_value = mock_cm
+
+        astf.gh_api("repos/owner/repo/issues", token="mytoken")
+
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.get_header("Authorization"), "Bearer mytoken")
+        self.assertEqual(req.get_header("Accept"), "application/vnd.github+json")
+        self.assertEqual(req.get_header("X-github-api-version"), "2022-11-28")
+
+    @patch("archive_stale_test_failures.urllib.request.urlopen")
+    def test_patch_request_sends_json_body(self, mock_urlopen):
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cm)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_cm.read.return_value = b'{}'
+        mock_urlopen.return_value = mock_cm
+
+        astf.gh_api(
+            "repos/owner/repo/issues/1",
+            token="tok",
+            method="PATCH",
+            body={"labels": ["test-failure-archive"]},
+        )
+
+        req, data = mock_urlopen.call_args[0]
+        self.assertEqual(req.method, "PATCH")
+        self.assertIsNotNone(data)
+
+    @patch("archive_stale_test_failures.urllib.request.urlopen")
+    def test_returns_parsed_json(self, mock_urlopen):
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cm)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_cm.read.return_value = b'{"number": 42}'
+        mock_urlopen.return_value = mock_cm
+
+        result = astf.gh_api("repos/owner/repo/issues/42", token="tok")
+        self.assertEqual(result, {"number": 42})
+
+
+# ---------------------------------------------------------------------------
+# fetch_stale_issues tests
+# ---------------------------------------------------------------------------
+
+class TestFetchStaleIssues(unittest.TestCase):
+
+    def _gh_api_side_effect(self, pages: list[list[dict]]):
+        """Return a side_effect function that yields successive pages."""
+        call_count = [0]
+
+        def side_effect(path, token, method="GET", body=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx < len(pages):
+                return pages[idx]
+            return []
+
+        return side_effect
+
+    def test_stale_issue_returned(self):
+        stale_ts = _CUTOFF - timedelta(days=1)
+        issue = _make_issue(1, "Old failure", stale_ts, ["test-failure"])
+
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([[issue], []])):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["number"], 1)
+
+    def test_recent_issue_not_returned(self):
+        fresh_ts = _CUTOFF + timedelta(days=1)
+        issue = _make_issue(2, "Recent failure", fresh_ts, ["test-failure"])
+
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([[issue], []])):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(result, [])
+
+    def test_issue_exactly_at_cutoff_not_returned(self):
+        """updated_at == cutoff means still active (cutoff is exclusive lower bound)."""
+        issue = _make_issue(3, "Exact cutoff", _CUTOFF, ["test-failure"])
+
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([[issue], []])):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(result, [])
+
+    def test_pagination_stops_on_empty_page(self):
+        """An empty page stops fetching; only one page of results is processed."""
+        stale_ts = _CUTOFF - timedelta(days=5)
+        issue = _make_issue(10, "Issue", stale_ts, ["test-failure"])
+
+        calls = []
+
+        def side_effect(path, token, method="GET", body=None):
+            calls.append(path)
+            if len(calls) == 1:
+                return [issue]
+            return []  # second call returns empty
+
+        with patch.object(astf, "gh_api", side_effect=side_effect):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(calls), 2)  # fetched page 1 then page 2 (empty)
+
+    def test_pagination_two_full_pages(self):
+        """Two pages of results are both collected."""
+        stale_ts = _CUTOFF - timedelta(days=10)
+        page1 = [_make_issue(i, f"Issue {i}", stale_ts, ["test-failure"]) for i in range(1, 4)]
+        page2 = [_make_issue(i, f"Issue {i}", stale_ts, ["test-failure"]) for i in range(4, 7)]
+
+        with patch.object(
+            astf, "gh_api", side_effect=self._gh_api_side_effect([page1, page2, []])
+        ):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(len(result), 6)
+
+    def test_mixed_stale_and_fresh(self):
+        stale_ts = _CUTOFF - timedelta(days=3)
+        fresh_ts = _CUTOFF + timedelta(days=3)
+        issues = [
+            _make_issue(1, "Stale", stale_ts, ["test-failure"]),
+            _make_issue(2, "Fresh", fresh_ts, ["test-failure"]),
+        ]
+
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([issues, []])):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["number"], 1)
+
+
+# ---------------------------------------------------------------------------
+# archive_issue tests
+# ---------------------------------------------------------------------------
+
+class TestArchiveIssue(unittest.TestCase):
+
+    def test_replaces_test_failure_with_archive_label(self):
+        issue = _make_issue(
+            42, "Old failure", _CUTOFF - timedelta(days=1),
+            ["test-failure", "ci", "for ai to do"],
+        )
+
+        with patch.object(astf, "gh_api") as mock_api:
+            astf.archive_issue(issue, "owner/repo", "tok")
+
+        mock_api.assert_called_once()
+        _, kwargs = mock_api.call_args[0], mock_api.call_args[1]
+        body = mock_api.call_args[1]["body"]
+        self.assertIn("test-failure-archive", body["labels"])
+        self.assertNotIn("test-failure", body["labels"])
+        self.assertIn("ci", body["labels"])
+        self.assertIn("for ai to do", body["labels"])
+
+    def test_archive_label_added_even_when_only_label(self):
+        issue = _make_issue(
+            5, "Bare label issue", _CUTOFF - timedelta(days=1),
+            ["test-failure"],
+        )
+
+        with patch.object(astf, "gh_api") as mock_api:
+            astf.archive_issue(issue, "owner/repo", "tok")
+
+        body = mock_api.call_args[1]["body"]
+        self.assertEqual(body["labels"], ["test-failure-archive"])
+
+    def test_uses_patch_method(self):
+        issue = _make_issue(7, "Issue", _CUTOFF - timedelta(days=1), ["test-failure"])
+
+        with patch.object(astf, "gh_api") as mock_api:
+            astf.archive_issue(issue, "owner/repo", "tok")
+
+        self.assertEqual(mock_api.call_args[1]["method"], "PATCH")
+
+    def test_targets_correct_issue_number_in_path(self):
+        issue = _make_issue(99, "Issue", _CUTOFF - timedelta(days=1), ["test-failure"])
+
+        with patch.object(astf, "gh_api") as mock_api:
+            astf.archive_issue(issue, "owner/repo", "tok")
+
+        path = mock_api.call_args[0][0]
+        self.assertIn("99", path)
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self._env_patch = patch.dict(os.environ, {
+            "GITHUB_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "STALE_DAYS": "21",
+        })
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_exit_0_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            result = astf.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            result = astf.main()
+        self.assertEqual(result, 0)
+
+    def test_stale_days_env_var_respected(self):
+        """STALE_DAYS=5 means only issues older than 5 days are archived."""
+        captured_cutoff = []
+
+        def fake_fetch(repo, token, cutoff):
+            captured_cutoff.append(cutoff)
+            return []
+
+        with patch.dict(os.environ, {"STALE_DAYS": "5"}):
+            with patch.object(astf, "fetch_stale_issues", side_effect=fake_fetch):
+                astf.main()
+
+        self.assertEqual(len(captured_cutoff), 1)
+        # cutoff should be approximately now - 5 days
+        expected = datetime.now(timezone.utc) - timedelta(days=5)
+        diff = abs((captured_cutoff[0] - expected).total_seconds())
+        self.assertLess(diff, 5)  # within 5 seconds
+
+    def test_archives_stale_issues(self):
+        stale_ts = datetime.now(timezone.utc) - timedelta(days=30)
+        stale_issue = _make_issue(10, "Stale", stale_ts, ["test-failure"])
+
+        with patch.object(astf, "fetch_stale_issues", return_value=[stale_issue]):
+            with patch.object(astf, "archive_issue") as mock_archive:
+                result = astf.main()
+
+        self.assertEqual(result, 0)
+        mock_archive.assert_called_once_with(stale_issue, "owner/repo", "test-token")
+
+    def test_exit_0_when_fetch_raises(self):
+        with patch.object(astf, "fetch_stale_issues", side_effect=Exception("network error")):
+            result = astf.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_archive_raises(self):
+        stale_ts = datetime.now(timezone.utc) - timedelta(days=30)
+        stale_issue = _make_issue(11, "Stale", stale_ts, ["test-failure"])
+
+        with patch.object(astf, "fetch_stale_issues", return_value=[stale_issue]):
+            with patch.object(astf, "archive_issue", side_effect=Exception("API error")):
+                result = astf.main()
+
+        self.assertEqual(result, 0)
+
+    def test_no_stale_issues_archives_nothing(self):
+        with patch.object(astf, "fetch_stale_issues", return_value=[]):
+            with patch.object(astf, "archive_issue") as mock_archive:
+                result = astf.main()
+
+        self.assertEqual(result, 0)
+        mock_archive.assert_not_called()
+
+    def test_continues_after_single_archive_failure(self):
+        """An error on one issue does not prevent processing subsequent issues."""
+        stale_ts = datetime.now(timezone.utc) - timedelta(days=30)
+        issues = [
+            _make_issue(20, "First", stale_ts, ["test-failure"]),
+            _make_issue(21, "Second", stale_ts, ["test-failure"]),
+        ]
+        archive_calls = []
+
+        def fake_archive(issue, repo, token):
+            archive_calls.append(issue["number"])
+            if issue["number"] == 20:
+                raise Exception("transient error")
+
+        with patch.object(astf, "fetch_stale_issues", return_value=issues):
+            with patch.object(astf, "archive_issue", side_effect=fake_archive):
+                result = astf.main()
+
+        self.assertEqual(result, 0)
+        self.assertIn(21, archive_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #217

## What this does

Adds a daily scheduled GitHub Actions workflow that finds all open `test-failure` issues with no activity for ≥21 days, removes the `test-failure` label, and adds `test-failure-archive`. This causes stale issues to fall out of Phase 4&#39;s dedup search scope.

## Files added

- **`.github/workflows/archive-stale-test-failures.yml`** — daily cron at 04:00 UTC with `issues: write` permission scoped to this workflow only. Calls the extracted Python script rather than embedding Python inline.
- **`scripts/archive_stale_test_failures.py`** — the archival logic, following the same patterns as `file_test_failure_issues.py`. Uses `urllib` (no third-party deps). Staleness is measured by `updated_at`. Configurable via `STALE_DAYS` (default 21). Always exits 0; API errors are logged.
- **`scripts/test_archive_stale_test_failures.py`** — unit tests covering label swap, staleness boundary, pagination, API error handling, and `STALE_DAYS` env var.

## Label to create manually

The `test-failure-archive` label (color `#cfd3d7`) must be created in the repository. It cannot be created via this PR — please create it under **Settings → Labels** before the workflow first runs.

## Test results

All 138 tests pass (`python3 -m unittest discover -s scripts -p &#34;test_*.py&#34;`).