### PR TITLE
Add robustness improvements to CI Monitor (Step 2 of #272)

### DIFF
--- a/scripts/ci_monitor.py
+++ b/scripts/ci_monitor.py
@@ -119,6 +119,22 @@ def parse_pr_sha(pr_json):
     return pr_json.get("head", {}).get("sha", "")
 
 
+def parse_pr_terminal(pr_json):
+    """Map a /pulls/{n} response to a terminal line for a done PR, or '' if open.
+
+    GitHub leaves `mergeable_state` at "unknown" indefinitely once a PR is
+    closed or merged, which would otherwise spin the poll loop until timeout.
+    Returns 'Merged' when the PR was merged, 'Closed' when it was closed without
+    merging, or '' when the PR is still open and should keep being polled. A
+    response missing both fields (e.g. a minimal mock) is treated as open.
+    """
+    if pr_json.get("merged"):
+        return "Merged"
+    if pr_json.get("state") == "closed":
+        return "Closed"
+    return ""
+
+
 def parse_check_result(check_json):
     """Map a /commits/{sha}/check-runs response to an overall result token.
 
@@ -193,11 +209,43 @@ def _err_detail(e):
     return "%s: %s" % (type(e).__name__, e)
 
 
+def _retry_after_seconds(e, now):
+    """Return how long to back off (seconds) for a rate-limited HTTPError.
+
+    On HTTP 403/429 GitHub advertises when to retry via either a `Retry-After`
+    header (delta seconds) or an `X-RateLimit-Reset` header (Unix timestamp).
+    Returns that delay clamped to a sane ceiling, or None when the error is not
+    a recognized rate-limit response or carries no usable hint.
+    """
+    if not isinstance(e, urllib.error.HTTPError) or e.code not in (403, 429):
+        return None
+    headers = getattr(e, "headers", None)
+    if headers is None:
+        return None
+    retry_after = headers.get("Retry-After")
+    if retry_after:
+        try:
+            return min(max(int(retry_after), 0), 300)
+        except (ValueError, TypeError):
+            pass
+    reset = headers.get("X-RateLimit-Reset")
+    if reset:
+        try:
+            return min(max(int(reset) - int(now), 0), 300)
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
 def _request(url, token, raw=False):
     """Perform an authenticated GET. Returns parsed JSON (or raw bytes if raw).
 
     Returns None on any HTTP/URL/JSON error so the poll loop can survive blips.
+    On an HTTP error the originating HTTPError is recorded on the function as
+    `_request.last_error` so callers that retry (e.g. the SHA fetch) can inspect
+    rate-limit headers; it is cleared to None on a successful request.
     """
+    _request.last_error = None
     req = urllib.request.Request(url)
     req.add_header("Authorization", "Bearer %s" % token)
     req.add_header("Accept", "application/vnd.github+json")
@@ -205,6 +253,7 @@ def _request(url, token, raw=False):
         with urllib.request.urlopen(req) as resp:
             data = resp.read()
     except (urllib.error.URLError, OSError) as e:
+        _request.last_error = e
         sys.stderr.write("request failed (%s): %s\n" % (url, _err_detail(e)))
         sys.stderr.flush()
         return None
@@ -216,6 +265,31 @@ def _request(url, token, raw=False):
         sys.stderr.write("response parse failed (%s): %s\n" % (url, e))
         sys.stderr.flush()
         return None
+
+
+_request.last_error = None
+
+
+def fetch_pr_with_retry(pr, token, attempts=3, base_delay=2):
+    """Fetch /pulls/{n} with bounded exponential backoff and rate-limit handling.
+
+    Tries up to `attempts` times. Between failed tries it sleeps with exponential
+    backoff (base_delay, 2x, 4x, ...), unless the failure is a rate-limit
+    response (HTTP 403/429) advertising a `Retry-After` or `X-RateLimit-Reset`
+    hint, in which case it honors that delay instead. Returns the parsed JSON on
+    success, or None if every attempt fails (the caller then handles the
+    throttled "could not fetch SHA" line).
+    """
+    url = "%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, pr)
+    for attempt in range(attempts):
+        pr_json = _request(url, token)
+        if pr_json is not None:
+            return pr_json
+        if attempt == attempts - 1:
+            break
+        hint = _retry_after_seconds(_request.last_error, time.time())
+        time.sleep(hint if hint is not None else base_delay * (2 ** attempt))
+    return None
 
 
 # ── Main poll loop ────────────────────────────────────────────────────────────
@@ -251,16 +325,36 @@ def main(argv):
         sys.stdout.flush()
         last_output_ts = time.time()
 
+    # Gap D — advertise our PID so the Orchestrator can stop us out-of-band
+    # (e.g. `kill -TERM <PID>`) if the Monitor tool's TaskStop is unavailable.
+    print("monitor PID %d — if TaskStop is unavailable, send SIGTERM to this PID to stop me" % os.getpid())
+    sys.stdout.flush()
+
     while True:
-        pr_json = _request("%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, pr), token)
+        # Gap C — retry the SHA fetch with backoff and rate-limit awareness
+        # instead of a flat 30s retry, so transient blips and 403/429 throttles
+        # are handled without hammering the API.
+        pr_json = fetch_pr_with_retry(pr, token)
         sha = parse_pr_sha(pr_json) if pr_json else ""
 
         if not sha:
-            print("PR#%s: could not fetch SHA" % pr)
-            sys.stdout.flush()
-            last_output_ts = time.time()
+            # Throttle the noise: only surface the failure after >120s of
+            # silence, matching the in_progress heartbeat suppression.
+            now = time.time()
+            if now - last_output_ts > 120:
+                print("PR#%s: could not fetch SHA" % pr)
+                sys.stdout.flush()
+                last_output_ts = now
             time.sleep(30)
             continue
+
+        # Gap A — a closed or merged PR leaves mergeable_state "unknown"
+        # forever; emit a terminal line and stop instead of spinning.
+        terminal = parse_pr_terminal(pr_json)
+        if terminal:
+            print("PR#%s: %s" % (pr, terminal))
+            sys.stdout.flush()
+            break
 
         check_json = _request(
             "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
@@ -344,12 +438,16 @@ def main(argv):
                 sys.stdout.flush()
                 break
             else:
-                print(
-                    "PR#%s: all_passed mergeable_state=%s (still computing)"
-                    % (pr, mergeable)
-                )
-                sys.stdout.flush()
-                last_output_ts = time.time()
+                # Gap B — throttle "still computing" to >120s of silence, just
+                # like the in_progress heartbeat, so it does not print every poll.
+                now = time.time()
+                if now - last_output_ts > 120:
+                    print(
+                        "PR#%s: all_passed mergeable_state=%s (still computing)"
+                        % (pr, mergeable)
+                    )
+                    sys.stdout.flush()
+                    last_output_ts = now
         elif result in ("Blocked", "Infra"):
             print("PR#%s: %s" % (pr, result))
             sys.stdout.flush()

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -15,6 +15,8 @@ Covers:
   (h) Mocked HTTP: _request returns parsed JSON without touching the network
   (i) main(): failing unit test signals (step failure + FAIL) emit once before terminal
   (j) main(): in_progress heartbeat fires after >120s and resets on emission
+  (k) Gap A: parse_pr_terminal() maps merged/closed/open + main() terminates on merged
+  (l) Gap C: fetch_pr_with_retry() retry/backoff and _retry_after_seconds() header parsing
 
 No network calls required; no GITHUB_TOKEN needed.
 Always exits 0 on success, non-zero on failure.
@@ -26,6 +28,7 @@ import json
 import os
 import sys
 import unittest.mock
+import urllib.error
 import zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -401,6 +404,214 @@ check(len(req_j) == 0,
       "all mocked requests consumed (65 entries drained)",
       "request deque not drained; %d entries left" % len(req_j))
 check(rc_j == 0, "main() returned 0", "main() returned %r" % rc_j)
+
+
+# ── (k) Gap A: closed/merged PR termination ────────────────────────────────────
+print("\n=== (k) Gap A: parse_pr_terminal maps merged/closed/open ===")
+
+check(ci_monitor.parse_pr_terminal({"merged": True, "state": "closed"}) == "Merged",
+      "parse_pr_terminal returns 'Merged' when merged is true",
+      "expected 'Merged'; got %r" % ci_monitor.parse_pr_terminal({"merged": True, "state": "closed"}))
+check(ci_monitor.parse_pr_terminal({"merged": False, "state": "closed"}) == "Closed",
+      "parse_pr_terminal returns 'Closed' when state is closed (not merged)",
+      "expected 'Closed'; got %r" % ci_monitor.parse_pr_terminal({"merged": False, "state": "closed"}))
+check(ci_monitor.parse_pr_terminal({"merged": False, "state": "open"}) == "",
+      "parse_pr_terminal returns '' when PR is open",
+      "expected ''; got %r" % ci_monitor.parse_pr_terminal({"merged": False, "state": "open"}))
+
+# Integration: iteration 1 is in_progress, iteration 2 the PR is merged. The
+# terminal check runs right after the SHA fetch (before check-runs), so on
+# iteration 2 main() emits 'PR#N: Merged' and breaks without issuing the
+# check-runs/runs/jobs/artifacts calls. Per-iteration request order is:
+#   pulls (sha), check-runs, runs, jobs, artifacts, [zip per new artifact].
+# Iteration 1 (open + in_progress, empty artifacts) issues 5 requests; iteration
+# 2 short-circuits after the single pulls fetch. 5 + 1 = 6 entries, drained.
+print("\n=== (k) main(): merged PR emits terminal 'Merged' and exits cleanly ===")
+
+PR_OPEN_K = {"head": {"sha": "feedface"}, "merged": False, "state": "open"}
+PR_MERGED_K = {"head": {"sha": "feedface"}, "merged": True, "state": "closed"}
+CHECK_IP_K = {"total_count": 1, "check_runs": [{"status": "in_progress", "conclusion": None}]}
+RUNS_K = {"workflow_runs": [{"id": 888, "status": "in_progress"}]}
+JOBS_EMPTY_K = {"jobs": [{"name": "build-and-test", "steps": []}]}
+ARTS_EMPTY_K = {"artifacts": []}
+
+side_effects_k = collections.deque([
+    # iteration 1 — open, in_progress (no heartbeat: clock frozen at start)
+    PR_OPEN_K,        # pulls -> sha, terminal == ''
+    CHECK_IP_K,       # check-runs -> in_progress
+    RUNS_K,           # runs -> run_id
+    JOBS_EMPTY_K,     # jobs -> nothing
+    ARTS_EMPTY_K,     # artifacts -> nothing
+    # iteration 2 — merged: terminal short-circuit before check-runs
+    PR_MERGED_K,      # pulls -> sha, terminal == 'Merged' -> break
+])
+
+
+def fake_request_k(url, token, raw=False):
+    return side_effects_k.popleft()
+
+
+buf_k = io.StringIO()
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_k), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None), \
+        unittest.mock.patch("sys.stdout", new=buf_k):
+    rc_k = ci_monitor.main(["ci_monitor.py", "--pr", "290"])
+
+out_k = buf_k.getvalue()
+lines_k = out_k.splitlines()
+merged_line_k = "PR#290: Merged"
+check(lines_k.count(merged_line_k) == 1,
+      "Merged terminal line emitted exactly once",
+      "Merged terminal line count != 1; output: %r" % out_k)
+check(not any("still computing" in ln for ln in lines_k),
+      "no 'still computing' spin while terminating on merged",
+      "unexpected 'still computing' line; output: %r" % out_k)
+check(len(side_effects_k) == 0,
+      "all 6 mocked requests consumed (merged short-circuits iteration 2)",
+      "request deque not drained; %d entries left" % len(side_effects_k))
+check(rc_k == 0, "main() returned 0 after merged terminal", "main() returned %r" % rc_k)
+
+
+# ── (l) Gap C: SHA-fetch retry/backoff ─────────────────────────────────────────
+print("\n=== (l) Gap C: _retry_after_seconds parses rate-limit headers ===")
+
+
+class _FakeHTTPError(urllib.error.HTTPError):
+    """An HTTPError with controllable code and headers, no real response body."""
+
+    def __init__(self, code, headers):
+        # Bypass HTTPError.__init__'s fp/url plumbing; set just what we read.
+        # _retry_after_seconds only inspects .code and .headers.
+        self.code = code
+        self.headers = headers
+
+
+# Retry-After header (delta seconds).
+ra = ci_monitor._retry_after_seconds(_FakeHTTPError(429, {"Retry-After": "42"}), 1000.0)
+check(ra == 42, "Retry-After header parsed as 42s",
+      "expected 42; got %r" % ra)
+
+# X-RateLimit-Reset header (Unix timestamp -> delta from now).
+xr = ci_monitor._retry_after_seconds(
+    _FakeHTTPError(403, {"X-RateLimit-Reset": "1100"}), 1000.0)
+check(xr == 100, "X-RateLimit-Reset parsed as (reset - now) = 100s",
+      "expected 100; got %r" % xr)
+
+# Clamp to 300s ceiling (huge reset far in the future).
+clamp = ci_monitor._retry_after_seconds(
+    _FakeHTTPError(403, {"X-RateLimit-Reset": "100000"}), 1000.0)
+check(clamp == 300, "huge backoff clamped to 300s max",
+      "expected 300; got %r" % clamp)
+
+# Non-rate-limit status returns None (no backoff hint).
+none_status = ci_monitor._retry_after_seconds(
+    _FakeHTTPError(500, {"Retry-After": "10"}), 1000.0)
+check(none_status is None, "non-403/429 status yields no hint (None)",
+      "expected None; got %r" % none_status)
+
+# Rate-limit status but no usable header returns None.
+none_hdr = ci_monitor._retry_after_seconds(_FakeHTTPError(429, {}), 1000.0)
+check(none_hdr is None, "rate-limit status without headers yields None",
+      "expected None; got %r" % none_hdr)
+
+# Invalid Retry-After value falls through to None (no X-RateLimit-Reset).
+bad_ra = ci_monitor._retry_after_seconds(
+    _FakeHTTPError(429, {"Retry-After": "soon"}), 1000.0)
+check(bad_ra is None, "non-numeric Retry-After yields None",
+      "expected None; got %r" % bad_ra)
+
+print("\n=== (l) fetch_pr_with_retry: first-try success, retry-then-success, all-fail ===")
+
+PR_RETRY = {"head": {"sha": "0ddba11"}}
+
+# Success on the first try: one _request call, no sleep.
+calls_first = {"n": 0}
+
+
+def req_first(url, token, raw=False):
+    calls_first["n"] += 1
+    return PR_RETRY
+
+
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=req_first), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", side_effect=AssertionError("should not sleep")), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0):
+    got_first = ci_monitor.fetch_pr_with_retry("290", "tok")
+check(got_first == PR_RETRY and calls_first["n"] == 1,
+      "fetch_pr_with_retry succeeds on first try with no sleep",
+      "first-try fetch wrong; got %r after %d calls" % (got_first, calls_first["n"]))
+
+# Transient URLError twice, then success. Backoff sleeps recorded.
+err = urllib.error.URLError("temporary blip")
+retry_results = collections.deque([None, None, PR_RETRY])
+slept = []
+
+
+def req_retry(url, token, raw=False):
+    r = retry_results.popleft()
+    # Emulate _request recording the last transient error on failure.
+    ci_monitor._request.last_error = None if r is not None else err
+    return r
+
+
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=req_retry), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", side_effect=slept.append), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0):
+    got_retry = ci_monitor.fetch_pr_with_retry("290", "tok", attempts=3, base_delay=2)
+check(got_retry == PR_RETRY,
+      "fetch_pr_with_retry retries transient failures and eventually succeeds",
+      "retry-then-success wrong; got %r" % got_retry)
+check(slept == [2, 4],
+      "exponential backoff sleeps were 2s then 4s before success",
+      "backoff schedule wrong; slept %r" % slept)
+check(len(retry_results) == 0, "all retry responses consumed",
+      "retry deque not drained; %d left" % len(retry_results))
+
+# Every attempt fails -> returns None after `attempts` tries, sleeps attempts-1 times.
+fail_calls = {"n": 0}
+slept_fail = []
+
+
+def req_allfail(url, token, raw=False):
+    fail_calls["n"] += 1
+    ci_monitor._request.last_error = err
+    return None
+
+
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=req_allfail), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", side_effect=slept_fail.append), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0):
+    got_fail = ci_monitor.fetch_pr_with_retry("290", "tok", attempts=3, base_delay=2)
+check(got_fail is None,
+      "fetch_pr_with_retry returns None when every attempt fails",
+      "expected None; got %r" % got_fail)
+check(fail_calls["n"] == 3,
+      "fetch_pr_with_retry made exactly `attempts` (3) requests",
+      "expected 3 requests; got %d" % fail_calls["n"])
+check(slept_fail == [2, 4],
+      "slept between the 3 failed attempts (2s, 4s), not after the last",
+      "fail backoff schedule wrong; slept %r" % slept_fail)
+
+# Rate-limit hint overrides exponential backoff: 403 with Retry-After=7.
+rl_err = _FakeHTTPError(429, {"Retry-After": "7"})
+rl_results = collections.deque([None, PR_RETRY])
+slept_rl = []
+
+
+def req_ratelimit(url, token, raw=False):
+    r = rl_results.popleft()
+    ci_monitor._request.last_error = None if r is not None else rl_err
+    return r
+
+
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=req_ratelimit), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", side_effect=slept_rl.append), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0):
+    got_rl = ci_monitor.fetch_pr_with_retry("290", "tok", attempts=3, base_delay=2)
+check(got_rl == PR_RETRY and slept_rl == [7],
+      "rate-limit Retry-After hint (7s) honored over exponential backoff",
+      "rate-limit backoff wrong; got %r, slept %r" % (got_rl, slept_rl))
 
 
 # ── Summary ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Addresses #272 (Step 2 only).

## What changed

Implements four robustness improvements to `scripts/ci_monitor.py`:

- **Gap A — Closed/merged PR termination**: Detect when a PR is already closed or merged and emit a terminal line (`Merged` or `Closed`) instead of spinning on "still computing" until timeout.
- **Gap B — Throttle "still computing" line**: Apply the same >120s silence suppression to the "still computing" line as the `in_progress` heartbeat.
- **Gap C — SHA-fetch retry/backoff**: Implement 2-3 retry attempts with exponential backoff (2s, 4s) for transient SHA-fetch failures. On HTTP 403/429, honor `Retry-After` and `X-RateLimit-Reset` headers for intelligent backoff.
- **Gap D — Bailout PID kill-switch**: Print an advisory line at startup with the process PID so the Orchestrator can stop the monitor via `kill -TERM <PID>`.

## Tests

All 54 tests pass (33 existing + 21 new):
- **Test (k)**: Closed/merged PR termination (3 unit cases + integration test)
- **Test (l)**: SHA-fetch retry/backoff (retry logic + rate-limit header parsing)

## Verification

`python3 scripts/test_ci_monitor.py` → 54 passed, 0 failed. All changes are additive; existing stdout vocabulary preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoARHaSjrPUoDipXHhNnHd)_