### PR TITLE
Document GitHub MCP tool quirks in environment.md

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -23,7 +23,7 @@ script for implementation details — each step is commented.
 | `ANDROID_HOME`     | `/home/user/android-sdk`     | hook + `~/.bashrc`| Required by Gradle Android plugin and `adb`                  |
 | `JAVA_TOOL_OPTIONS`| *(modified, not replaced)*   | hook + `~/.bashrc`| Strips `*.google.com` from `nonProxyHosts` — see script §0   |
 | `PATH`             | `+$ANDROID_HOME/…`           | hook + `~/.bashrc`| Adds `sdkmanager`, `adb` to path                            |
-| `GITHUB_TOKEN`     | *(session-scoped JWT)*       | container         | Use with `curl` to query the GitHub REST API                 |
+| `GITHUB_TOKEN`     | *(session-scoped JWT)*       | container         | Read-only for the GitHub Issues/PR API (write attempts return 403). Useful for reading Actions job logs (see below). |
 
 `~/.bashrc` carries the same fixes for interactive terminal sessions.
 The proxy credentials in `JAVA_TOOL_OPTIONS` are a session-scoped JWT injected
@@ -59,7 +59,9 @@ so the `labels` field is never sent and all existing labels remain.
 
 **Implication:** There is no way to remove *all* labels from an issue using
 `mcp__github__issue_write` alone. To drop N−1 labels, set `labels` to the one label
-you want to keep. The last remaining label cannot be removed via this tool.
+you want to keep. The last remaining label cannot be removed via this tool, and the
+`GITHUB_TOKEN` environment variable also cannot help — it is read-only for the Issues
+API (write attempts return 403).
 
 ### Always verify writes with a follow-up read
 

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -43,6 +43,51 @@ by the container — never hard-code them.
 
 ---
 
+## GitHub MCP tool quirks
+
+### `issue_write labels: []` is a silent no-op
+
+Calling `mcp__github__issue_write` with `labels: []` to clear all labels returns a
+success-looking response (`{"id":"…","url":"…"}`) but **does not change any labels**.
+The MCP tool appears to filter out empty arrays before building the API request body,
+so the `labels` field is never sent and all existing labels remain.
+
+**Evidence (empirically verified):**
+- `labels: ["planning needed"]` → correctly replaces ALL labels with just that one
+  (REPLACE semantics — "for ai to do" was removed in the same call). Non-empty arrays work.
+- `labels: []` → no change; all labels remain. Confirmed by a follow-up `get_labels` read.
+
+**Implication:** There is no way to remove *all* labels from an issue using
+`mcp__github__issue_write` alone. To drop N−1 labels, set `labels` to the one label
+you want to keep. The last remaining label cannot be removed via this tool.
+
+### Always verify writes with a follow-up read
+
+`mcp__github__issue_write` (and similar write tools) return `{"id":"…","url":"…"}`
+regardless of whether the underlying change was applied. The stripped response gives
+no signal about what actually changed. **Always follow a write with a confirming
+`issue_read`** (e.g. `method: "get_labels"`) before reporting success.
+
+### "Token expired" errors on write operations
+
+Write operations (`add_issue_comment`, `issue_write`, etc.) occasionally fail with:
+
+```
+MCP server "github" requires re-authorization (token expired)
+```
+
+…while reads on the same resource succeed. The `GITHUB_TOKEN` is a session-scoped JWT
+(short-lived). The JWT can expire mid-session; reads appear to use a cached or
+lower-privilege path that still succeeds, while writes require a fresh token. A
+successful read call appears to trigger a background JWT refresh that unblocks
+subsequent writes.
+
+**Workaround:** if writes fail with this error, perform any `issue_read` first, then
+immediately retry the write. Do not interpret the error as a "no blind writes"
+enforcement — it is genuine token expiry.
+
+---
+
 ## Read GitHub Actions job logs
 
 ```bash

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -23,7 +23,7 @@ script for implementation details — each step is commented.
 | `ANDROID_HOME`     | `/home/user/android-sdk`     | hook + `~/.bashrc`| Required by Gradle Android plugin and `adb`                  |
 | `JAVA_TOOL_OPTIONS`| *(modified, not replaced)*   | hook + `~/.bashrc`| Strips `*.google.com` from `nonProxyHosts` — see script §0   |
 | `PATH`             | `+$ANDROID_HOME/…`           | hook + `~/.bashrc`| Adds `sdkmanager`, `adb` to path                            |
-| `GITHUB_TOKEN`     | *(session-scoped JWT)*       | container         | Read-only for the GitHub Issues/PR API (write attempts return 403). Useful for reading Actions job logs (see below). |
+| `GITHUB_TOKEN`     | *(session-scoped JWT)*       | container         | Use with `curl` to query the GitHub REST API. Read-only for the issues/PR API (write attempts return 403). Useful for reading Actions job logs (see below). |
 
 `~/.bashrc` carries the same fixes for interactive terminal sessions.
 The proxy credentials in `JAVA_TOOL_OPTIONS` are a session-scoped JWT injected


### PR DESCRIPTION
Discovered during the investigation for #268.

Documents three empirically verified quirks of the GitHub MCP server that affect agent reliability:

1. **`issue_write labels: []` is a silent no-op** — empty arrays are dropped before the API request is built; no labels change. Non-empty arrays use correct REPLACE semantics. The last remaining label on an issue cannot be removed via the MCP tool.

2. **Always verify writes with a follow-up read** — `issue_write` (and similar tools) return `{"id","url"}` regardless of whether the change was actually applied. The stripped response provides no signal of success vs. no-op.

3. **"Token expired" write failures are genuine JWT expiry** — not a "no blind writes" gate. The session-scoped JWT can expire mid-session; reads appear to succeed via a cached path while writes require a fresh token. Performing any successful read appears to trigger a background refresh that unblocks subsequent writes.