### PR TITLE
Make requests import hard in file_test_failure_issues.py

### DIFF
--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -28,7 +28,6 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-
 import requests
 
 

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -29,10 +29,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-try:
-    import requests
-except ImportError:
-    requests = None  # type: ignore[assignment]
+import requests
 
 
 # ---------------------------------------------------------------------------
@@ -236,10 +233,6 @@ def find_existing_issue(
     *state* is the string returned by the GitHub API, e.g. ``"open"`` or
     ``"closed"``.
     """
-    if requests is None:
-        print("  Error: 'requests' library not available.", file=sys.stderr)
-        return None
-
     simple_class = class_name.split(".")[-1]
     # Omit is:open / is:closed so both states are searched.
     query = f'repo:{repository} is:issue label:test-failure "[{simple_class}] {method_name}" in:title'
@@ -268,10 +261,6 @@ def create_issue(
     body: str,
 ) -> int | None:
     """Create a new GitHub issue.  Returns the issue number or None on failure."""
-    if requests is None:
-        print("  Error: 'requests' library not available.", file=sys.stderr)
-        return None
-
     url = f"https://api.github.com/repos/{repository}/issues"
     payload = {"title": title, "body": body, "labels": LABELS}
     try:
@@ -290,10 +279,6 @@ def add_issue_comment(
     body: str,
 ) -> bool:
     """Append a comment to an existing issue.  Returns True on success."""
-    if requests is None:
-        print("  Error: 'requests' library not available.", file=sys.stderr)
-        return False
-
     url = f"https://api.github.com/repos/{repository}/issues/{issue_number}/comments"
     try:
         resp = requests.post(url, headers=_github_headers(token), json={"body": body}, timeout=30)
@@ -310,10 +295,6 @@ def reopen_issue(
     issue_number: int,
 ) -> bool:
     """Re-open a closed GitHub issue.  Returns True on success."""
-    if requests is None:
-        print("  Error: 'requests' library not available.", file=sys.stderr)
-        return False
-
     url = f"https://api.github.com/repos/{repository}/issues/{issue_number}"
     try:
         resp = requests.patch(

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -412,11 +412,6 @@ class TestFindExistingIssue(unittest.TestCase):
         result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
         self.assertIsNone(result)
 
-    def test_returns_none_when_requests_unavailable(self):
-        with patch.object(ftfi, "requests", None):
-            result = ftfi.find_existing_issue("token", "owner/repo", "FooTest", "testBar")
-        self.assertIsNone(result)
-
 
 class TestCreateIssue(unittest.TestCase):
 
@@ -432,11 +427,6 @@ class TestCreateIssue(unittest.TestCase):
     def test_returns_none_on_api_error(self, mock_requests):
         mock_requests.post.side_effect = Exception("server error")
         result = ftfi.create_issue("token", "owner/repo", "Title", "Body")
-        self.assertIsNone(result)
-
-    def test_returns_none_when_requests_unavailable(self):
-        with patch.object(ftfi, "requests", None):
-            result = ftfi.create_issue("token", "owner/repo", "Title", "Body")
         self.assertIsNone(result)
 
     @patch("file_test_failure_issues.requests")
@@ -467,11 +457,6 @@ class TestAddIssueComment(unittest.TestCase):
         result = ftfi.add_issue_comment("token", "owner/repo", 42, "Comment body")
         self.assertFalse(result)
 
-    def test_returns_false_when_requests_unavailable(self):
-        with patch.object(ftfi, "requests", None):
-            result = ftfi.add_issue_comment("token", "owner/repo", 42, "Comment body")
-        self.assertFalse(result)
-
 
 class TestReopenIssue(unittest.TestCase):
 
@@ -494,11 +479,6 @@ class TestReopenIssue(unittest.TestCase):
     def test_returns_false_on_api_error(self, mock_requests):
         mock_requests.patch.side_effect = Exception("server error")
         result = ftfi.reopen_issue("token", "owner/repo", 42)
-        self.assertFalse(result)
-
-    def test_returns_false_when_requests_unavailable(self):
-        with patch.object(ftfi, "requests", None):
-            result = ftfi.reopen_issue("token", "owner/repo", 42)
         self.assertFalse(result)
 
 


### PR DESCRIPTION
Fixes #250

Replace the soft `try/except ImportError` block (which silently set `requests = None`) with a plain `import requests`. Remove all four `if requests is None` guard blocks from `find_existing_issue`, `create_issue`, `add_issue_comment`, and `reopen_issue`. If `requests` is not installed the script will now fail loudly at import time rather than silently no-oping at runtime.

The four `test_returns_*_when_requests_unavailable` tests that exercised the now-removed guards are also removed.