### PR TITLE
Stream per-test CI signals and extract Monitor script to scripts/ (#258)

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -89,7 +89,8 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
   if Reviewer gave approval:
     Orchestrator launches a Monitor tool call (run_in_background: true, timeout_ms: 1800000)
     Each stdout line arrives as a task-notification event
-    Act only on lines containing Clear, Blocked, or Infra. Relay in_progress lines to the user as brief status updates (the script suppresses these unless no other output has been emitted for over 120 seconds).
+    Act only on the terminal lines Clear, Blocked, or Infra. Relay in_progress lines to the user as brief status updates (the script suppresses these unless no other output has been emitted for over 120 seconds).
+    Relay `step "..." -> ...` and `FAIL [...] ...` lines to the user as informational test-result deltas; they do NOT end the loop or start a new Author round.
     if Monitor emits a Blocked line  → goto newAuthor
     if Monitor emits an Infra line   → escalate to user; stop
     if Monitor emits a Clear line    → PR may be merged
@@ -106,6 +107,18 @@ REPO="gallery-button-for-pixel-camera"
 PR=<PR_NUMBER>
 HEADERS=(-H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json")
 last_output_ts=$(date +%s)
+
+# Dedup state for the streamed test-result signals (removed when the loop exits).
+seen_steps=$(mktemp); seen_arts=$(mktemp); seen_fails=$(mktemp)
+trap 'rm -f "$seen_steps" "$seen_arts" "$seen_fails"' EXIT
+
+# Print each line of $1 prefixed with the PR tag, and reset the 120s silence
+# timer (any streamed output counts as liveness).
+emit_block() {
+  [ -z "$1" ] && return 0
+  printf '%s\n' "$1" | sed "s/^/PR#${PR}: /"
+  last_output_ts=$(date +%s)
+}
 
 while true; do
   sha=$(curl -s "${HEADERS[@]}" "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | \
@@ -134,6 +147,96 @@ elif all(s=='completed' for s in statuses):
 else:
     print('in_progress')
 " 2>/dev/null)
+
+  # --- Streamed test-result signals -----------------------------------------
+  # Emitted independent of the overall check conclusion, so E2E failures surface
+  # even while the check stays green via continue-on-error. Both signals are
+  # purely informational: they reset the silence timer but never end the loop.
+  run_id=$(curl -s "${HEADERS[@]}" \
+    "https://api.github.com/repos/$OWNER/$REPO/actions/runs?head_sha=$sha&event=pull_request&per_page=5" | \
+    python3 -c "
+import sys,json
+for r in json.load(sys.stdin).get('workflow_runs',[]):
+    if r.get('status')!='cancelled': print(r['id']); break
+" 2>/dev/null)
+
+  if [ -n "$run_id" ]; then
+    # Signal 1 — per-step conclusion deltas for the build-and-test job. Emit when
+    # a step reaches 'completed' if it is one of the three named test steps (on any
+    # conclusion) or genuinely failed; successful setup steps and skipped
+    # conditional (upload-on-failure) steps are suppressed as noise. Deduped by step
+    # number. Gives the live "which group finished/failed, and when" signal.
+    steps_out=$(curl -s "${HEADERS[@]}" \
+      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/jobs?per_page=30" | \
+      SEEN="$seen_steps" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN']
+seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
+new=[]; out=[]
+for j in json.load(sys.stdin).get('jobs',[]):
+    if j.get('name')!='build-and-test': continue
+    for s in j.get('steps',[]):
+        if s.get('status')!='completed': continue
+        num=str(s.get('number'))
+        if num in seen: continue
+        new.append(num)
+        name=s.get('name','?'); concl=s.get('conclusion') or '?'
+        if name=='Build and run unit tests' or 'E2ETest' in name or concl in ('failure','cancelled','timed_out','action_required'):
+            out.append('step \"%s\" -> %s' % (name, concl))
+if new: open(seen_f,'a').write('\n'.join(new)+'\n')
+print('\n'.join(out))
+" 2>/dev/null)
+    emit_block "$steps_out"
+
+    # Signal 2 — per-test FAIL detail from the testresults-<group> artifacts the
+    # workflow uploads after each test step. Download each new artifact once, parse
+    # its ##GB4PC_TEST## ndjson markers, and emit new FAIL entries (message +
+    # truncated trace), deduped across polls by suite#name.
+    arts=$(curl -s "${HEADERS[@]}" \
+      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/artifacts?per_page=100" | \
+      SEEN="$seen_arts" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN']
+seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
+for a in json.load(sys.stdin).get('artifacts',[]):
+    n=a.get('name','')
+    if n.startswith('testresults-') and not a.get('expired') and str(a['id']) not in seen:
+        print('%s\t%s' % (a['id'], n))
+" 2>/dev/null)
+    while IFS=$'\t' read -r aid aname; do
+      [ -z "$aid" ] && continue
+      tmp=$(mktemp -d)
+      if curl -sL "${HEADERS[@]}" \
+           "https://api.github.com/repos/$OWNER/$REPO/actions/artifacts/$aid/zip" -o "$tmp/a.zip" \
+         && unzip -qo "$tmp/a.zip" -d "$tmp" 2>/dev/null; then
+        fails_out=$(find "$tmp" -name '*.ndjson' -exec cat {} + 2>/dev/null | SEEN_FAILS="$seen_fails" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN_FAILS']
+seen=set(open(seen_f).read().splitlines()) if os.path.getsize(seen_f) else set()
+new=[]
+for raw in sys.stdin:
+    i=raw.find('##GB4PC_TEST##')
+    if i==-1: continue
+    try: m=json.loads(raw[i+len('##GB4PC_TEST##'):].strip())
+    except Exception: continue
+    if m.get('outcome')!='FAIL': continue
+    key=m.get('suite','')+'#'+m.get('name','')
+    if key in seen: continue
+    seen.add(key); new.append(key)
+    msg=(m.get('msg') or '').strip(); tr=(m.get('trace') or '').strip()
+    if len(tr)>800: tr=tr[:800]+' ...(truncated)'
+    line='FAIL [%s] %s: %s' % (m.get('suite','?'), m.get('name','?'), msg)
+    if tr: line+='\n  '+tr.replace('\n','\n  ')
+    print(line)
+if new: open(seen_f,'a').write('\n'.join(new)+'\n')
+")
+        emit_block "$fails_out"
+        echo "$aid" >> "$seen_arts"
+      fi
+      rm -rf "$tmp"
+    done <<< "$arts"
+  fi
+  # --------------------------------------------------------------------------
 
   if [ "$result" = "in_progress" ]; then
     now=$(date +%s)
@@ -173,7 +276,11 @@ done
 | `PR#N: Blocked ...`   | A check failed (`failure`/`action_required`) or `mergeable_state` is `behind`/`dirty`; new Author round needed. |
 | `PR#N: Infra ...`     | A CI infrastructure problem (`cancelled`, `timed_out`, `stale`, `startup_failure`, or `mergeable_state=blocked`); escalate to user. |
 | `PR#N: in_progress`   | CI still running; emitted only after >120 s of silence (no other output); relay to user as a brief status update. |
+| `PR#N: step "..." -> ...` | A `build-and-test` step reached a conclusion: one of the three named test steps (`Build and run unit tests`, `Run *E2ETest`), or any genuine step failure. **Informational** — surfaces *which group* finished/failed and when; never ends the loop. |
+| `PR#N: FAIL [suite] name: ...` | A per-test failure (message + truncated trace) parsed from a `testresults-<group>` artifact, possibly followed by indented trace lines. **Informational** — surfaces even when the check stays green via `continue-on-error`; never ends the loop. |
 
+- `step`/`FAIL` lines are **informational test-result deltas**, not terminal outcomes: relay them to the user but do not start a new Author round. Only a `Blocked` line does that.
+- The Monitor reads results at **step granularity** from two polled REST signals — per-step `conclusion` (`/actions/runs/{id}/jobs`) and the `testresults-<group>` artifacts (`/actions/runs/{id}/artifacts`). It deliberately does **not** scrape the in-progress job log: `GET /actions/jobs/{job_id}/logs` returns 404 until the job completes, so markers are not readable mid-run that way.
 - The 30-minute escalation threshold is enforced by `timeout_ms: 1800000` on the Monitor call — no elapsed-time tracking needed.
 - Do not subscribe to PR events or delay dispatching the Reviewer while waiting for CI; the Monitor loop replaces that pattern.
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -87,7 +87,7 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
 ```
   if Reviewer requested changes → goto newAuthor
   if Reviewer gave approval:
-    Orchestrator launches a Monitor tool call (run_in_background: true, timeout_ms: 1800000)
+    Orchestrator launches a Monitor tool call running `bash scripts/ci_monitor.sh <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000)
     Each stdout line arrives as a task-notification event
     Act only on the terminal lines Clear, Blocked, or Infra. Relay in_progress lines to the user as brief status updates (the script suppresses these unless no other output has been emitted for over 120 seconds).
     Relay `step "..." -> ...` and `FAIL [...] ...` lines to the user as informational test-result deltas; they do NOT end the loop or start a new Author round.
@@ -99,174 +99,13 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
 
 ### Monitor bash script
 
-Use the following script verbatim as the `command` for the `Monitor` tool call. Replace `<PR_NUMBER>` with the actual PR number at runtime.
+The poll loop lives in [`scripts/ci_monitor.sh`](../scripts/ci_monitor.sh). Run it from the repo root, passing the PR number as the sole argument, as the `command` for the `Monitor` tool call:
 
 ```bash
-OWNER="aunger"
-REPO="gallery-button-for-pixel-camera"
-PR=<PR_NUMBER>
-HEADERS=(-H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json")
-last_output_ts=$(date +%s)
-
-# Dedup state for the streamed test-result signals (removed when the loop exits).
-seen_steps=$(mktemp); seen_arts=$(mktemp); seen_fails=$(mktemp)
-trap 'rm -f "$seen_steps" "$seen_arts" "$seen_fails"' EXIT
-
-# Print each line of $1 prefixed with the PR tag, and reset the 120s silence
-# timer (any streamed output counts as liveness).
-emit_block() {
-  [ -z "$1" ] && return 0
-  printf '%s\n' "$1" | sed "s/^/PR#${PR}: /"
-  last_output_ts=$(date +%s)
-}
-
-while true; do
-  sha=$(curl -s "${HEADERS[@]}" "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | \
-    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('head',{}).get('sha',''))" 2>/dev/null)
-
-  [ -z "$sha" ] && { echo "PR#${PR}: could not fetch SHA"; last_output_ts=$(date +%s); sleep 30; continue; }
-
-  check_data=$(curl -s "${HEADERS[@]}" \
-    "https://api.github.com/repos/$OWNER/$REPO/commits/$sha/check-runs" 2>/dev/null)
-
-  result=$(echo "$check_data" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-runs=d.get('check_runs',[])
-total=d.get('total_count',0)
-if total==0:
-    print('Clear'); exit()
-statuses=[r['status'] for r in runs]
-conclusions=[r.get('conclusion','') for r in runs if r['status']=='completed']
-if any(s in ('in_progress','queued') for s in statuses):
-    print('in_progress')
-elif all(s=='completed' for s in statuses):
-    if any(c in ('cancelled','timed_out','stale','startup_failure') for c in conclusions): print('Infra')
-    elif any(c in ('failure','action_required') for c in conclusions): print('Blocked')
-    else: print('all_passed')
-else:
-    print('in_progress')
-" 2>/dev/null)
-
-  # --- Streamed test-result signals -----------------------------------------
-  # Emitted independent of the overall check conclusion, so E2E failures surface
-  # even while the check stays green via continue-on-error. Both signals are
-  # purely informational: they reset the silence timer but never end the loop.
-  run_id=$(curl -s "${HEADERS[@]}" \
-    "https://api.github.com/repos/$OWNER/$REPO/actions/runs?head_sha=$sha&event=pull_request&per_page=5" | \
-    python3 -c "
-import sys,json
-for r in json.load(sys.stdin).get('workflow_runs',[]):
-    if r.get('status')!='cancelled': print(r['id']); break
-" 2>/dev/null)
-
-  if [ -n "$run_id" ]; then
-    # Signal 1 — per-step conclusion deltas for the build-and-test job. Emit when
-    # a step reaches 'completed' if it is one of the three named test steps (on any
-    # conclusion) or genuinely failed; successful setup steps and skipped
-    # conditional (upload-on-failure) steps are suppressed as noise. Deduped by step
-    # number. Gives the live "which group finished/failed, and when" signal.
-    steps_out=$(curl -s "${HEADERS[@]}" \
-      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/jobs?per_page=30" | \
-      SEEN="$seen_steps" python3 -c "
-import sys,json,os
-seen_f=os.environ['SEEN']
-seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
-new=[]; out=[]
-for j in json.load(sys.stdin).get('jobs',[]):
-    if j.get('name')!='build-and-test': continue
-    for s in j.get('steps',[]):
-        if s.get('status')!='completed': continue
-        num=str(s.get('number'))
-        if num in seen: continue
-        new.append(num)
-        name=s.get('name','?'); concl=s.get('conclusion') or '?'
-        if name=='Build and run unit tests' or 'E2ETest' in name or concl in ('failure','cancelled','timed_out','action_required'):
-            out.append('step \"%s\" -> %s' % (name, concl))
-if new: open(seen_f,'a').write('\n'.join(new)+'\n')
-print('\n'.join(out))
-" 2>/dev/null)
-    emit_block "$steps_out"
-
-    # Signal 2 — per-test FAIL detail from the testresults-<group> artifacts the
-    # workflow uploads after each test step. Download each new artifact once, parse
-    # its ##GB4PC_TEST## ndjson markers, and emit new FAIL entries (message +
-    # truncated trace), deduped across polls by suite#name.
-    arts=$(curl -s "${HEADERS[@]}" \
-      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/artifacts?per_page=100" | \
-      SEEN="$seen_arts" python3 -c "
-import sys,json,os
-seen_f=os.environ['SEEN']
-seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
-for a in json.load(sys.stdin).get('artifacts',[]):
-    n=a.get('name','')
-    if n.startswith('testresults-') and not a.get('expired') and str(a['id']) not in seen:
-        print('%s\t%s' % (a['id'], n))
-" 2>/dev/null)
-    while IFS=$'\t' read -r aid aname; do
-      [ -z "$aid" ] && continue
-      tmp=$(mktemp -d)
-      if curl -sL "${HEADERS[@]}" \
-           "https://api.github.com/repos/$OWNER/$REPO/actions/artifacts/$aid/zip" -o "$tmp/a.zip" \
-         && unzip -qo "$tmp/a.zip" -d "$tmp" 2>/dev/null; then
-        fails_out=$(find "$tmp" -name '*.ndjson' -exec cat {} + 2>/dev/null | SEEN_FAILS="$seen_fails" python3 -c "
-import sys,json,os
-seen_f=os.environ['SEEN_FAILS']
-seen=set(open(seen_f).read().splitlines()) if os.path.getsize(seen_f) else set()
-new=[]
-for raw in sys.stdin:
-    i=raw.find('##GB4PC_TEST##')
-    if i==-1: continue
-    try: m=json.loads(raw[i+len('##GB4PC_TEST##'):].strip())
-    except Exception: continue
-    if m.get('outcome')!='FAIL': continue
-    key=m.get('suite','')+'#'+m.get('name','')
-    if key in seen: continue
-    seen.add(key); new.append(key)
-    msg=(m.get('msg') or '').strip(); tr=(m.get('trace') or '').strip()
-    if len(tr)>800: tr=tr[:800]+' ...(truncated)'
-    line='FAIL [%s] %s: %s' % (m.get('suite','?'), m.get('name','?'), msg)
-    if tr: line+='\n  '+tr.replace('\n','\n  ')
-    print(line)
-if new: open(seen_f,'a').write('\n'.join(new)+'\n')
-")
-        emit_block "$fails_out"
-        echo "$aid" >> "$seen_arts"
-      fi
-      rm -rf "$tmp"
-    done <<< "$arts"
-  fi
-  # --------------------------------------------------------------------------
-
-  if [ "$result" = "in_progress" ]; then
-    now=$(date +%s)
-    if [ $((now - last_output_ts)) -gt 120 ]; then
-      echo "PR#${PR}: in_progress"
-      last_output_ts=$now
-    fi
-  elif [ "$result" = "all_passed" ]; then
-    mergeable=$(curl -s "${HEADERS[@]}" "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | \
-      python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('mergeable_state','unknown'))" 2>/dev/null)
-    if [ "$mergeable" = "clean" ] || [ "$mergeable" = "unstable" ]; then
-      echo "PR#${PR}: Clear (mergeable_state=$mergeable)"; break
-    elif [ "$mergeable" = "behind" ] || [ "$mergeable" = "dirty" ]; then
-      echo "PR#${PR}: Blocked (mergeable_state=$mergeable)"; break
-    elif [ "$mergeable" = "blocked" ]; then
-      echo "PR#${PR}: Infra (mergeable_state=blocked)"; break
-    else
-      echo "PR#${PR}: all_passed mergeable_state=$mergeable (still computing)"
-      last_output_ts=$(date +%s)
-    fi
-  elif [ "$result" = "Blocked" ] || [ "$result" = "Infra" ]; then
-    echo "PR#${PR}: $result"; break
-  else
-    echo "PR#${PR}: $result"
-    last_output_ts=$(date +%s)
-  fi
-
-  sleep 30
-done
+bash scripts/ci_monitor.sh <PR_NUMBER>
 ```
+
+`OWNER`/`REPO` default to this repo at the top of the script, and it reads `$GITHUB_TOKEN` from the environment. The script deliberately omits `set -e` so transient REST/parse failures cannot kill the resilient poll loop; the 30-minute escalation threshold is enforced by `timeout_ms: 1800000` on the Monitor call, not inside the script. Each stdout line is the interface (see the outcome vocabulary below): terminal lines (`Clear`/`Blocked`/`Infra`) end the loop, while informational lines keep it alive.
 
 ### Outcome vocabulary
 

--- a/scripts/ci_monitor.sh
+++ b/scripts/ci_monitor.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# ci_monitor.sh — Poll a PR's CI and stream a terminal outcome plus per-test signals.
+#
+# Invoked by the Orchestrator's Monitor tool call (see agents/dev_orchestration.md).
+# Each stdout line is consumed as a task-notification event, so output is the
+# interface: terminal outcome lines end the loop, while informational lines
+# (in_progress heartbeat, per-step deltas, per-test FAILs) keep it alive.
+#
+# Usage:
+#   bash scripts/ci_monitor.sh <PR_NUMBER>
+#
+# Arguments:
+#   <PR_NUMBER>   The pull request number to monitor (required).
+#
+# Environment:
+#   GITHUB_TOKEN  GitHub token used for the REST calls (required).
+#
+# Outcome vocabulary (one terminal line ends the loop):
+#   PR#N: Clear ...      All checks passed and mergeable_state is clean/unstable.
+#   PR#N: Blocked ...    A check failed, or mergeable_state is behind/dirty.
+#   PR#N: Infra ...      A CI infrastructure problem, or mergeable_state=blocked.
+#   PR#N: in_progress    CI still running; emitted only after >120 s of silence.
+#   PR#N: step "..." -> ...    A build-and-test step reached a conclusion (informational).
+#   PR#N: FAIL [suite] name: ...   A per-test failure from a testresults artifact (informational).
+#
+# NOTE on error handling: this script deliberately does NOT use `set -e`. The
+# poll loop must survive transient REST/parse failures — the many
+# `curl ... 2>/dev/null` and `python3` invocations may exit non-zero on a
+# hiccup, and `set -e` would kill the resilient loop on the first such blip.
+# `set -u`/`set -o pipefail` are likewise avoided so a missing field or a
+# python exit inside a pipeline cannot abort the loop. The 30-minute escalation
+# threshold is enforced by `timeout_ms` on the Monitor call, not here.
+
+OWNER="aunger"
+REPO="gallery-button-for-pixel-camera"
+PR="$1"
+HEADERS=(-H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json")
+last_output_ts=$(date +%s)
+
+# Dedup state for the streamed test-result signals (removed when the loop exits).
+seen_steps=$(mktemp); seen_arts=$(mktemp); seen_fails=$(mktemp)
+trap 'rm -f "$seen_steps" "$seen_arts" "$seen_fails"' EXIT
+
+# Print each line of $1 prefixed with the PR tag, and reset the 120s silence
+# timer (any streamed output counts as liveness).
+emit_block() {
+  [ -z "$1" ] && return 0
+  printf '%s\n' "$1" | sed "s/^/PR#${PR}: /"
+  last_output_ts=$(date +%s)
+}
+
+while true; do
+  sha=$(curl -s "${HEADERS[@]}" "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | \
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('head',{}).get('sha',''))" 2>/dev/null)
+
+  [ -z "$sha" ] && { echo "PR#${PR}: could not fetch SHA"; last_output_ts=$(date +%s); sleep 30; continue; }
+
+  check_data=$(curl -s "${HEADERS[@]}" \
+    "https://api.github.com/repos/$OWNER/$REPO/commits/$sha/check-runs" 2>/dev/null)
+
+  result=$(echo "$check_data" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+runs=d.get('check_runs',[])
+total=d.get('total_count',0)
+if total==0:
+    print('Clear'); exit()
+statuses=[r['status'] for r in runs]
+conclusions=[r.get('conclusion','') for r in runs if r['status']=='completed']
+if any(s in ('in_progress','queued') for s in statuses):
+    print('in_progress')
+elif all(s=='completed' for s in statuses):
+    if any(c in ('cancelled','timed_out','stale','startup_failure') for c in conclusions): print('Infra')
+    elif any(c in ('failure','action_required') for c in conclusions): print('Blocked')
+    else: print('all_passed')
+else:
+    print('in_progress')
+" 2>/dev/null)
+
+  # --- Streamed test-result signals -----------------------------------------
+  # Emitted independent of the overall check conclusion, so E2E failures surface
+  # even while the check stays green via continue-on-error. Both signals are
+  # purely informational: they reset the silence timer but never end the loop.
+  run_id=$(curl -s "${HEADERS[@]}" \
+    "https://api.github.com/repos/$OWNER/$REPO/actions/runs?head_sha=$sha&event=pull_request&per_page=5" | \
+    python3 -c "
+import sys,json
+for r in json.load(sys.stdin).get('workflow_runs',[]):
+    if r.get('status')!='cancelled': print(r['id']); break
+" 2>/dev/null)
+
+  if [ -n "$run_id" ]; then
+    # Signal 1 — per-step conclusion deltas for the build-and-test job. Emit when
+    # a step reaches 'completed' if it is one of the three named test steps (on any
+    # conclusion) or genuinely failed; successful setup steps and skipped
+    # conditional (upload-on-failure) steps are suppressed as noise. Deduped by step
+    # number. Gives the live "which group finished/failed, and when" signal.
+    steps_out=$(curl -s "${HEADERS[@]}" \
+      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/jobs?per_page=30" | \
+      SEEN="$seen_steps" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN']
+seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
+new=[]; out=[]
+for j in json.load(sys.stdin).get('jobs',[]):
+    if j.get('name')!='build-and-test': continue
+    for s in j.get('steps',[]):
+        if s.get('status')!='completed': continue
+        num=str(s.get('number'))
+        if num in seen: continue
+        new.append(num)
+        name=s.get('name','?'); concl=s.get('conclusion') or '?'
+        if name=='Build and run unit tests' or 'E2ETest' in name or concl in ('failure','cancelled','timed_out','action_required'):
+            out.append('step \"%s\" -> %s' % (name, concl))
+if new: open(seen_f,'a').write('\n'.join(new)+'\n')
+print('\n'.join(out))
+" 2>/dev/null)
+    emit_block "$steps_out"
+
+    # Signal 2 — per-test FAIL detail from the testresults-<group> artifacts the
+    # workflow uploads after each test step. Download each new artifact once, parse
+    # its ##GB4PC_TEST## ndjson markers, and emit new FAIL entries (message +
+    # truncated trace), deduped across polls by suite#name.
+    arts=$(curl -s "${HEADERS[@]}" \
+      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/artifacts?per_page=100" | \
+      SEEN="$seen_arts" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN']
+seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
+for a in json.load(sys.stdin).get('artifacts',[]):
+    n=a.get('name','')
+    if n.startswith('testresults-') and not a.get('expired') and str(a['id']) not in seen:
+        print('%s\t%s' % (a['id'], n))
+" 2>/dev/null)
+    while IFS=$'\t' read -r aid _; do
+      [ -z "$aid" ] && continue
+      tmp=$(mktemp -d)
+      if curl -sL "${HEADERS[@]}" \
+           "https://api.github.com/repos/$OWNER/$REPO/actions/artifacts/$aid/zip" -o "$tmp/a.zip" \
+         && unzip -qo "$tmp/a.zip" -d "$tmp" 2>/dev/null; then
+        fails_out=$(find "$tmp" -name '*.ndjson' -exec cat {} + 2>/dev/null | SEEN_FAILS="$seen_fails" python3 -c "
+import sys,json,os
+seen_f=os.environ['SEEN_FAILS']
+seen=set(open(seen_f).read().splitlines()) if os.path.getsize(seen_f) else set()
+new=[]
+for raw in sys.stdin:
+    i=raw.find('##GB4PC_TEST##')
+    if i==-1: continue
+    try: m=json.loads(raw[i+len('##GB4PC_TEST##'):].strip())
+    except Exception: continue
+    if m.get('outcome')!='FAIL': continue
+    key=m.get('suite','')+'#'+m.get('name','')
+    if key in seen: continue
+    seen.add(key); new.append(key)
+    msg=(m.get('msg') or '').strip(); tr=(m.get('trace') or '').strip()
+    if len(tr)>800: tr=tr[:800]+' ...(truncated)'
+    line='FAIL [%s] %s: %s' % (m.get('suite','?'), m.get('name','?'), msg)
+    if tr: line+='\n  '+tr.replace('\n','\n  ')
+    print(line)
+if new: open(seen_f,'a').write('\n'.join(new)+'\n')
+")
+        emit_block "$fails_out"
+        echo "$aid" >> "$seen_arts"
+      fi
+      rm -rf "$tmp"
+    done <<< "$arts"
+  fi
+  # --------------------------------------------------------------------------
+
+  if [ "$result" = "in_progress" ]; then
+    now=$(date +%s)
+    if [ $((now - last_output_ts)) -gt 120 ]; then
+      echo "PR#${PR}: in_progress"
+      last_output_ts=$now
+    fi
+  elif [ "$result" = "all_passed" ]; then
+    mergeable=$(curl -s "${HEADERS[@]}" "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | \
+      python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('mergeable_state','unknown'))" 2>/dev/null)
+    if [ "$mergeable" = "clean" ] || [ "$mergeable" = "unstable" ]; then
+      echo "PR#${PR}: Clear (mergeable_state=$mergeable)"; break
+    elif [ "$mergeable" = "behind" ] || [ "$mergeable" = "dirty" ]; then
+      echo "PR#${PR}: Blocked (mergeable_state=$mergeable)"; break
+    elif [ "$mergeable" = "blocked" ]; then
+      echo "PR#${PR}: Infra (mergeable_state=blocked)"; break
+    else
+      echo "PR#${PR}: all_passed mergeable_state=$mergeable (still computing)"
+      last_output_ts=$(date +%s)
+    fi
+  elif [ "$result" = "Blocked" ] || [ "$result" = "Infra" ]; then
+    echo "PR#${PR}: $result"; break
+  else
+    echo "PR#${PR}: $result"
+    last_output_ts=$(date +%s)
+  fi
+
+  sleep 30
+done

--- a/scripts/test_ci_monitor.sh
+++ b/scripts/test_ci_monitor.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# test_ci_monitor.sh — Shell-based tests for ci_monitor.sh.
+#
+# Covers:
+#   (a) Signal 1 step parser: all-success build-and-test emits exactly the 3 test-step lines
+#   (b) Signal 1 step parser: a genuine failure step is emitted
+#   (c) Signal 1 step parser: successful setup steps and skipped conditional steps are suppressed
+#   (d) Signal 1 step parser: deduplication across two iterations (same step not re-emitted)
+#   (e) Signal 2 artifact parser: FAIL with multi-line trace is emitted with indented trace
+#   (f) Signal 2 artifact parser: all-PASS artifact emits nothing
+#   (g) Signal 2 artifact parser: deduplication by suite#name across two calls
+#
+# No network calls required; no GITHUB_TOKEN needed.
+# Always exits 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# ── Step-parser helper ────────────────────────────────────────────────────────
+#
+# The Signal 1 python3 snippet from ci_monitor.sh reads jobs JSON from stdin,
+# uses $SEEN env var pointing to a dedup-state file, and prints step deltas.
+# We invoke it directly here to test its logic in isolation.
+
+STEP_PARSER_CODE='
+import sys,json,os
+seen_f=os.environ["SEEN"]
+seen=set(open(seen_f).read().split()) if os.path.getsize(seen_f) else set()
+new=[]; out=[]
+for j in json.load(sys.stdin).get("jobs",[]):
+    if j.get("name")!="build-and-test": continue
+    for s in j.get("steps",[]):
+        if s.get("status")!="completed": continue
+        num=str(s.get("number"))
+        if num in seen: continue
+        new.append(num)
+        name=s.get("name","?"); concl=s.get("conclusion") or "?"
+        if name=="Build and run unit tests" or "E2ETest" in name or concl in ("failure","cancelled","timed_out","action_required"):
+            out.append("step \"%s\" -> %s" % (name, concl))
+if new: open(seen_f,"a").write("\n".join(new)+"\n")
+print("\n".join(out))
+'
+
+run_step_parser() {
+  # Usage: run_step_parser <jobs-json-file> <seen-file>
+  local json_file="$1"
+  local seen_file="$2"
+  SEEN="$seen_file" python3 -c "$STEP_PARSER_CODE" < "$json_file" 2>/dev/null
+}
+
+# ── Fail-parser helper ────────────────────────────────────────────────────────
+#
+# The Signal 2 python3 snippet reads ndjson from stdin, uses $SEEN_FAILS env
+# var pointing to a dedup-state file, and prints FAIL entries.
+
+FAIL_PARSER_CODE='
+import sys,json,os
+seen_f=os.environ["SEEN_FAILS"]
+seen=set(open(seen_f).read().splitlines()) if os.path.getsize(seen_f) else set()
+new=[]
+for raw in sys.stdin:
+    i=raw.find("##GB4PC_TEST##")
+    if i==-1: continue
+    try: m=json.loads(raw[i+len("##GB4PC_TEST##"):].strip())
+    except Exception: continue
+    if m.get("outcome")!="FAIL": continue
+    key=m.get("suite","")+"#"+m.get("name","")
+    if key in seen: continue
+    seen.add(key); new.append(key)
+    msg=(m.get("msg") or "").strip(); tr=(m.get("trace") or "").strip()
+    if len(tr)>800: tr=tr[:800]+" ...(truncated)"
+    line="FAIL [%s] %s: %s" % (m.get("suite","?"), m.get("name","?"), msg)
+    if tr: line+="\n  "+tr.replace("\n","\n  ")
+    print(line)
+if new: open(seen_f,"a").write("\n".join(new)+"\n")
+'
+
+run_fail_parser() {
+  # Usage: run_fail_parser <ndjson-file> <seen-fails-file>
+  local ndjson_file="$1"
+  local seen_fails_file="$2"
+  SEEN_FAILS="$seen_fails_file" python3 -c "$FAIL_PARSER_CODE" < "$ndjson_file" 2>/dev/null
+}
+
+# ── Fixture: all-success build-and-test jobs JSON ────────────────────────────
+
+ALL_SUCCESS_JOBS="$TMPDIR_TESTS/all_success_jobs.json"
+cat > "$ALL_SUCCESS_JOBS" << 'EOF'
+{
+  "jobs": [
+    {
+      "name": "build-and-test",
+      "steps": [
+        {"number": 1, "name": "Set up job",                         "status": "completed", "conclusion": "success"},
+        {"number": 2, "name": "Checkout",                           "status": "completed", "conclusion": "success"},
+        {"number": 3, "name": "Set up JDK",                        "status": "completed", "conclusion": "success"},
+        {"number": 4, "name": "Build and run unit tests",          "status": "completed", "conclusion": "success"},
+        {"number": 5, "name": "Run PixelCameraOverlayE2ETest",     "status": "completed", "conclusion": "success"},
+        {"number": 6, "name": "Run GalleryButtonVisualE2ETest",    "status": "completed", "conclusion": "success"},
+        {"number": 7, "name": "Upload test results on failure",    "status": "completed", "conclusion": "skipped"},
+        {"number": 8, "name": "Complete job",                      "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ]
+}
+EOF
+
+# ── (a) All-success: exactly 3 test-step lines emitted ───────────────────────
+echo ""
+echo "=== (a) Signal 1: all-success build-and-test emits exactly 3 test-step lines ==="
+
+SEEN_A="$TMPDIR_TESTS/seen_a.txt"; touch "$SEEN_A"
+output_a="$(run_step_parser "$ALL_SUCCESS_JOBS" "$SEEN_A")"
+line_count_a="$(echo "$output_a" | grep -c '^step ' || true)"
+
+if [[ "$line_count_a" -eq 3 ]]; then
+  pass "emits exactly 3 step lines (got $line_count_a)"
+else
+  fail "expected 3 step lines, got $line_count_a; output: '$output_a'"
+fi
+
+if echo "$output_a" | grep -qF 'step "Build and run unit tests" -> success'; then
+  pass "unit tests step line present"
+else
+  fail "unit tests step line missing; output: '$output_a'"
+fi
+
+if echo "$output_a" | grep -qF 'step "Run PixelCameraOverlayE2ETest" -> success'; then
+  pass "PixelCameraOverlayE2ETest step line present"
+else
+  fail "PixelCameraOverlayE2ETest step line missing; output: '$output_a'"
+fi
+
+if echo "$output_a" | grep -qF 'step "Run GalleryButtonVisualE2ETest" -> success'; then
+  pass "GalleryButtonVisualE2ETest step line present"
+else
+  fail "GalleryButtonVisualE2ETest step line missing; output: '$output_a'"
+fi
+
+# ── (b) Genuine failure step is emitted ──────────────────────────────────────
+echo ""
+echo "=== (b) Signal 1: a genuine failure step is emitted ==="
+
+FAILURE_JOBS="$TMPDIR_TESTS/failure_jobs.json"
+cat > "$FAILURE_JOBS" << 'EOF'
+{
+  "jobs": [
+    {
+      "name": "build-and-test",
+      "steps": [
+        {"number": 1, "name": "Set up job",          "status": "completed", "conclusion": "success"},
+        {"number": 2, "name": "Download AVD",         "status": "completed", "conclusion": "failure"}
+      ]
+    }
+  ]
+}
+EOF
+
+SEEN_B="$TMPDIR_TESTS/seen_b.txt"; touch "$SEEN_B"
+output_b="$(run_step_parser "$FAILURE_JOBS" "$SEEN_B")"
+
+if echo "$output_b" | grep -qF 'step "Download AVD" -> failure'; then
+  pass "failed step 'Download AVD' is emitted"
+else
+  fail "failed step not emitted; output: '$output_b'"
+fi
+
+if echo "$output_b" | grep -q 'Set up job'; then
+  fail "successful setup step 'Set up job' should NOT be emitted; output: '$output_b'"
+else
+  pass "successful setup step 'Set up job' correctly suppressed"
+fi
+
+# ── (c) Setup and skipped conditional steps are suppressed ───────────────────
+echo ""
+echo "=== (c) Signal 1: successful setup steps and skipped conditional steps are suppressed ==="
+
+SEEN_C="$TMPDIR_TESTS/seen_c.txt"; touch "$SEEN_C"
+output_c="$(run_step_parser "$ALL_SUCCESS_JOBS" "$SEEN_C")"
+
+if echo "$output_c" | grep -q '"Set up job"'; then
+  fail "'Set up job' should be suppressed; output: '$output_c'"
+else
+  pass "'Set up job' suppressed"
+fi
+
+if echo "$output_c" | grep -q '"Checkout"'; then
+  fail "'Checkout' should be suppressed; output: '$output_c'"
+else
+  pass "'Checkout' suppressed"
+fi
+
+if echo "$output_c" | grep -q '"Set up JDK"'; then
+  fail "'Set up JDK' should be suppressed; output: '$output_c'"
+else
+  pass "'Set up JDK' suppressed"
+fi
+
+if echo "$output_c" | grep -q '"Upload test results on failure"'; then
+  fail "'Upload test results on failure' (skipped) should be suppressed; output: '$output_c'"
+else
+  pass "'Upload test results on failure' (skipped) suppressed"
+fi
+
+if echo "$output_c" | grep -q '"Complete job"'; then
+  fail "'Complete job' should be suppressed; output: '$output_c'"
+else
+  pass "'Complete job' suppressed"
+fi
+
+# ── (d) Deduplication across two iterations ───────────────────────────────────
+echo ""
+echo "=== (d) Signal 1: deduplication — same steps not re-emitted on second iteration ==="
+
+# First iteration: populate the seen file with all steps.
+SEEN_D="$TMPDIR_TESTS/seen_d.txt"; touch "$SEEN_D"
+output_d1="$(run_step_parser "$ALL_SUCCESS_JOBS" "$SEEN_D")"
+
+# Second iteration: same fixture — should produce no output.
+output_d2="$(run_step_parser "$ALL_SUCCESS_JOBS" "$SEEN_D")"
+
+if [[ -z "$output_d2" ]]; then
+  pass "second iteration emits nothing (all steps already seen)"
+else
+  fail "second iteration re-emitted steps: '$output_d2'"
+fi
+
+# First iteration must still have produced the 3 test lines.
+line_count_d1="$(echo "$output_d1" | grep -c '^step ' || true)"
+if [[ "$line_count_d1" -eq 3 ]]; then
+  pass "first iteration still emitted 3 step lines before dedup kicks in"
+else
+  fail "first iteration emitted $line_count_d1 step lines (expected 3)"
+fi
+
+# ── Fixture: ndjson with one FAIL and several PASS lines ─────────────────────
+
+FAIL_NDJSON="$TMPDIR_TESTS/testresults.ndjson"
+cat > "$FAIL_NDJSON" << 'EOF'
+some prefix ##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1a","outcome":"FAIL","ms":0,"msg":"java.lang.AssertionError: expected button visible","trace":"java.lang.AssertionError: expected button visible\n\tat org.junit.Assert.fail(Assert.java:89)\n\tat com.gb4pc.e2e.GalleryButtonVisualE2ETest.test1a(GalleryButtonVisualE2ETest.kt:42)"}
+##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1b","outcome":"PASS","ms":120,"msg":"","trace":""}
+##GB4PC_TEST## {"suite":"com.gb4pc.e2e.PixelCameraOverlayE2ETest","name":"test2a","outcome":"PASS","ms":200,"msg":"","trace":""}
+##GB4PC_TEST## {"suite":"com.gb4pc.e2e.PixelCameraOverlayE2ETest","name":"test2b","outcome":"PASS","ms":150,"msg":"","trace":""}
+EOF
+
+PASS_ONLY_NDJSON="$TMPDIR_TESTS/testresults_pass.ndjson"
+cat > "$PASS_ONLY_NDJSON" << 'EOF'
+##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test3a","outcome":"PASS","ms":100,"msg":"","trace":""}
+##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test3b","outcome":"PASS","ms":110,"msg":"","trace":""}
+EOF
+
+# ── (e) FAIL with multi-line trace emitted with indented trace ────────────────
+echo ""
+echo "=== (e) Signal 2: FAIL with multi-line trace is emitted with indented trace ==="
+
+SEEN_FAILS_E="$TMPDIR_TESTS/seen_fails_e.txt"; touch "$SEEN_FAILS_E"
+output_e="$(run_fail_parser "$FAIL_NDJSON" "$SEEN_FAILS_E")"
+
+if echo "$output_e" | grep -qF 'FAIL [com.gb4pc.e2e.GalleryButtonVisualE2ETest] test1a:'; then
+  pass "FAIL line for test1a emitted"
+else
+  fail "FAIL line for test1a not found; output: '$output_e'"
+fi
+
+if echo "$output_e" | grep -qF 'java.lang.AssertionError: expected button visible'; then
+  pass "failure message present in output"
+else
+  fail "failure message missing; output: '$output_e'"
+fi
+
+# Trace line should be indented with at least 2 spaces.
+if echo "$output_e" | grep -qE '^ {2}'; then
+  pass "trace lines are indented"
+else
+  fail "trace lines are not indented; output: '$output_e'"
+fi
+
+# ── (f) All-PASS artifact emits nothing ──────────────────────────────────────
+echo ""
+echo "=== (f) Signal 2: all-PASS artifact emits nothing ==="
+
+SEEN_FAILS_F="$TMPDIR_TESTS/seen_fails_f.txt"; touch "$SEEN_FAILS_F"
+output_f="$(run_fail_parser "$PASS_ONLY_NDJSON" "$SEEN_FAILS_F")"
+
+if [[ -z "$output_f" ]]; then
+  pass "all-PASS artifact produces no output"
+else
+  fail "all-PASS artifact unexpectedly produced output: '$output_f'"
+fi
+
+# ── (g) Deduplication by suite#name across two calls ─────────────────────────
+echo ""
+echo "=== (g) Signal 2: deduplication by suite#name across two calls ==="
+
+SEEN_FAILS_G="$TMPDIR_TESTS/seen_fails_g.txt"; touch "$SEEN_FAILS_G"
+
+# First call: should emit the FAIL.
+output_g1="$(run_fail_parser "$FAIL_NDJSON" "$SEEN_FAILS_G")"
+if echo "$output_g1" | grep -qF 'FAIL [com.gb4pc.e2e.GalleryButtonVisualE2ETest] test1a:'; then
+  pass "first call emits FAIL"
+else
+  fail "first call did not emit FAIL; output: '$output_g1'"
+fi
+
+# Second call with same fixture: FAIL already seen — should produce no output.
+output_g2="$(run_fail_parser "$FAIL_NDJSON" "$SEEN_FAILS_G")"
+if [[ -z "$output_g2" ]]; then
+  pass "second call produces no output (FAIL already seen)"
+else
+  fail "second call re-emitted already-seen FAIL: '$output_g2'"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Fixes #258

## What this PR does

### 1. Streaming per-test signals from the CI Monitor (commit `f109bcd`)

The Monitor poll loop now emits two informational output lines on every iteration, in addition to the terminal `Clear`/`Blocked`/`Infra` outcomes:

- **Signal 1 — per-step conclusion deltas** (`step "..." -> ...`): when a `build-and-test` step reaches `completed`, it is emitted if it is one of the three named test steps (`Build and run unit tests`, `Run PixelCameraOverlayE2ETest`, `Run GalleryButtonVisualE2ETest`) or if its conclusion is a genuine failure. Successful setup steps and `skipped` conditional steps (e.g. upload-on-failure) are suppressed. Deduped by step number across polls.

- **Signal 2 — per-test FAIL detail** (`FAIL [suite] name: ...`): each new `testresults-<group>` artifact is downloaded once, its `##GB4PC_TEST##` ndjson markers parsed, and every `FAIL` entry emitted with the failure message and truncated trace (≤800 chars), indented for readability. Deduped by `suite#name` across polls.

Both signals are purely informational: they reset the 120 s silence timer but never end the loop. Validated against real CI run 26489423099.

### 2. Extract Monitor script to `scripts/ci_monitor.sh` (commit `fa7144c`)

The bash block previously embedded in `agents/dev_orchestration.md` is now a standalone, executable script at `scripts/ci_monitor.sh`. The Orchestrator runs it as:

```bash
bash scripts/ci_monitor.sh <PR_NUMBER>
```

`OWNER`/`REPO` default to this repo; `$GITHUB_TOKEN` is read from the environment. `set -e` is deliberately absent so transient REST/parse failures cannot kill the resilient poll loop. `agents/dev_orchestration.md` is updated to reference the script instead of embedding it; the outcome-vocabulary table and all informational-signal notes remain intact.

### 3. Shell unit tests for the parsers (commit `8c01864`)

`scripts/test_ci_monitor.sh` tests both parsers in isolation — no network, no `$GITHUB_TOKEN`. It is picked up automatically by the CI step that runs `for test_script in scripts/test_*.sh`.

**Signal 1 tests:**
- All-success `build-and-test` fixture emits exactly the 3 test-step lines.
- A genuine failure step is emitted.
- Successful setup steps and `skipped` conditional steps are suppressed.
- Step numbers are deduped across two iterations.

**Signal 2 tests:**
- FAIL entry with multi-line trace is emitted with indented trace.
- All-PASS artifact emits nothing.
- `suite#name` is deduped across two calls.

All 19 tests pass locally; `bash -n` and `shellcheck` are clean on both scripts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbfU9NqAAUT3XSkkp4Pw1q)_