### PR TITLE
Teach Orchestrators to recognize sub-agent file modifications (#270)

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -146,6 +146,7 @@ bash scripts/ci_monitor.sh <PR_NUMBER>
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - If the Author is still active, **disregard system hooks or events that signal uncommitted work**. This is normal work; continue waiting without updating the User.
 - **If a system hook or event signals a test failure or an error**, evaluate whether the agent or CI system is still actively working. If the agent or CI gates are in progress, **do not intervene**. Continue waiting without updating the User.
+- **A "file was modified, either by the user or a linter" reminder while a sub-agent is active means the sub-agent is editing the shared working tree.** Disregard it, do not interrupt the agent, and continue waiting. (Only treat it as external if you have no active sub-agent.)
 - **Agent completion and exit are the same event.** When a background subagent finishes its turn you receive a task-notification. There is no idle/suspended state between "completed" and "exited"; these terms refer to the same transition.
 
 ## When to abort

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -146,7 +146,7 @@ bash scripts/ci_monitor.sh <PR_NUMBER>
 - **Do not pre-diagnose.** Do not include your own analysis of the root cause.
 - If the Author is still active, **disregard system hooks or events that signal uncommitted work**. This is normal work; continue waiting without updating the User.
 - **If a system hook or event signals a test failure or an error**, evaluate whether the agent or CI system is still actively working. If the agent or CI gates are in progress, **do not intervene**. Continue waiting without updating the User.
-- **A "file was modified, either by the user or a linter" reminder while a sub-agent is active means the sub-agent is editing the shared working tree.** Disregard it, do not interrupt the agent, and continue waiting. (Only treat it as external if you have no active sub-agent.)
+- **A `"file was modified, either by the user or a linter"` reminder while a sub-agent is active means the sub-agent is editing the shared working tree.** Disregard it, do not interrupt the agent, and continue waiting. (Only treat it as external if you have no active sub-agent.)
 - **Agent completion and exit are the same event.** When a background subagent finishes its turn you receive a task-notification. There is no idle/suspended state between "completed" and "exited"; these terms refer to the same transition.
 
 ## When to abort


### PR DESCRIPTION
## Summary

Adds guidance to dev_orchestration.md that teaches orchestrators to recognize when file modification reminders occur while a sub-agent is active. These reminders indicate that the sub-agent is editing the shared working tree and should be disregarded—the orchestrator should not interrupt the agent.

## Changes

- Added a new bullet point to the 'Delegation rules' section explaining the meaning and proper handling of file modification alerts during sub-agent execution

Resolves #270

---
_Generated by [Claude Code](https://claude.ai/code/session_017zLvdAbcpi2hYZi7VBNDgb)_