### PR TITLE
Replace tail -300 with timestamp-based logcat capture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,13 +318,13 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
+          LOGCAT_SINCE=$("$ADB" shell date +'%m-%d %H:%M:%S.000')
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.PixelCameraOverlayE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-overlay.ndjson) || {
-            echo "=== LOGCAT (last 300 lines) ==="
-            "$ADB" logcat -d | \
-              bash scripts/filter_logcat.sh | \
-              tail -300
+            echo "=== LOGCAT (since test start) ==="
+            "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
+              bash scripts/filter_logcat.sh
             exit 1
           }
 
@@ -345,13 +345,13 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
+          LOGCAT_SINCE=$("$ADB" shell date +'%m-%d %H:%M:%S.000')
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.GalleryButtonVisualE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-gallery.ndjson) || {
-            echo "=== LOGCAT (last 300 lines) ==="
-            "$ADB" logcat -d | \
-              bash scripts/filter_logcat.sh | \
-              tail -300
+            echo "=== LOGCAT (since test start) ==="
+            "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
+              bash scripts/filter_logcat.sh
             exit 1
           }
 

--- a/scripts/filter_logcat.sh
+++ b/scripts/filter_logcat.sh
@@ -15,7 +15,7 @@
 #
 # Usage:
 #   adb logcat -d | scripts/filter_logcat.sh
-#   adb logcat -d | scripts/filter_logcat.sh | tail -300
+#   SINCE=$(adb shell date +'%m-%d %H:%M:%S.000') && adb logcat -d -T "$SINCE" | scripts/filter_logcat.sh
 #
 # Examples of elided patterns:
 #   data:image/jpeg;base64,/9j/4AAQ...    →  data:image/jpeg;base64,[elided]


### PR DESCRIPTION
Fixes #268

## What changed

Both E2E test steps in `.github/workflows/build.yml` previously dumped the full device log buffer and truncated it to the last 300 filtered lines on failure. This could silently drop early failures and included pre-step noise from boot/setup.

The new approach records the device clock immediately before the Gradle invocation and passes that timestamp to `adb logcat -T` on failure, capturing all filtered lines from the start of the step with no arbitrary cutoff.

Key implementation detail: `adb shell date` (device clock) is used rather than host `date` to avoid clock skew between the CI runner and the emulator. `-T <time>` is supported on Android 4.1+ (API 16+); no compatibility concern with the API 35 target.

Also updates the usage comment in `scripts/filter_logcat.sh` to reflect the new recommended pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNa9d26UtzCM446jExQMFC)_