### PR TITLE
Add rough-draft task complexity rubric to agents/

### DIFF
--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -41,15 +41,11 @@ Same dimensions and tier ranges, with:
 
 ## GitHub labels
 
-Author complexity:
-- `c-a-haiku` Haiku
-- `c-a-sonnet` Sonnet
-- `c-a-opus` Opus
-
-Reviewer complexity:
-- `c-r-haiku` Haiku
-- `c-r-sonnet` Sonnet
-- `c-r-opus` Opus
+| Tier | Author | Reviewer |
+|------|--------|----------|
+| Haiku | `c-a-haiku` | `c-r-haiku` |
+| Sonnet | `c-a-sonnet` | `c-r-sonnet` |
+| Opus | `c-a-opus` | `c-r-opus` |
 
 ## General notes
 
@@ -64,11 +60,11 @@ Scores are listed as: task type / ambiguity / context / domain / reasoning / inv
 
 **#254 / PR #269 — Add reviewer rule: don't mention bylines** (Author: 6, Reviewer: 6)
 Single `agents/` file, exact wording provided, no reasoning required.
-1 / 1 / 1 / 1 / 1 / 1
+Author: 1 / 1 / 1 / 1 / 1 / 1 — Reviewer: 1 / 1 / 1 / 1 / 1 / 1
 
 **#250 / PR #251 — Make `requests` import hard** (Author: 6, Reviewer: 6)
 Remove a soft-import guard in one Python file; change fully specified.
-1 / 1 / 1 / 1 / 1 / 1
+Author: 1 / 1 / 1 / 1 / 1 / 1 — Reviewer: 1 / 1 / 1 / 1 / 1 / 1
 
 **#246 / PR #247 — Re-open closed issues when CI detects recurrence** (Author: 8, Reviewer: 7)
 Two-step Python change (search API + reopen call) but fully specified and self-contained.
@@ -77,7 +73,7 @@ Author: 2 / 1 / 1 / 1 / 2 / 1 — Reviewer: 2 / 1 / 1 / 1 / 1 / 1 (investigation
 ### Tier 2 — Sonnet (9–13)
 
 **#237 / PR #238 — Auto-filed issue format fixes** (Author: 9, Reviewer: 8 → Haiku)
-Four sub-tasks across a Python script and a workflow YAML, but each is well-specified. Reviewer applies floor: Haiku is Sonnet − 1, so Haiku is the minimum.
+Four sub-tasks across a Python script and a workflow YAML, but each is well-specified. Reviewer score of 8 is at the floor (Author tier − 1), so Haiku applies.
 Author: 2 / 1 / 2 / 1 / 2 / 1 — Reviewer: 2 / 1 / 2 / 1 / 1 / 1
 
 **#257 / PR #262 — Emit per-test markers in Gradle** (Author: 10, Reviewer: 10)

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -1,12 +1,11 @@
 # Task complexity rubric
 
 > **Status: rough draft — not yet in use.**
-> This rubric is under review and has not been wired into the orchestration workflow.
-> Do not apply it until it replaces this notice.
+> Do not apply it until this notice is replaced.
 
 ## Purpose
 
-Route tasks to the right model tier by scoring five dimensions of task complexity.
+Route tasks to the right model tier by scoring six dimensions of task complexity.
 Score each dimension 1–3, sum them, and map the total to a tier.
 
 ## Dimensions
@@ -18,64 +17,71 @@ Score each dimension 1–3, sum them, and map the total to a tier.
 | **Context breadth** | Single file / self-contained | A few related files | Cross-cutting; large-codebase awareness needed |
 | **Domain depth** | Generic code or prose | Moderate domain knowledge | Specialized (GitHub Actions internals, Android build system, security, etc.) |
 | **Reasoning chain** | Single step, pattern match | Multi-step, some tradeoffs | Long chain, competing concerns, novel reasoning |
+| **Investigation** | Approach clear from the issue; at most a standard docs lookup | Some unknowns, resolvable via code inspection or documentation | Requires empirical investigation — undocumented API behavior, platform quirks that must be tested to understand |
 
 ## Scoring → tier
 
 | Total | Tier | Model |
 |-------|------|-------|
-| 5–7 | 1 | Haiku |
-| 8–11 | 2 | Sonnet |
-| 12–15 | 3 | Opus |
+| 6–8 | 1 | Haiku |
+| 9–13 | 2 | Sonnet |
+| 14–18 | 3 | Opus |
 
-**Modifier:** if the issue requires empirical investigation to determine the approach (e.g. undocumented API behavior, unknown platform semantics), add **+2** to the total before mapping to a tier.
+## GitHub labels
+
+Apply one complexity label per issue before dispatching to an agent:
+
+- `complexity haiku` — score 6–8
+- `complexity sonnet` — score 9–13
+- `complexity opus` — score 14–18
 
 ## Project-specific notes
 
 - Any issue that touches `.github/workflows/build.yml` or `app/build.gradle.kts` should score **domain depth ≥ 2**, because GitHub Actions quirks (trigger types, `continue-on-error` propagation, artifact availability timing) and the Gradle/Android build system routinely introduce hidden complexity.
-- Issues limited to editing files under `agents/` with exact wording provided are typically score **5** (all 1s) — Haiku territory.
+- Issues limited to editing files under `agents/` with exact wording provided typically score **6** (all 1s) — Haiku territory.
 
 ## Calibration examples
 
-These examples were scored against actual closed issues and PRs in this repo.
+Scores are listed as: task type / ambiguity / context / domain / reasoning / investigation.
 
-### Tier 1 — Haiku (5–7)
+### Tier 1 — Haiku (6–8)
 
-**#254 / PR #269 — Add reviewer rule: don't mention bylines** (score: 5)
+**#254 / PR #269 — Add reviewer rule: don't mention bylines** (score: 6)
 Single `agents/` file, exact wording provided, no reasoning required.
-1 / 1 / 1 / 1 / 1
+1 / 1 / 1 / 1 / 1 / 1
 
-**#250 / PR #251 — Make `requests` import hard** (score: 5)
+**#250 / PR #251 — Make `requests` import hard** (score: 6)
 Remove a soft-import guard in one Python file; change fully specified.
-1 / 1 / 1 / 1 / 1
+1 / 1 / 1 / 1 / 1 / 1
 
-**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (score: 7)
+**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (score: 8)
 Two-step Python change (search API + reopen call) but fully specified and self-contained.
-2 / 1 / 1 / 1 / 2
+2 / 1 / 1 / 1 / 2 / 1
 
-### Tier 2 — Sonnet (8–11)
+### Tier 2 — Sonnet (9–13)
 
-**#237 / PR #238 — Auto-filed issue format fixes** (score: 8)
+**#237 / PR #238 — Auto-filed issue format fixes** (score: 9)
 Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
-2 / 1 / 2 / 1 / 2
+2 / 1 / 2 / 1 / 2 / 1
 
-**#257 / PR #262 — Emit per-test markers in Gradle** (score: 9)
+**#257 / PR #262 — Emit per-test markers in Gradle** (score: 10)
 New Gradle test listener + E2E marker emission; requires Gradle Kotlin DSL knowledge.
-2 / 1 / 2 / 2 / 2
+2 / 1 / 2 / 2 / 2 / 1
 
-**#225 / PR #226 — Issue filer workflow not triggered** (score: 10)
+**#225 / PR #226 — Issue filer workflow not triggered** (score: 11)
 Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
-2 / 2 / 2 / 2 / 2
+2 / 2 / 2 / 2 / 2 / 1
 
-**#264 / PR #266 — Upload per-step artifact plumbing** (score: 10)
+**#264 / PR #266 — Upload per-step artifact plumbing** (score: 11)
 Multi-step workflow change; premise correction needed after inspecting actual CI structure.
-2 / 2 / 2 / 2 / 2
+2 / 2 / 2 / 2 / 2 / 1
 
-### Tier 3 — Opus (12–15)
+### Tier 3 — Opus (14–18)
 
-**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (score: 14)
-Two new parser systems, shell test infrastructure, cross-cutting changes; empirical API investigation required (+2).
-3 / 2 / 3 / 3 / 3
+**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (score: 17)
+Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability.
+3 / 2 / 3 / 3 / 3 / 3
 
-**#236 — CI monitor should surface failing tests (design)** (score: 15)
+**#236 — CI monitor should surface failing tests (design)** (score: 18)
 Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
-3 / 3 / 3 / 3 / 3
+3 / 3 / 3 / 3 / 3 / 3

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -37,7 +37,7 @@ Same dimensions and tier ranges, with:
 - **Investigation** ≤ 2
 - **Context breadth** ≤ Author's score
 
-**Floor**: Reviewer tier ≥ impl tier − 1
+**Floor**: Reviewer tier ≥ Author tier − 1
 
 ## GitHub labels
 
@@ -45,10 +45,10 @@ Same dimensions and tier ranges, with:
 - `c-sonnet` Sonnet
 - `c-opus` Opus
 
-## Project-specific notes
+## General notes
 
-- Any issue that touches `.github/workflows/build.yml` or `app/build.gradle.kts` should score **domain depth ≥ 2**, because GitHub Actions quirks (trigger types, `continue-on-error` propagation, artifact availability timing) and the Gradle/Android build system routinely introduce hidden complexity.
-- Issues limited to editing files under `agents/` with exact wording provided typically score **6** (all 1s) — Haiku territory.
+- Build system and CI configuration files (Makefiles, Dockerfiles, workflow YAMLs, Gradle scripts, etc.) should score **domain depth ≥ 2** — these systems have undocumented interactions and hidden complexity that is easy to underestimate.
+- Tasks limited to editing plain text or documents (policies, instructions, docs) with exact content provided typically score **6** (all 1s) — Haiku territory.
 
 ## Calibration examples
 
@@ -56,38 +56,38 @@ Scores are listed as: task type / ambiguity / context / domain / reasoning / inv
 
 ### Tier 1 — Haiku (6–8)
 
-**#254 / PR #269 — Add reviewer rule: don't mention bylines** (impl: 6, review: 6)
+**#254 / PR #269 — Add reviewer rule: don't mention bylines** (Author: 6, Reviewer: 6)
 Single `agents/` file, exact wording provided, no reasoning required.
 1 / 1 / 1 / 1 / 1 / 1
 
-**#250 / PR #251 — Make `requests` import hard** (impl: 6, review: 6)
+**#250 / PR #251 — Make `requests` import hard** (Author: 6, Reviewer: 6)
 Remove a soft-import guard in one Python file; change fully specified.
 1 / 1 / 1 / 1 / 1 / 1
 
-**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (impl: 8, review: 7)
+**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (Author: 8, Reviewer: 7)
 Two-step Python change (search API + reopen call) but fully specified and self-contained.
-Impl: 2 / 1 / 1 / 1 / 2 / 1 — Review: 2 / 1 / 1 / 1 / 1 / 1
+Author: 2 / 1 / 1 / 1 / 2 / 1 — Reviewer: 2 / 1 / 1 / 1 / 1 / 1 (investigation drops; reasoning is lighter once the code is written)
 
 ### Tier 2 — Sonnet (9–13)
 
-**#237 / PR #238 — Auto-filed issue format fixes** (impl: 9, review: 8 → Haiku)
-Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
-Impl: 2 / 1 / 2 / 1 / 2 / 1 — Review: 2 / 1 / 2 / 1 / 1 / 1
+**#237 / PR #238 — Auto-filed issue format fixes** (Author: 9, Reviewer: 8 → Haiku)
+Four sub-tasks across a Python script and a workflow YAML, but each is well-specified. Reviewer applies floor: Haiku is Sonnet − 1, so Haiku is the minimum.
+Author: 2 / 1 / 2 / 1 / 2 / 1 — Reviewer: 2 / 1 / 2 / 1 / 1 / 1
 
-**#257 / PR #262 — Emit per-test markers in Gradle** (impl: 10, review: 10)
-New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge.
-Impl: 2 / 1 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1
+**#257 / PR #262 — Emit per-test markers in Gradle** (Author: 10, Reviewer: 10)
+New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge. Reviewer needs equal domain depth to evaluate correctness of the listener hook and JSON escaping.
+Author: 2 / 1 / 2 / 2 / 2 / 1 — Reviewer: 2 / 1 / 2 / 2 / 2 / 1
 
-**#225 / PR #226 — Issue filer workflow not triggered** (impl: 11, review: 10)
+**#225 / PR #226 — Issue filer workflow not triggered** (Author: 11, Reviewer: 10)
 Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
-Impl: 2 / 2 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1
+Author: 2 / 2 / 2 / 2 / 2 / 1 — Reviewer: 2 / 1 / 2 / 2 / 2 / 1 (ambiguity drops once implementation is written)
 
 ### Tier 3 — Opus (14–18)
 
-**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (impl: 17, review: 14)
-Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability.
-Impl: 3 / 2 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 2 / 2
+**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (Author: 17, Reviewer: 14)
+Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability. Investigation drops from 3 to 2 for review; reasoning chain also lighter.
+Author: 3 / 2 / 3 / 3 / 3 / 3 — Reviewer: 3 / 2 / 3 / 3 / 2 / 2
 
-**#236 — CI monitor should surface failing tests (design)** (impl: 18, review: 16)
-Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
-Impl: 3 / 3 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 3 / 2
+**#236 — CI monitor should surface failing tests (design)** (Author: 18, Reviewer: 16)
+Full system design with competing approaches; undocumented API behavior; 5-file implementation plan. Investigation and ambiguity both drop for review.
+Author: 3 / 3 / 3 / 3 / 3 / 3 — Reviewer: 3 / 2 / 3 / 3 / 3 / 2

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -1,0 +1,81 @@
+# Task complexity rubric
+
+> **Status: rough draft — not yet in use.**
+> This rubric is under review and has not been wired into the orchestration workflow.
+> Do not apply it until it replaces this notice.
+
+## Purpose
+
+Route tasks to the right model tier by scoring five dimensions of task complexity.
+Score each dimension 1–3, sum them, and map the total to a tier.
+
+## Dimensions
+
+| Dimension | 1 — Low | 2 — Medium | 3 — High |
+|-----------|---------|------------|----------|
+| **Task type** | Boilerplate, formatting, simple config edit | Standard feature, bug fix, refactor | Architecture, novel algorithm, system design |
+| **Ambiguity** | Fully specified, clear acceptance criteria | Some interpretation needed | Underspecified, requires judgment or design |
+| **Context breadth** | Single file / self-contained | A few related files | Cross-cutting; large-codebase awareness needed |
+| **Domain depth** | Generic code or prose | Moderate domain knowledge | Specialized (GitHub Actions internals, Android build system, security, etc.) |
+| **Reasoning chain** | Single step, pattern match | Multi-step, some tradeoffs | Long chain, competing concerns, novel reasoning |
+
+## Scoring → tier
+
+| Total | Tier | Model |
+|-------|------|-------|
+| 5–7 | 1 | Haiku |
+| 8–11 | 2 | Sonnet |
+| 12–15 | 3 | Opus |
+
+**Modifier:** if the issue requires empirical investigation to determine the approach (e.g. undocumented API behavior, unknown platform semantics), add **+2** to the total before mapping to a tier.
+
+## Project-specific notes
+
+- Any issue that touches `.github/workflows/build.yml` or `app/build.gradle.kts` should score **domain depth ≥ 2**, because GitHub Actions quirks (trigger types, `continue-on-error` propagation, artifact availability timing) and the Gradle/Android build system routinely introduce hidden complexity.
+- Issues limited to editing files under `agents/` with exact wording provided are typically score **5** (all 1s) — Haiku territory.
+
+## Calibration examples
+
+These examples were scored against actual closed issues and PRs in this repo.
+
+### Tier 1 — Haiku (5–7)
+
+**#254 / PR #269 — Add reviewer rule: don't mention bylines** (score: 5)
+Single `agents/` file, exact wording provided, no reasoning required.
+1 / 1 / 1 / 1 / 1
+
+**#250 / PR #251 — Make `requests` import hard** (score: 5)
+Remove a soft-import guard in one Python file; change fully specified.
+1 / 1 / 1 / 1 / 1
+
+**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (score: 7)
+Two-step Python change (search API + reopen call) but fully specified and self-contained.
+2 / 1 / 1 / 1 / 2
+
+### Tier 2 — Sonnet (8–11)
+
+**#237 / PR #238 — Auto-filed issue format fixes** (score: 8)
+Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
+2 / 1 / 2 / 1 / 2
+
+**#257 / PR #262 — Emit per-test markers in Gradle** (score: 9)
+New Gradle test listener + E2E marker emission; requires Gradle Kotlin DSL knowledge.
+2 / 1 / 2 / 2 / 2
+
+**#225 / PR #226 — Issue filer workflow not triggered** (score: 10)
+Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
+2 / 2 / 2 / 2 / 2
+
+**#264 / PR #266 — Upload per-step artifact plumbing** (score: 10)
+Multi-step workflow change; premise correction needed after inspecting actual CI structure.
+2 / 2 / 2 / 2 / 2
+
+### Tier 3 — Opus (12–15)
+
+**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (score: 14)
+Two new parser systems, shell test infrastructure, cross-cutting changes; empirical API investigation required (+2).
+3 / 2 / 3 / 3 / 3
+
+**#236 — CI monitor should surface failing tests (design)** (score: 15)
+Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
+3 / 3 / 3 / 3 / 3

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -41,9 +41,15 @@ Same dimensions and tier ranges, with:
 
 ## GitHub labels
 
-- `c-haiku` Haiku
-- `c-sonnet` Sonnet
-- `c-opus` Opus
+Author complexity:
+- `c-a-haiku` Haiku
+- `c-a-sonnet` Sonnet
+- `c-a-opus` Opus
+
+Reviewer complexity:
+- `c-r-haiku` Haiku
+- `c-r-sonnet` Sonnet
+- `c-r-opus` Opus
 
 ## General notes
 

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -29,11 +29,9 @@ Score each dimension 1–3, sum them, and map the total to a tier.
 
 ## GitHub labels
 
-Apply one complexity label per issue before dispatching to an agent:
-
-- `c-haiku` — score 6–8
-- `c-sonnet` — score 9–13
-- `c-opus` — score 14–18
+- `c-haiku` Haiku
+- `c-sonnet` Sonnet
+- `c-opus` Opus
 
 ## Project-specific notes
 

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -18,14 +18,6 @@ Route tasks to the right model tier. Score the six dimensions below, sum them, a
 | **Reasoning chain** | Single step, pattern match | Multi-step, some tradeoffs | Long chain, competing concerns, novel reasoning |
 | **Investigation** | Approach clear from the issue; at most a standard docs lookup | Some unknowns, resolvable via code inspection or documentation | Requires empirical investigation — undocumented API behavior, platform quirks that must be tested to understand |
 
-## Scoring → tier
-
-| Total | Tier | Model |
-|-------|------|-------|
-| 6–8 | 1 | Haiku |
-| 9–13 | 2 | Sonnet |
-| 14–18 | 3 | Opus |
-
 ## Author leveling
 
 Score **context breadth** on what a thorough resolution requires, not just the files named in the issue.
@@ -38,6 +30,14 @@ Same dimensions and tier ranges, with:
 - **Context breadth** ≤ Author's score
 
 **Floor**: Reviewer tier ≥ Author tier − 1
+
+## Scoring → tier
+
+| Total | Tier | Model |
+|-------|------|-------|
+| 6–8 | 1 | Haiku |
+| 9–13 | 2 | Sonnet |
+| 14–18 | 3 | Opus |
 
 ## GitHub labels
 

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -31,9 +31,9 @@ Score each dimension 1–3, sum them, and map the total to a tier.
 
 Apply one complexity label per issue before dispatching to an agent:
 
-- `complexity haiku` — score 6–8
-- `complexity sonnet` — score 9–13
-- `complexity opus` — score 14–18
+- `c-haiku` — score 6–8
+- `c-sonnet` — score 9–13
+- `c-opus` — score 14–18
 
 ## Project-specific notes
 

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -41,7 +41,7 @@ Same dimensions and tier ranges, with:
 
 ## GitHub labels
 
-| Tier | Author | Reviewer |
+| Model | Author | Reviewer |
 |------|--------|----------|
 | Haiku | `c-a-haiku` | `c-r-haiku` |
 | Sonnet | `c-a-sonnet` | `c-r-sonnet` |

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -28,24 +28,22 @@ Route tasks to the right model tier. Score the six dimensions below, sum them, a
 
 ## Author leveling
 
-Score all six dimensions as described above. Score **context breadth** based on what a thorough resolution requires, not just the files named in the issue — if proper authorship means searching for all instances of a pattern error across the codebase, that scope should be reflected.
+Score **context breadth** on what a thorough resolution requires, not just the files named in the issue.
 
 ## Reviewer leveling
 
-Use the same dimensions and tier ranges with two constraints:
+Same dimensions and tier ranges, with:
 
-- **Investigation**: score at most 2. Reviewers read code and documentation; empirical investigation is the Author's responsibility.
-- **Context breadth**: score at most the Author's score for the same issue. Finding all instances of an error, verifying related files, and identifying regressions are Author responsibilities. The Reviewer's job is to verify the Author completed that work — not to redo it.
+- **Investigation** ≤ 2
+- **Context breadth** ≤ Author's score
 
-**Floor rule**: the Reviewer tier must be at least one tier below the implementation tier (i.e. a Sonnet implementation gets a Haiku-or-higher Reviewer; an Opus implementation gets a Sonnet-or-higher Reviewer).
+**Floor**: Reviewer tier ≥ impl tier − 1
 
 ## GitHub labels
 
-Labels reflect Author complexity. Apply one per issue before dispatching:
-
-- `c-haiku` — score 6–8
-- `c-sonnet` — score 9–13
-- `c-opus` — score 14–18
+- `c-haiku` Haiku
+- `c-sonnet` Sonnet
+- `c-opus` Opus
 
 ## Project-specific notes
 
@@ -68,28 +66,28 @@ Remove a soft-import guard in one Python file; change fully specified.
 
 **#246 / PR #247 — Re-open closed issues when CI detects recurrence** (impl: 8, review: 7)
 Two-step Python change (search API + reopen call) but fully specified and self-contained.
-Impl: 2 / 1 / 1 / 1 / 2 / 1 — Review: 2 / 1 / 1 / 1 / 1 / 1 (investigation drops; reasoning is lighter once the code is written)
+Impl: 2 / 1 / 1 / 1 / 2 / 1 — Review: 2 / 1 / 1 / 1 / 1 / 1
 
 ### Tier 2 — Sonnet (9–13)
 
 **#237 / PR #238 — Auto-filed issue format fixes** (impl: 9, review: 8 → Haiku)
-Four sub-tasks across a Python script and a workflow YAML, but each is well-specified. Reviewer applies floor: Haiku is Sonnet − 1, so Haiku is the minimum.
+Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
 Impl: 2 / 1 / 2 / 1 / 2 / 1 — Review: 2 / 1 / 2 / 1 / 1 / 1
 
 **#257 / PR #262 — Emit per-test markers in Gradle** (impl: 10, review: 10)
-New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge. Reviewer needs equal domain depth to evaluate correctness of the listener hook and JSON escaping.
+New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge.
 Impl: 2 / 1 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1
 
 **#225 / PR #226 — Issue filer workflow not triggered** (impl: 11, review: 10)
 Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
-Impl: 2 / 2 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1 (ambiguity drops once implementation is written)
+Impl: 2 / 2 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1
 
 ### Tier 3 — Opus (14–18)
 
 **#258 / PR #271 — Stream per-test CI signals + extract monitor script** (impl: 17, review: 14)
-Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability. Investigation drops from 3 to 2 for review; reasoning chain also lighter.
+Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability.
 Impl: 3 / 2 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 2 / 2
 
 **#236 — CI monitor should surface failing tests (design)** (impl: 18, review: 16)
-Full system design with competing approaches; undocumented API behavior; 5-file implementation plan. Investigation and ambiguity both drop for review.
+Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
 Impl: 3 / 3 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 3 / 2

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -5,8 +5,7 @@
 
 ## Purpose
 
-Route tasks to the right model tier by scoring six dimensions of task complexity.
-Score each dimension 1–3, sum them, and map the total to a tier.
+Route tasks to the right model tier. Score the six dimensions below, sum them, and map to a tier. Apply separately for the Author (implementation) and the Reviewer (code review), using the adjustments in the Reviewer section.
 
 ## Dimensions
 
@@ -27,11 +26,26 @@ Score each dimension 1–3, sum them, and map the total to a tier.
 | 9–13 | 2 | Sonnet |
 | 14–18 | 3 | Opus |
 
+## Author leveling
+
+Score all six dimensions as described above. Score **context breadth** based on what a thorough resolution requires, not just the files named in the issue — if proper authorship means searching for all instances of a pattern error across the codebase, that scope should be reflected.
+
+## Reviewer leveling
+
+Use the same dimensions and tier ranges with two constraints:
+
+- **Investigation**: score at most 2. Reviewers read code and documentation; empirical investigation is the Author's responsibility.
+- **Context breadth**: score at most the Author's score for the same issue. Finding all instances of an error, verifying related files, and identifying regressions are Author responsibilities. The Reviewer's job is to verify the Author completed that work — not to redo it.
+
+**Floor rule**: the Reviewer tier must be at least one tier below the implementation tier (i.e. a Sonnet implementation gets a Haiku-or-higher Reviewer; an Opus implementation gets a Sonnet-or-higher Reviewer).
+
 ## GitHub labels
 
-- `c-haiku` Haiku
-- `c-sonnet` Sonnet
-- `c-opus` Opus
+Labels reflect Author complexity. Apply one per issue before dispatching:
+
+- `c-haiku` — score 6–8
+- `c-sonnet` — score 9–13
+- `c-opus` — score 14–18
 
 ## Project-specific notes
 
@@ -44,42 +58,38 @@ Scores are listed as: task type / ambiguity / context / domain / reasoning / inv
 
 ### Tier 1 — Haiku (6–8)
 
-**#254 / PR #269 — Add reviewer rule: don't mention bylines** (score: 6)
+**#254 / PR #269 — Add reviewer rule: don't mention bylines** (impl: 6, review: 6)
 Single `agents/` file, exact wording provided, no reasoning required.
 1 / 1 / 1 / 1 / 1 / 1
 
-**#250 / PR #251 — Make `requests` import hard** (score: 6)
+**#250 / PR #251 — Make `requests` import hard** (impl: 6, review: 6)
 Remove a soft-import guard in one Python file; change fully specified.
 1 / 1 / 1 / 1 / 1 / 1
 
-**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (score: 8)
+**#246 / PR #247 — Re-open closed issues when CI detects recurrence** (impl: 8, review: 7)
 Two-step Python change (search API + reopen call) but fully specified and self-contained.
-2 / 1 / 1 / 1 / 2 / 1
+Impl: 2 / 1 / 1 / 1 / 2 / 1 — Review: 2 / 1 / 1 / 1 / 1 / 1 (investigation drops; reasoning is lighter once the code is written)
 
 ### Tier 2 — Sonnet (9–13)
 
-**#237 / PR #238 — Auto-filed issue format fixes** (score: 9)
-Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
-2 / 1 / 2 / 1 / 2 / 1
+**#237 / PR #238 — Auto-filed issue format fixes** (impl: 9, review: 8 → Haiku)
+Four sub-tasks across a Python script and a workflow YAML, but each is well-specified. Reviewer applies floor: Haiku is Sonnet − 1, so Haiku is the minimum.
+Impl: 2 / 1 / 2 / 1 / 2 / 1 — Review: 2 / 1 / 2 / 1 / 1 / 1
 
-**#257 / PR #262 — Emit per-test markers in Gradle** (score: 10)
-New Gradle test listener + E2E marker emission; requires Gradle Kotlin DSL knowledge.
-2 / 1 / 2 / 2 / 2 / 1
+**#257 / PR #262 — Emit per-test markers in Gradle** (impl: 10, review: 10)
+New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge. Reviewer needs equal domain depth to evaluate correctness of the listener hook and JSON escaping.
+Impl: 2 / 1 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1
 
-**#225 / PR #226 — Issue filer workflow not triggered** (score: 11)
+**#225 / PR #226 — Issue filer workflow not triggered** (impl: 11, review: 10)
 Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
-2 / 2 / 2 / 2 / 2 / 1
-
-**#264 / PR #266 — Upload per-step artifact plumbing** (score: 11)
-Multi-step workflow change; premise correction needed after inspecting actual CI structure.
-2 / 2 / 2 / 2 / 2 / 1
+Impl: 2 / 2 / 2 / 2 / 2 / 1 — Review: 2 / 1 / 2 / 2 / 2 / 1 (ambiguity drops once implementation is written)
 
 ### Tier 3 — Opus (14–18)
 
-**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (score: 17)
-Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability.
-3 / 2 / 3 / 3 / 3 / 3
+**#258 / PR #271 — Stream per-test CI signals + extract monitor script** (impl: 17, review: 14)
+Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability. Investigation drops from 3 to 2 for review; reasoning chain also lighter.
+Impl: 3 / 2 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 2 / 2
 
-**#236 — CI monitor should surface failing tests (design)** (score: 18)
-Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
-3 / 3 / 3 / 3 / 3 / 3
+**#236 — CI monitor should surface failing tests (design)** (impl: 18, review: 16)
+Full system design with competing approaches; undocumented API behavior; 5-file implementation plan. Investigation and ambiguity both drop for review.
+Impl: 3 / 3 / 3 / 3 / 3 / 3 — Review: 3 / 2 / 3 / 3 / 3 / 2


### PR DESCRIPTION
Adds `agents/task_complexity.md` — a rubric for routing tasks to Haiku, Sonnet, or Opus based on task complexity. Marked as a rough draft; not in use until the notice is removed.

## What's in it

Six scored dimensions (task type, ambiguity, context breadth, domain depth, reasoning chain, investigation), each 1–3. Sum maps to a tier:

| Total | Tier |
|-------|------|
| 6–8 | Haiku |
| 9–13 | Sonnet |
| 14–18 | Opus |

Separate leveling rules for the **Author** (implementation) and **Reviewer** (code review) roles, with a floor of Reviewer tier ≥ Author tier − 1.

GitHub label scheme: `c-a-(haiku|sonnet|opus)` for Author complexity, `c-r-(haiku|sonnet|opus)` for Reviewer complexity.

Calibrated against ~10 closed issues and PRs from this repo, with scored examples for each tier.

## What it doesn't do yet

- Not wired into `dev_orchestration.md` or any other agent instruction.
- Thresholds and dimension definitions haven't been validated on a larger sample.
- The right moment to invoke it (Orchestrator reads it? embedded inline?) is TBD.

## Test plan

- [ ] Review the scored examples against your recollection of those issues — do the tiers feel right?
- [ ] Check whether any dimension is redundant or missing for your issue patterns
- [ ] Decide whether the Investigation dimension is correctly weighted relative to the others

---
_Generated by [Claude Code](https://claude.ai/code/session_0157PWC1ur9hF2x2NHhJeddq)_