### PR TITLE
Upload per-step test marker artifacts for near-real-time CI signal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,10 +123,13 @@ jobs:
         if: steps.diff_check.outputs.needs_full_build == 'true'
         env:
           BUILD_NUMBER: ${{ github.run_number }}
-        run: >
-          ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug
-          :e2e-mock-gallery:assembleDebug
-          testDebugUnitTest -PversionName=dev.${{ github.run_number }}
+        run: |
+          mkdir -p results
+          set -o pipefail
+          ./gradlew assembleDebug assembleDebugAndroidTest :e2e-mock-camera:assembleDebug \
+            :e2e-mock-gallery:assembleDebug \
+            testDebugUnitTest -PversionName=dev.${{ github.run_number }} \
+            | tee >(grep '^##GB4PC_TEST##' > results/unit.ndjson)
 
       - name: Upload unit test results
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
@@ -136,6 +139,14 @@ jobs:
           path: |
             app/build/test-results/testDebugUnitTest/
             app/build/reports/tests/
+          retention-days: 14
+
+      - name: Upload unit test markers
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: testresults-unit
+          path: results/unit.ndjson
           retention-days: 14
 
       - name: Start emulator
@@ -305,14 +316,25 @@ jobs:
         continue-on-error: true
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
+          mkdir -p results
+          set -o pipefail
           ./gradlew connectedE2EAndroidTest \
-            -Pe2eClass=com.gb4pc.e2e.PixelCameraOverlayE2ETest || {
+            -Pe2eClass=com.gb4pc.e2e.PixelCameraOverlayE2ETest \
+            | tee >(grep '^##GB4PC_TEST##' > results/e2e-overlay.ndjson) || {
             echo "=== LOGCAT (last 300 lines) ==="
             "$ADB" logcat -d | \
               bash scripts/filter_logcat.sh | \
               tail -300
             exit 1
           }
+
+      - name: Upload overlay E2E markers
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: testresults-e2e-overlay
+          path: results/e2e-overlay.ndjson
+          retention-days: 14
 
       - name: Run GalleryButtonVisualE2ETest
         # Failures auto-tracked as issues. continue-on-error lets subsequent steps run even on failure.
@@ -321,14 +343,25 @@ jobs:
         continue-on-error: true
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
+          mkdir -p results
+          set -o pipefail
           ./gradlew connectedE2EAndroidTest \
-            -Pe2eClass=com.gb4pc.e2e.GalleryButtonVisualE2ETest || {
+            -Pe2eClass=com.gb4pc.e2e.GalleryButtonVisualE2ETest \
+            | tee >(grep '^##GB4PC_TEST##' > results/e2e-gallery.ndjson) || {
             echo "=== LOGCAT (last 300 lines) ==="
             "$ADB" logcat -d | \
               bash scripts/filter_logcat.sh | \
               tail -300
             exit 1
           }
+
+      - name: Upload gallery E2E markers
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: testresults-e2e-gallery
+          path: results/e2e-gallery.ndjson
+          retention-days: 14
 
       - name: Pull and upload E2E screenshots on failure
         id: pull_e2e_screenshots


### PR DESCRIPTION
Fixes #264.

## Scope: plumbing-only

This PR is **plumbing-only** by decision. The `##GB4PC_TEST##` markers it tees on are emitted by **#257**, which is **not yet implemented**, so the uploaded `.ndjson` artifacts will be **empty until #257 lands**. Merging this first is intentional: it puts the producer wiring (tee + per-step uploads) in place so that once #257 emits markers the artifacts immediately carry content. End-to-end verification — non-empty artifacts, and confirming the `^##GB4PC_TEST##` grep anchor matches #257's emitted format (watch for Gradle log line-prefixing) — is tracked in **#267**.

## What this does

Each of the three test steps now tees its `##GB4PC_TEST##` markers to a per-step ndjson file under `results/`, using `set -o pipefail` + `tee >(grep '^##GB4PC_TEST##' > results/<group>.ndjson)` so the Gradle exit code still drives the step conclusion:

- `results/unit.ndjson` — **Build and run unit tests** (single step, unchanged grouping)
- `results/e2e-overlay.ndjson` — **Run PixelCameraOverlayE2ETest**
- `results/e2e-gallery.ndjson` — **Run GalleryButtonVisualE2ETest**

Immediately after each test step, an `actions/upload-artifact` step with `if: always()` uploads a distinctly-named artifact (`testresults-unit`, `testresults-e2e-overlay`, `testresults-e2e-gallery`) so artifacts appear in the run's artifact list as soon as that step finishes, mid-job. Each upload is also gated on `steps.diff_check.outputs.needs_full_build == 'true'` so uploads only occur when tests actually ran.

The existing `continue-on-error: true` on both E2E steps and all logcat-on-failure blocks are preserved unchanged. No new token scope is required; artifact upload works under the existing `permissions: contents: read`.

## Correction to the issue's premise

The issue's original text said "Keep E2E as a single step initially (avoid repeated emulator boot)." That premise was already false before this PR. The workflow already had two separate, well-named E2E steps — `Run PixelCameraOverlayE2ETest` and `Run GalleryButtonVisualE2ETest` — each running `connectedE2EAndroidTest` filtered to one class via `-Pe2eClass=`, both against the same already-booted emulator (AVD booted once in an earlier setup step; the E2E steps use `--post-boot` and do not re-boot). There is no repeated-boot cost and E2E already provides per-class step conclusions. (#264 has been updated to reflect this.)

Per the repo owner's decision:
- **Unit tests: kept as a single step** (not split further).
- **E2E: the two existing per-class steps left exactly as they are.** No merging, no additions.

## Files changed

- `.github/workflows/build.yml` — 39 insertions, 6 deletions: added `mkdir -p results` + tee-to-ndjson in the unit test step; added three `Upload *` artifact steps (one after each test step, `if: always() && needs_full_build == 'true'`).

## Related issues

- Depends on #257 (marker emission) to make artifacts non-empty.
- #267 — end-to-end verification once #257 + this land.
- #265 — dormant instrumented classes (independent).
