### PR TITLE
Emit per-test result markers to CI job log

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,25 @@ val buildNumber: Int = when {
     else -> error("BUILD_NUMBER env var is set but not a valid integer: '$envBuildNumber'")
 }
 
+// ── Test-result marker helpers ────────────────────────────────────────────────
+// Shared by the unit-test listener (tasks.withType<Test>) and the E2E parser.
+// Produces the stable ##GB4PC_TEST## line format consumed by the CI Monitor.
+
+/** JSON-escapes a string value (no surrounding quotes). */
+fun jsonEscape(s: String): String = s
+    .replace("\\", "\\\\")
+    .replace("\"", "\\\"")
+    .replace("\n", "\\n")
+    .replace("\r", "\\r")
+    .replace("\t", "\\t")
+
+/** Returns the first ≤10 stack frames of [ex] as a single newline-separated string. */
+fun buildTrace(ex: Throwable): String {
+    val frames = ex.stackTrace.take(10).joinToString("\n") { "\tat $it" }
+    val header = ex.toString()
+    return if (frames.isEmpty()) header else "$header\n$frames"
+}
+
 android {
     namespace = "com.gb4pc"
     compileSdk = 35
@@ -103,6 +122,29 @@ android {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
+            all { testTask ->
+                testTask.addTestListener(object : TestListener {
+                    override fun beforeSuite(suite: TestDescriptor) {}
+                    override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
+                    override fun beforeTest(test: TestDescriptor) {}
+                    override fun afterTest(test: TestDescriptor, result: TestResult) {
+                        val outcome = when (result.resultType) {
+                            TestResult.ResultType.SUCCESS -> "PASS"
+                            TestResult.ResultType.FAILURE -> "FAIL"
+                            TestResult.ResultType.SKIPPED -> "SKIP"
+                        }
+                        val suite = test.className ?: ""
+                        val name = test.name
+                        val ms = result.endTime - result.startTime
+                        val ex = result.exception
+                        val msg = if (ex != null) jsonEscape(ex.message ?: ex.javaClass.name) else ""
+                        val trace = if (ex != null) jsonEscape(buildTrace(ex)) else ""
+                        println(
+                            """##GB4PC_TEST## {"suite":"${jsonEscape(suite)}","name":"${jsonEscape(name)}","outcome":"$outcome","ms":$ms,"msg":"$msg","trace":"$trace"}"""
+                        )
+                    }
+                })
+            }
         }
     }
 }
@@ -244,7 +286,26 @@ tasks.register("connectedE2EAndroidTest") {
                     inStack = false
                     val code = line.removePrefix("INSTRUMENTATION_STATUS_CODE:").trim().toIntOrNull() ?: 0
                     if (curName.isNotEmpty()) {
-                        if (code != 1) cases += TestCase(curClass, curName, code, curStack.toString())
+                        if (code != 1) {
+                            cases += TestCase(curClass, curName, code, curStack.toString())
+                            // Emit per-test marker immediately so the CI log is the source of truth.
+                            val outcome = when (code) {
+                                0 -> "PASS"
+                                -3 -> "SKIP"
+                                else -> "FAIL"
+                            }
+                            val stackStr = curStack.toString()
+                            val msg = if (code != 0 && code != -3)
+                                jsonEscape(stackStr.lines().firstOrNull().orEmpty().take(200))
+                            else ""
+                            val trace = if (code != 0 && code != -3) {
+                                val frames = stackStr.lines().take(10).joinToString("\\n")
+                                jsonEscape(frames)
+                            } else ""
+                            println(
+                                """##GB4PC_TEST## {"suite":"${jsonEscape(curClass)}","name":"${jsonEscape(curName)}","outcome":"$outcome","ms":0,"msg":"$msg","trace":"$trace"}"""
+                            )
+                        }
                         curStack = StringBuilder()  // always reset so stale stack can't leak into the next test
                     }
                 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,7 +299,7 @@ tasks.register("connectedE2EAndroidTest") {
                                 jsonEscape(stackStr.lines().firstOrNull().orEmpty().take(200))
                             else ""
                             val trace = if (code != 0 && code != -3) {
-                                val frames = stackStr.lines().take(10).joinToString("\\n")
+                                val frames = stackStr.lines().take(10).joinToString("\n")
                                 jsonEscape(frames)
                             } else ""
                             println(


### PR DESCRIPTION
Fixes #257.

Adds stable, greppable `##GB4PC_TEST##` markers — one per test, emitted as each test finishes — so the CI job log becomes the single source of truth for per-test results. The marker format is a JSON payload on a single line:

```
##GB4PC_TEST## {"suite":"com.gb4pc.FooTest","name":"doesBar","outcome":"FAIL","ms":42,"msg":"expected:<1> but was:<2>","trace":"java.lang.AssertionError: ...\n\tat ..."}
```

`outcome` ∈ `PASS` / `FAIL` / `SKIP`. On `FAIL`, `msg` carries the exception message and `trace` carries the first ≤10 stack frames. Both fields are empty strings on `PASS`/`SKIP`.

## Changes in `app/build.gradle.kts`

- **`jsonEscape()` and `buildTrace()` helpers** added above `android {}`, shared by both test paths.
- **Unit tests:** `testOptions.unitTests.all { addTestListener { afterTest { … } } }` registers a `TestListener` on the `testDebugUnitTest` task that prints one marker per test.
- **E2E tests:** the `INSTRUMENTATION_STATUS_CODE` branch in `connectedE2EAndroidTest` now emits the same marker immediately when each test's final status code arrives (`code != 1`), using the already-captured `curClass`/`curName`/`curStack` state. The marker format is identical to the unit-test path so a downstream parser can treat both uniformly.

Verified locally: `./gradlew testDebugUnitTest` prints `PASS` markers for all passing tests; a deliberately-failing test (added and then removed before this commit) produced a `FAIL` marker with the correct exception message and a 10-frame truncated trace.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbfU9NqAAUT3XSkkp4Pw1q)_