### PR TITLE
Limit Haiku shortcut to simple conditional-approval changes

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -64,23 +64,26 @@ A Reviewer may give **conditional approval**: an approval combined with minimal 
 
 ```
   if Reviewer gave conditional approval:
-    route to Author to consider the specific change(s) named
-    after Author commits the targeted change:
-      spawn a Haiku sanity-check agent (model: haiku) with narrowed context:
-        - the Reviewer's specific instruction (verbatim)
-        - the Author's new diff/commit addressing it
-        - nothing else (no full PR diff, no prior review history)
-      prompt the Haiku agent with exactly:
-          > The Reviewer requested
-          > [specific change]
-          > 
-          > The Author responded with
-          > [diff]
-          >
-          > Answer one of three ways: (A) the Author fully addressed the requested change and introduced no other concerns; (B) the Author did not address the requested change (incomplete or missing work, no new concerns raised); or (C) the Author's response raises a new concern beyond the scope of the original request.
-      if Haiku answers A → treat as approved; proceed to CI Monitor loop (do NOT run another full review cycle)
-      if Haiku answers B → the PR hasn't yet converged; resume the normal cycle by routing to the full-fledged Reviewer.
-      if Haiku answers C → the PR is unstable; stop the PR cycle and escalate to the User.
+    if the requested change involves multiple locations, design choices, or non-trivial logic:
+      treat as "changes requested"; route to Author, then dispatch a full-fledged Reviewer — do NOT use the Haiku shortcut
+    else:
+      route to Author to consider the specific change(s) named
+      after Author commits the targeted change:
+        spawn a Haiku sanity-check agent (model: haiku) with narrowed context:
+          - the Reviewer's specific instruction (verbatim)
+          - the Author's new diff/commit addressing it
+          - nothing else (no full PR diff, no prior review history)
+        prompt the Haiku agent with exactly:
+            > The Reviewer requested
+            > [specific change]
+            > 
+            > The Author responded with
+            > [diff]
+            >
+            > Answer one of three ways: (A) the Author fully addressed the requested change and introduced no other concerns; (B) the Author did not address the requested change (incomplete or missing work, no new concerns raised); or (C) the Author's response raises a new concern beyond the scope of the original request.
+        if Haiku answers A → treat as approved; proceed to CI Monitor loop (do NOT run another full review cycle)
+        if Haiku answers B → the PR hasn't yet converged; resume the normal cycle by routing to the full-fledged Reviewer.
+        if Haiku answers C → the PR is unstable; stop the PR cycle and escalate to the User.
 ```
 
 ### Haiku agent constraints

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -24,6 +24,7 @@
 
 - A Reviewer **may** give conditional approval: an approval combined with minimal and specific instructions for the Author to take before merging.
   - This is only appropriate when the request is unlikely to be contested.
+  - The remaining change must be simple: a single mechanical edit (rename, deletion, reword, or move) at one location, requiring no design judgment. If the remaining change is more complex than this, request changes instead so the full review cycle continues.
   - Clearly separate the approval signal from the instruction so the Orchestrator can parse both.
   - Phrase it unambiguously, e.g. "Approved, pending [specific change]." or "Approved — please [specific action] before merging."
   - Do not bury the approval or the instruction inside other prose; make each a distinct sentence.


### PR DESCRIPTION
Fixes #274

The Haiku sanity-check shortcut was reachable after any conditional approval, including cases where the Reviewer's requested change was complex enough to warrant a full Sonnet review. This adds a matching constraint in both documents.

**`agents/pr_participation.md`** — Reviewer rule: conditional approval is now restricted to changes that are a single mechanical edit (rename, deletion, reword, or move) at one location, with no design judgment required. For anything more complex, the Reviewer must request changes so the full cycle continues.

**`agents/dev_orchestration.md`** — Orchestrator guard: before dispatching the Haiku sanity-check agent, the Orchestrator checks whether the requested change meets the same simplicity criterion. If not, it treats the conditional approval as "changes requested" and routes to a full-fledged Reviewer instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uvFMM3LntzcXcRFAwcKs5)_