### PR TITLE
Orchestrator: select sub-agent model from complexity labels

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -31,9 +31,17 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 - See `inaugurate.md` for the full protocol when starting fresh work.
 
+## Model selection
+
+For each sub-agent role, use the first rule that applies:
+
+1. **User-specified**: the user named a model for this role — use it.
+2. **Label-based**: the work item carries a `c-a-<model>` label — use that model for the Author; a `c-r-<model>` label — use that model for the Reviewer.
+3. **Default**: Sonnet.
+
 ## Assigning a Programmer
 
-- Create a Sonnet sub-agent unless the user requested otherwise
+- Create a sub-agent at the Author model (see Model selection above)
 - *Create a dedicated per-issue branch* for the Programmer to use. Branch names should follow the pattern `fix/issue-N-short-description` for bug fixes or `feature/issue-N-short-description` for new features. Never direct two Programmers for unrelated issues to the same branch.
 - Inform the agent of its role as an expert software developer resolving the issue
 - Inform the agent of its responsibility to commit its work to a branch and open a PR (if one doesn't already exist)
@@ -43,7 +51,7 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 ## Assigning a Reviewer
 
-- Create a Sonnet sub-agent unless the user requested otherwise
+- Create a sub-agent at the Reviewer model (see Model selection above)
 - Inform the agent of its role as an expert software reviewer who ensures high quality code and adherence to development plans
 - Pass the issue number to the subagent
 - Relay any relevant instruction from the user


### PR DESCRIPTION
Adds a **Model selection** section to `agents/dev_orchestration.md` so the Orchestrator picks sub-agent models from complexity labels rather than always defaulting to Sonnet.

## Priority order

1. **User-specified** — if the user named a model for this role, use it.
2. **Label-based** — `c-a-<model>` drives the Author tier; `c-r-<model>` drives the Reviewer tier.
3. **Default** — Sonnet.

## Changes

- New `## Model selection` section in `dev_orchestration.md`, placed between "Inaugurating work" and "Assigning a Programmer"
- `Assigning a Programmer` and `Assigning a Reviewer` each updated to reference the shared section instead of hardcoding Sonnet

The label scheme (`c-a-*` / `c-r-*`) is defined in `agents/task_complexity.md` (PR #275).

## Test plan

- [ ] Verify the Orchestrator reads labels before spawning Author/Reviewer agents
- [ ] Confirm user-specified model still overrides labels

---
_Generated by [Claude Code](https://claude.ai/code/session_0157PWC1ur9hF2x2NHhJeddq)_