### PR TITLE
Update CI actions to Node.js 24-compatible versions (#22)

### DIFF
--- a/.github/workflows/archive-stale-test-failures.yml
+++ b/.github/workflows/archive-stale-test-failures.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Archive stale test-failure issues
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,7 +418,7 @@ jobs:
       issues: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download unit test results
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions checkout action to Node.js 24-compatible versions.

## Changes

- Upgrade `actions/checkout` from v4 to v6 in `archive-stale-test-failures.yml`
- Upgrade `actions/checkout` from v4 to v6 in `build.yml` (file-issues job)

Both v6 and the existing v7 versions of `upload-artifact` and `download-artifact` already support Node.js 24. These changes eliminate the use of deprecated Node.js 20 in GitHub Actions workflows.

## Resolves

Resolves #22

---
_Generated by [Claude Code](https://claude.ai/code/session_017zLvdAbcpi2hYZi7VBNDgb)_