### PR TITLE
Document GitHub API access and Actions log reading in environment.md

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -39,3 +39,23 @@ by the container — never hard-code them.
 | `Failed to find package 'platform-tools'` | sdkmanager can't fetch repo manifest | Same root cause as above |
 | `Failed to install … licences have not been accepted` | Missing `$ANDROID_HOME/licenses/` files | Hook §2b writes them; or run `sdkmanager --licenses` |
 | Build picks up wrong SDK | `ANDROID_HOME` unset or wrong | Check `local.properties` and `ANDROID_HOME` |
+
+---
+
+## GitHub API access
+
+`$GITHUB_TOKEN` is available in the environment. Use it to query the GitHub REST API directly with `curl`.
+
+### Read GitHub Actions job logs
+
+```bash
+# List jobs for a workflow run (to get job IDs):
+curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/aunger/gallery-button-for-pixel-camera/actions/runs/{run_id}/jobs"
+
+# Fetch the log for a specific job:
+curl -s -L -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/aunger/gallery-button-for-pixel-camera/actions/jobs/{job_id}/logs"
+```

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -23,6 +23,7 @@ script for implementation details — each step is commented.
 | `ANDROID_HOME`     | `/home/user/android-sdk`     | hook + `~/.bashrc`| Required by Gradle Android plugin and `adb`                  |
 | `JAVA_TOOL_OPTIONS`| *(modified, not replaced)*   | hook + `~/.bashrc`| Strips `*.google.com` from `nonProxyHosts` — see script §0   |
 | `PATH`             | `+$ANDROID_HOME/…`           | hook + `~/.bashrc`| Adds `sdkmanager`, `adb` to path                            |
+| `GITHUB_TOKEN`     | *(session-scoped JWT)*       | container         | Use with `curl` to query the GitHub REST API                 |
 
 `~/.bashrc` carries the same fixes for interactive terminal sessions.
 The proxy credentials in `JAVA_TOOL_OPTIONS` are a session-scoped JWT injected
@@ -42,11 +43,7 @@ by the container — never hard-code them.
 
 ---
 
-## GitHub API access
-
-`$GITHUB_TOKEN` is available in the environment. Use it to query the GitHub REST API directly with `curl`.
-
-### Read GitHub Actions job logs
+## Read GitHub Actions job logs
 
 ```bash
 # List jobs for a workflow run (to get job IDs):


### PR DESCRIPTION
Adds a GitHub API section to `.claude/environment.md` documenting that `$GITHUB_TOKEN` is available and showing the `curl` commands for listing workflow run jobs and fetching job log output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUu7w5AfqZgJyrVdBwUjh2)_