### PR TITLE
Add regex filters for FAIL/PASS/SKIP outcomes to CI monitor

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -161,6 +161,29 @@ python3 scripts/ci_monitor.py --pr <PR_NUMBER>
 
 `OWNER`/`REPO` default to this repo at the top of the script, and it reads `$GITHUB_TOKEN` from the environment. The script catches transient REST/parse failures per call so they cannot kill the resilient poll loop; the 30-minute escalation threshold is enforced by `timeout_ms: 1800000` on the Monitor call, not inside the script. Each stdout line is the interface (see the outcome vocabulary below): terminal lines (`Clear`/`Blocked`/`Infra`) end the loop, while informational lines keep it alive.
 
+### Per-test outcome filters
+
+By default the monitor reports **all FAIL markers**, **all SKIP markers**, and **no PASS markers**. The Orchestrator may supply independent filter flags to narrow or expand which per-test outcomes are streamed:
+
+| Flag | Effect |
+|---|---|
+| `--include-fail [PATTERN]` | Report FAIL markers (default); optionally restrict to those whose `name` matches PATTERN. |
+| `--no-include-fail` | Suppress all FAIL markers. |
+| `--include-skip [PATTERN]` | Report SKIP markers (default); optionally restrict to those whose `name` matches PATTERN. |
+| `--no-include-skip` | Suppress all SKIP markers. |
+| `--include-pass [PATTERN]` | Report PASS markers (not the default); optionally restrict to those whose `name` matches PATTERN. |
+| `--no-include-pass` | Suppress all PASS markers (explicit form of the default). |
+
+Each `--include-*` flag takes an **optional regex** matched against the marker's `name` field. Supplied without a pattern it includes *all* markers of that outcome. The three outcomes keep their distinct labels in output: `--include-pass` never relabels a SKIP as PASS.
+
+**Task-relevance validation.** To verify that a task-relevant test actually ran and passed — rather than being silently skipped — supply `--include-pass` with a regex matching the test(s) of interest:
+
+```bash
+python3 scripts/ci_monitor.py --pr <PR_NUMBER> --include-pass 'MyFeatureTest'
+```
+
+This emits a `PASS` line when the matching test passes and a `SKIP` line if it was skipped (which would be a false-validation trap: the code path was never exercised). With no pattern (`--include-pass ''`), every passing test is reported.
+
 ### Outcome vocabulary
 
 | Line emitted          | Meaning                                                                                               |
@@ -170,9 +193,11 @@ python3 scripts/ci_monitor.py --pr <PR_NUMBER>
 | `PR#N: Infra ...`     | A CI infrastructure problem (`cancelled`, `timed_out`, `stale`, `startup_failure`, or `mergeable_state=blocked`); escalate to user. |
 | `PR#N: in_progress`   | CI still running; emitted only after >120 s of silence (no other output); relay to user as a brief status update. |
 | `PR#N: step "..." -> ...` | A `build-and-test` step reached a conclusion: one of the three named test steps (`Build and run unit tests`, `Run *E2ETest`), or any genuine step failure. **Informational** — surfaces *which group* finished/failed and when; never ends the loop. |
-| `PR#N: FAIL [suite] name: ...` | A per-test failure (message + truncated trace) parsed from a `testresults-<group>` artifact, possibly followed by indented trace lines. **Informational** — surfaces even when the check stays green via `continue-on-error`; never ends the loop. |
+| `PR#N: FAIL [suite] name: ...` | A per-test failure (message + truncated trace) parsed from a `testresults-<group>` artifact, possibly followed by indented trace lines. **Informational** — emitted by default; suppress with `--no-include-fail`; never ends the loop. |
+| `PR#N: SKIP [suite] name: ...` | A per-test skip parsed from a `testresults-<group>` artifact. **Informational** — emitted by default; suppress with `--no-include-skip`; never ends the loop. A skipped task-relevant test is a false-validation trap. |
+| `PR#N: PASS [suite] name: ...` | A per-test pass parsed from a `testresults-<group>` artifact. **Informational** — suppressed by default; enable with `--include-pass [PATTERN]`; never ends the loop. |
 
-- `step`/`FAIL` lines are **informational test-result deltas**, not terminal outcomes: relay them to the user but do not start a new Author round. Only a `Blocked` line does that.
+- `step`/`FAIL`/`SKIP`/`PASS` lines are **informational test-result deltas**, not terminal outcomes: relay them to the user but do not start a new Author round. Only a `Blocked` line does that.
 - The Monitor reads results at **step granularity** from two polled REST signals — per-step `conclusion` (`/actions/runs/{id}/jobs`) and the `testresults-<group>` artifacts (`/actions/runs/{id}/artifacts`). It deliberately does **not** scrape the in-progress job log: `GET /actions/jobs/{job_id}/logs` returns 404 until the job completes, so markers are not readable mid-run that way.
 - The 30-minute escalation threshold is enforced by `timeout_ms: 1800000` on the Monitor call — no elapsed-time tracking needed.
 - Do not subscribe to PR events or delay dispatching the Reviewer while waiting for CI; the Monitor loop replaces that pattern.

--- a/scripts/ci_monitor.py
+++ b/scripts/ci_monitor.py
@@ -7,10 +7,21 @@ interface: terminal outcome lines end the loop, while informational lines
 (in_progress heartbeat, per-step deltas, per-test FAILs) keep it alive.
 
 Usage:
-    python3 scripts/ci_monitor.py --pr <PR_NUMBER>
+    python3 scripts/ci_monitor.py --pr <PR_NUMBER> [filter flags]
 
 Arguments:
     --pr <PR_NUMBER>   The pull request number to monitor (required).
+
+Per-outcome filter flags (each outcome is independent):
+    --include-fail [PATTERN]   Report FAIL markers, optionally regex-filtered on name.
+                               Default: all FAIL markers reported.
+    --no-include-fail          Suppress all FAIL markers.
+    --include-skip [PATTERN]   Report SKIP markers, optionally regex-filtered on name.
+                               Default: all SKIP markers reported.
+    --no-include-skip          Suppress all SKIP markers.
+    --include-pass [PATTERN]   Report PASS markers, optionally regex-filtered on name.
+                               Default: no PASS markers reported.
+    --no-include-pass          Suppress all PASS markers (explicit form of default).
 
 Environment:
     GITHUB_TOKEN  GitHub token used for the REST calls (required).
@@ -22,6 +33,8 @@ Outcome vocabulary (one terminal line ends the loop):
     PR#N: in_progress    CI still running; emitted only after >120 s of silence.
     PR#N: step "..." -> ...    A build-and-test step reached a conclusion (informational).
     PR#N: FAIL [suite] name: ...   A per-test failure from a testresults artifact (informational).
+    PR#N: PASS [suite] name: ...   A per-test pass (informational; emitted only when --include-pass used).
+    PR#N: SKIP [suite] name: ...   A per-test skip (informational; suppressed only with --no-include-skip).
 
 NOTE on error handling: the poll loop must survive transient REST/parse
 failures. HTTP and JSON errors are caught per-call and treated as "no data this
@@ -85,14 +98,28 @@ def parse_steps(jobs_json, seen):
     return out
 
 
-def parse_fails(lines, seen):
-    """Emit FAIL lines from ##GB4PC_TEST## ndjson markers.
+def parse_fails(lines, seen, outcome_filters=None):
+    """Emit FAIL/PASS/SKIP lines from ##GB4PC_TEST## ndjson markers.
 
     `lines` is an iterable of raw text lines; `seen` is a set of already-reported
-    suite#name keys (mutated in place). Returns a list of FAIL lines, each
+    suite#name#outcome keys (mutated in place). Returns a list of output lines, each
     possibly carrying an indented (truncated) trace. Deduped across calls by
-    suite#name.
+    suite#name#outcome.
+
+    `outcome_filters` is a dict mapping outcome names ('FAIL', 'PASS', 'SKIP') to
+    (enabled, pattern) tuples, where `enabled` is a bool and `pattern` is either
+    None (match all) or a regex string (match only markers whose `name` matches).
+    Default behavior (outcome_filters=None): report all FAIL, all SKIP, no PASS.
     """
+    import re as _re
+
+    if outcome_filters is None:
+        outcome_filters = {
+            "FAIL": (True, None),
+            "SKIP": (True, None),
+            "PASS": (False, None),
+        }
+
     out = []
     for raw in lines:
         i = raw.find(TEST_MARKER)
@@ -102,9 +129,17 @@ def parse_fails(lines, seen):
             m = json.loads(raw[i + len(TEST_MARKER):].strip())
         except Exception:
             continue
-        if m.get("outcome") != "FAIL":
+        outcome = m.get("outcome", "")
+        if outcome not in outcome_filters:
             continue
-        key = m.get("suite", "") + "#" + m.get("name", "")
+        enabled, pattern = outcome_filters[outcome]
+        if not enabled:
+            continue
+        # Pattern is matched against the marker's `name` field.
+        name = m.get("name", "")
+        if pattern is not None and not _re.search(pattern, name):
+            continue
+        key = m.get("suite", "") + "#" + name + "#" + outcome
         if key in seen:
             continue
         seen.add(key)
@@ -112,7 +147,7 @@ def parse_fails(lines, seen):
         tr = (m.get("trace") or "").strip()
         if len(tr) > 800:
             tr = tr[:800] + " ...(truncated)"
-        line = "FAIL [%s] %s: %s" % (m.get("suite", "?"), m.get("name", "?"), msg)
+        line = "%s [%s] %s: %s" % (outcome, m.get("suite", "?"), name or "?", msg)
         if tr:
             line += "\n  " + tr.replace("\n", "\n  ")
         out.append(line)
@@ -300,6 +335,34 @@ def fetch_pr_with_retry(pr, token, attempts=3, base_delay=2):
 # ── Main poll loop ────────────────────────────────────────────────────────────
 
 
+def _parse_outcome_filters(args):
+    """Build an outcome_filters dict from parsed CLI args.
+
+    Each outcome has an independent pair of flags:
+      --include-fail [pattern] / --no-include-fail
+      --include-skip [pattern] / --no-include-skip
+      --include-pass [pattern] / --no-include-pass
+
+    Returns a dict: {'FAIL': (enabled, pattern), 'SKIP': (enabled, pattern),
+                     'PASS': (enabled, pattern)}.
+    Defaults: FAIL all, SKIP all, PASS none.
+    """
+    def _outcome(no_flag, include_flag, default_enabled):
+        if no_flag:
+            return (False, None)
+        if include_flag is None:
+            # flag was not provided at all — use default
+            return (default_enabled, None)
+        # flag was provided; include_flag is either '' (no pattern) or a pattern string
+        return (True, include_flag if include_flag != "" else None)
+
+    return {
+        "FAIL": _outcome(args.no_include_fail, args.include_fail, True),
+        "SKIP": _outcome(args.no_include_skip, args.include_skip, True),
+        "PASS": _outcome(args.no_include_pass, args.include_pass, False),
+    }
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         prog="ci_monitor.py",
@@ -308,9 +371,31 @@ def main(argv):
     parser.add_argument(
         "--pr", required=True, metavar="PR_NUMBER", help="The pull request number to monitor."
     )
+
+    # Per-outcome filter flags. Each outcome has an --include-* (optional regex)
+    # and a --no-include-* suppressor. Defaults: all FAIL, all SKIP, no PASS.
+    for outcome in ("fail", "skip", "pass"):
+        parser.add_argument(
+            "--include-%s" % outcome,
+            dest="include_%s" % outcome,
+            metavar="PATTERN",
+            nargs="?",
+            default=None,   # sentinel: flag not supplied
+            const="",       # supplied with no argument: match all
+            help="Include %s markers, optionally filtered by regex on name." % outcome.upper(),
+        )
+        parser.add_argument(
+            "--no-include-%s" % outcome,
+            dest="no_include_%s" % outcome,
+            action="store_true",
+            default=False,
+            help="Suppress all %s markers." % outcome.upper(),
+        )
+
     args = parser.parse_args(argv[1:])
     pr = args.pr
     token = os.environ.get("GITHUB_TOKEN", "")
+    outcome_filters = _parse_outcome_filters(args)
 
     last_output_ts = time.time()
 
@@ -410,7 +495,7 @@ def main(argv):
                         lines = list(extract_ndjson_lines(zip_bytes))
                     except (zipfile.BadZipFile, OSError):
                         continue
-                    emit_block(parse_fails(lines, seen_fails))
+                    emit_block(parse_fails(lines, seen_fails, outcome_filters))
                     # Mark the artifact seen only after a successful download
                     # and parse: a transient failure above hits `continue` and
                     # leaves the id unseen, so it is retried on the next poll.

--- a/scripts/ci_monitor.py
+++ b/scripts/ci_monitor.py
@@ -363,8 +363,23 @@ def _parse_outcome_filters(args):
     }
 
 
+class _DocstringParser(argparse.ArgumentParser):
+    """ArgumentParser that prints the module docstring for --help/-h."""
+
+    def print_help(self, file=None):
+        if file is None:
+            file = sys.stdout
+        file.write(__doc__)
+        file.write("\n")
+        file.flush()
+
+    def error(self, message):
+        sys.stderr.write("%s: error: %s\nUse --help for usage information.\n" % (self.prog, message))
+        sys.exit(2)
+
+
 def main(argv):
-    parser = argparse.ArgumentParser(
+    parser = _DocstringParser(
         prog="ci_monitor.py",
         description="Poll a PR's CI and stream a terminal outcome plus per-test signals.",
     )

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -1089,6 +1089,328 @@ check(len(req_q) == 0,
 check(rc_q == 0, "main() returned 0", "main() returned %r" % rc_q)
 
 
+# ── (r) #260 outcome filters: parse_fails with explicit outcome_filters ────────
+print("\n=== (r) #260 outcome filters: parse_fails obeys outcome_filters for FAIL/PASS/SKIP ===")
+
+FILTER_NDJSON = [
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.FooTest","name":"test_fail","outcome":"FAIL","ms":1,"msg":"boom","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.FooTest","name":"test_pass","outcome":"PASS","ms":2,"msg":"","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.FooTest","name":"test_skip","outcome":"SKIP","ms":0,"msg":"","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.BarTest","name":"test_fail_bar","outcome":"FAIL","ms":3,"msg":"kaboom","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.BarTest","name":"test_pass_bar","outcome":"PASS","ms":4,"msg":"","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.BarTest","name":"test_skip_bar","outcome":"SKIP","ms":0,"msg":"","trace":""}',
+]
+
+# Default behavior: all FAIL, all SKIP, no PASS
+out_r_default = ci_monitor.parse_fails(FILTER_NDJSON, set())
+out_r_default_str = "\n".join(out_r_default)
+check("FAIL [com.gb4pc.unit.FooTest] test_fail:" in out_r_default_str,
+      "default: FAIL marker emitted", "default: FAIL marker missing; output: %r" % out_r_default)
+check("FAIL [com.gb4pc.unit.BarTest] test_fail_bar:" in out_r_default_str,
+      "default: FAIL marker for BarTest emitted", "default: BarTest FAIL missing; output: %r" % out_r_default)
+check("SKIP [com.gb4pc.unit.FooTest] test_skip:" in out_r_default_str,
+      "default: SKIP marker emitted", "default: SKIP marker missing; output: %r" % out_r_default)
+check("SKIP [com.gb4pc.unit.BarTest] test_skip_bar:" in out_r_default_str,
+      "default: SKIP marker for BarTest emitted", "default: BarTest SKIP missing; output: %r" % out_r_default)
+check("PASS" not in out_r_default_str,
+      "default: no PASS markers emitted", "default: unexpected PASS in output: %r" % out_r_default)
+
+# --no-include-fail: suppress all FAIL
+out_r_nofail = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (False, None), "SKIP": (True, None), "PASS": (False, None)},
+)
+out_r_nofail_str = "\n".join(out_r_nofail)
+check("FAIL" not in out_r_nofail_str,
+      "--no-include-fail: no FAIL emitted", "--no-include-fail: FAIL in output: %r" % out_r_nofail)
+check("SKIP [com.gb4pc.unit.FooTest] test_skip:" in out_r_nofail_str,
+      "--no-include-fail: SKIP still emitted", "--no-include-fail: SKIP missing; output: %r" % out_r_nofail)
+
+# --no-include-skip: suppress all SKIP
+out_r_noskip = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (True, None), "SKIP": (False, None), "PASS": (False, None)},
+)
+out_r_noskip_str = "\n".join(out_r_noskip)
+check("SKIP" not in out_r_noskip_str,
+      "--no-include-skip: no SKIP emitted", "--no-include-skip: SKIP in output: %r" % out_r_noskip)
+check("FAIL [com.gb4pc.unit.FooTest] test_fail:" in out_r_noskip_str,
+      "--no-include-skip: FAIL still emitted", "--no-include-skip: FAIL missing; output: %r" % out_r_noskip)
+
+# --include-pass '' (no pattern): all PASS markers emitted
+out_r_allpass = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (True, None), "SKIP": (True, None), "PASS": (True, None)},
+)
+out_r_allpass_str = "\n".join(out_r_allpass)
+check("PASS [com.gb4pc.unit.FooTest] test_pass:" in out_r_allpass_str,
+      "--include-pass: PASS marker emitted", "--include-pass: PASS missing; output: %r" % out_r_allpass)
+check("PASS [com.gb4pc.unit.BarTest] test_pass_bar:" in out_r_allpass_str,
+      "--include-pass: PASS marker for BarTest emitted", "--include-pass: BarTest PASS missing; output: %r" % out_r_allpass)
+
+# --include-pass with a pattern: only matching passes emitted
+out_r_patpass = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (False, None), "SKIP": (False, None), "PASS": (True, "test_pass$")},
+)
+out_r_patpass_str = "\n".join(out_r_patpass)
+check("PASS [com.gb4pc.unit.FooTest] test_pass:" in out_r_patpass_str,
+      "--include-pass with pattern: matching PASS emitted",
+      "--include-pass pattern: matching PASS missing; output: %r" % out_r_patpass)
+check("PASS [com.gb4pc.unit.BarTest] test_pass_bar:" not in out_r_patpass_str,
+      "--include-pass with pattern: non-matching PASS suppressed",
+      "--include-pass pattern: non-matching PASS leaked; output: %r" % out_r_patpass)
+
+# --include-fail with a pattern: only matching FAIL emitted
+out_r_patfail = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (True, "test_fail$"), "SKIP": (False, None), "PASS": (False, None)},
+)
+out_r_patfail_str = "\n".join(out_r_patfail)
+check("FAIL [com.gb4pc.unit.FooTest] test_fail:" in out_r_patfail_str,
+      "--include-fail with pattern: matching FAIL emitted",
+      "--include-fail pattern: matching FAIL missing; output: %r" % out_r_patfail)
+check("FAIL [com.gb4pc.unit.BarTest] test_fail_bar:" not in out_r_patfail_str,
+      "--include-fail with pattern: non-matching FAIL suppressed",
+      "--include-fail pattern: non-matching FAIL leaked; output: %r" % out_r_patfail)
+
+# --include-skip with a pattern: only matching SKIP emitted
+out_r_patskip = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (False, None), "SKIP": (True, "test_skip$"), "PASS": (False, None)},
+)
+out_r_patskip_str = "\n".join(out_r_patskip)
+check("SKIP [com.gb4pc.unit.FooTest] test_skip:" in out_r_patskip_str,
+      "--include-skip with pattern: matching SKIP emitted",
+      "--include-skip pattern: matching SKIP missing; output: %r" % out_r_patskip)
+check("SKIP [com.gb4pc.unit.BarTest] test_skip_bar:" not in out_r_patskip_str,
+      "--include-skip with pattern: non-matching SKIP suppressed",
+      "--include-skip pattern: non-matching SKIP leaked; output: %r" % out_r_patskip)
+
+# SKIP stays labeled SKIP, never relabeled as PASS (even with --include-pass '')
+out_r_labelcheck = ci_monitor.parse_fails(
+    FILTER_NDJSON, set(),
+    outcome_filters={"FAIL": (False, None), "SKIP": (True, None), "PASS": (True, None)},
+)
+out_r_labelcheck_str = "\n".join(out_r_labelcheck)
+check(all(not ln.startswith("PASS") for ln in out_r_labelcheck_str.splitlines()
+          if "test_skip" in ln),
+      "SKIP marker is never relabeled as PASS",
+      "SKIP was relabeled as PASS; output: %r" % out_r_labelcheck)
+check(any(ln.startswith("SKIP") for ln in out_r_labelcheck_str.splitlines()),
+      "SKIP outcome retains SKIP label in output",
+      "SKIP label missing; output: %r" % out_r_labelcheck)
+
+# ── (s) #260 CLI flags: _parse_outcome_filters and main() respect filter flags ─
+print("\n=== (s) #260 CLI flags: _parse_outcome_filters and main() pass filter flags through ===")
+
+# _parse_outcome_filters: defaults (no flags)
+import argparse as _argparse
+
+def _make_args(**kw):
+    """Build a namespace with the six flag attributes, defaulting to 'not supplied'."""
+    defaults = {
+        "include_fail": None, "no_include_fail": False,
+        "include_skip": None, "no_include_skip": False,
+        "include_pass": None, "no_include_pass": False,
+    }
+    defaults.update(kw)
+    return _argparse.Namespace(**defaults)
+
+# Defaults: all FAIL, all SKIP, no PASS
+filters_default = ci_monitor._parse_outcome_filters(_make_args())
+check(filters_default["FAIL"] == (True, None),
+      "_parse_outcome_filters default FAIL=(True,None)",
+      "_parse_outcome_filters FAIL default wrong; got %r" % (filters_default["FAIL"],))
+check(filters_default["SKIP"] == (True, None),
+      "_parse_outcome_filters default SKIP=(True,None)",
+      "_parse_outcome_filters SKIP default wrong; got %r" % (filters_default["SKIP"],))
+check(filters_default["PASS"] == (False, None),
+      "_parse_outcome_filters default PASS=(False,None)",
+      "_parse_outcome_filters PASS default wrong; got %r" % (filters_default["PASS"],))
+
+# --no-include-fail
+filters_nofail = ci_monitor._parse_outcome_filters(_make_args(no_include_fail=True))
+check(filters_nofail["FAIL"] == (False, None),
+      "_parse_outcome_filters --no-include-fail -> FAIL=(False,None)",
+      "_parse_outcome_filters --no-include-fail wrong; got %r" % (filters_nofail["FAIL"],))
+
+# --no-include-skip
+filters_noskip = ci_monitor._parse_outcome_filters(_make_args(no_include_skip=True))
+check(filters_noskip["SKIP"] == (False, None),
+      "_parse_outcome_filters --no-include-skip -> SKIP=(False,None)",
+      "_parse_outcome_filters --no-include-skip wrong; got %r" % (filters_noskip["SKIP"],))
+
+# --no-include-pass (explicit form of default)
+filters_nopass = ci_monitor._parse_outcome_filters(_make_args(no_include_pass=True))
+check(filters_nopass["PASS"] == (False, None),
+      "_parse_outcome_filters --no-include-pass -> PASS=(False,None)",
+      "_parse_outcome_filters --no-include-pass wrong; got %r" % (filters_nopass["PASS"],))
+
+# --include-pass '' (const, no pattern -> match all)
+filters_allpass = ci_monitor._parse_outcome_filters(_make_args(include_pass=""))
+check(filters_allpass["PASS"] == (True, None),
+      "_parse_outcome_filters --include-pass '' -> PASS=(True,None)",
+      "_parse_outcome_filters --include-pass '' wrong; got %r" % (filters_allpass["PASS"],))
+
+# --include-pass 'MyTest' (pattern)
+filters_patpass = ci_monitor._parse_outcome_filters(_make_args(include_pass="MyTest"))
+check(filters_patpass["PASS"] == (True, "MyTest"),
+      "_parse_outcome_filters --include-pass 'MyTest' -> PASS=(True,'MyTest')",
+      "_parse_outcome_filters --include-pass pattern wrong; got %r" % (filters_patpass["PASS"],))
+
+# --include-fail '' (supplied with no pattern -> match all)
+filters_allfail = ci_monitor._parse_outcome_filters(_make_args(include_fail=""))
+check(filters_allfail["FAIL"] == (True, None),
+      "_parse_outcome_filters --include-fail '' -> FAIL=(True,None)",
+      "_parse_outcome_filters --include-fail '' wrong; got %r" % (filters_allfail["FAIL"],))
+
+# --include-fail 'Foo' (pattern)
+filters_patfail = ci_monitor._parse_outcome_filters(_make_args(include_fail="Foo"))
+check(filters_patfail["FAIL"] == (True, "Foo"),
+      "_parse_outcome_filters --include-fail 'Foo' -> FAIL=(True,'Foo')",
+      "_parse_outcome_filters --include-fail pattern wrong; got %r" % (filters_patfail["FAIL"],))
+
+# main() with --include-pass '' emits PASS lines, not just FAIL/SKIP
+# Reuse side-effect fixtures from earlier: two polls, in_progress then Blocked.
+# The artifact contains one FAIL, one PASS, one SKIP. We expect FAIL+PASS+SKIP all
+# emitted (since --include-pass '' is supplied), but only once each.
+FILTER_NDJSON_MIXED = [
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.MixTest","name":"test_fail","outcome":"FAIL","ms":1,"msg":"oops","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.MixTest","name":"test_pass","outcome":"PASS","ms":2,"msg":"","trace":""}',
+    '##GB4PC_TEST## {"suite":"com.gb4pc.unit.MixTest","name":"test_skip","outcome":"SKIP","ms":0,"msg":"","trace":""}',
+]
+ZIP_MIXED = make_zip_ndjson(FILTER_NDJSON_MIXED)
+
+PR_S = {"head": {"sha": "5ce5c0de"}}
+CHECK_IP_S = {"total_count": 1, "check_runs": [{"status": "in_progress", "conclusion": None}]}
+CHECK_BL_S = {"total_count": 1, "check_runs": [{"status": "completed", "conclusion": "failure"}]}
+RUNS_S = {"workflow_runs": [{"id": 1111, "status": "in_progress"}]}
+JOBS_EMPTY_S = {"jobs": [{"name": "build-and-test", "steps": []}]}
+ARTS_MIX_S = {"artifacts": [{"id": 2222, "name": "testresults-mix", "expired": False}]}
+
+# Poll 1 (6): artifact available, zip downloaded; poll 2 (5): terminal Blocked.
+side_effects_s = collections.deque([
+    PR_S, CHECK_IP_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S, ZIP_MIXED,
+    PR_S, CHECK_BL_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S,
+])
+
+
+def fake_request_s(url, token, raw=False):
+    return side_effects_s.popleft()
+
+
+buf_s = io.StringIO()
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_s), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=3000.0), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None), \
+        unittest.mock.patch("sys.stdout", new=buf_s):
+    rc_s = ci_monitor.main(["ci_monitor.py", "--pr", "260", "--include-pass", ""])
+
+out_s = buf_s.getvalue()
+lines_s = out_s.splitlines()
+check("PR#260: FAIL [com.gb4pc.unit.MixTest] test_fail: oops" in lines_s,
+      "main() --include-pass '': FAIL line emitted",
+      "main() --include-pass '': FAIL missing; output: %r" % out_s)
+check(any("PR#260: PASS [com.gb4pc.unit.MixTest] test_pass:" in ln for ln in lines_s),
+      "main() --include-pass '': PASS line emitted",
+      "main() --include-pass '': PASS missing; output: %r" % out_s)
+check(any("PR#260: SKIP [com.gb4pc.unit.MixTest] test_skip:" in ln for ln in lines_s),
+      "main() --include-pass '': SKIP line emitted and stays labeled SKIP",
+      "main() --include-pass '': SKIP missing or mislabeled; output: %r" % out_s)
+check(len(side_effects_s) == 0,
+      "main() --include-pass '': all 11 mocked requests consumed",
+      "request deque not drained; %d entries left" % len(side_effects_s))
+check(rc_s == 0, "main() --include-pass '' returned 0", "main() returned %r" % rc_s)
+
+# main() with no flags: FAIL+SKIP emitted, no PASS
+side_effects_s2 = collections.deque([
+    PR_S, CHECK_IP_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S, ZIP_MIXED,
+    PR_S, CHECK_BL_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S,
+])
+
+
+def fake_request_s2(url, token, raw=False):
+    return side_effects_s2.popleft()
+
+
+buf_s2 = io.StringIO()
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_s2), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=3000.0), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None), \
+        unittest.mock.patch("sys.stdout", new=buf_s2):
+    rc_s2 = ci_monitor.main(["ci_monitor.py", "--pr", "260"])
+
+out_s2 = buf_s2.getvalue()
+lines_s2 = out_s2.splitlines()
+check(any("FAIL [com.gb4pc.unit.MixTest] test_fail:" in ln for ln in lines_s2),
+      "main() no flags: FAIL emitted",
+      "main() no flags: FAIL missing; output: %r" % out_s2)
+check(any("SKIP [com.gb4pc.unit.MixTest] test_skip:" in ln for ln in lines_s2),
+      "main() no flags: SKIP emitted",
+      "main() no flags: SKIP missing; output: %r" % out_s2)
+check(not any("PASS" in ln for ln in lines_s2 if not ln.startswith("monitor PID")),
+      "main() no flags: no PASS emitted",
+      "main() no flags: unexpected PASS; output: %r" % out_s2)
+check(len(side_effects_s2) == 0,
+      "main() no flags: all 11 mocked requests consumed",
+      "request deque not drained; %d entries left" % len(side_effects_s2))
+
+# main() with --no-include-fail: only SKIP emitted (no FAIL, no PASS)
+side_effects_s3 = collections.deque([
+    PR_S, CHECK_IP_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S, ZIP_MIXED,
+    PR_S, CHECK_BL_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S,
+])
+
+
+def fake_request_s3(url, token, raw=False):
+    return side_effects_s3.popleft()
+
+
+buf_s3 = io.StringIO()
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_s3), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=3000.0), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None), \
+        unittest.mock.patch("sys.stdout", new=buf_s3):
+    rc_s3 = ci_monitor.main(["ci_monitor.py", "--pr", "260", "--no-include-fail"])
+
+out_s3 = buf_s3.getvalue()
+lines_s3 = out_s3.splitlines()
+check(not any("FAIL" in ln for ln in lines_s3 if "PR#260:" in ln),
+      "main() --no-include-fail: no FAIL emitted",
+      "main() --no-include-fail: FAIL leaked; output: %r" % out_s3)
+check(any("SKIP [com.gb4pc.unit.MixTest] test_skip:" in ln for ln in lines_s3),
+      "main() --no-include-fail: SKIP still emitted",
+      "main() --no-include-fail: SKIP missing; output: %r" % out_s3)
+
+# main() with --no-include-skip: only FAIL emitted (no SKIP, no PASS)
+side_effects_s4 = collections.deque([
+    PR_S, CHECK_IP_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S, ZIP_MIXED,
+    PR_S, CHECK_BL_S, RUNS_S, JOBS_EMPTY_S, ARTS_MIX_S,
+])
+
+
+def fake_request_s4(url, token, raw=False):
+    return side_effects_s4.popleft()
+
+
+buf_s4 = io.StringIO()
+with unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_s4), \
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=3000.0), \
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None), \
+        unittest.mock.patch("sys.stdout", new=buf_s4):
+    rc_s4 = ci_monitor.main(["ci_monitor.py", "--pr", "260", "--no-include-skip"])
+
+out_s4 = buf_s4.getvalue()
+lines_s4 = out_s4.splitlines()
+check(not any("SKIP" in ln for ln in lines_s4 if "PR#260:" in ln),
+      "main() --no-include-skip: no SKIP emitted",
+      "main() --no-include-skip: SKIP leaked; output: %r" % out_s4)
+check(any("FAIL [com.gb4pc.unit.MixTest] test_fail:" in ln for ln in lines_s4),
+      "main() --no-include-skip: FAIL still emitted",
+      "main() --no-include-skip: FAIL missing; output: %r" % out_s4)
+
+
 # ── Summary ────────────────────────────────────────────────────────────────────
 print("\nResults: %d passed, %d failed." % (PASS, FAIL))
 if FAIL > 0:


### PR DESCRIPTION
## Summary

Fixes #260

Implements the three independent per-outcome filter flag pairs for `scripts/ci_monitor.py`, enabling the Orchestrator to control which per-test markers the CI monitor streams.

- `parse_fails()` now accepts an `outcome_filters` dict mapping each outcome (`FAIL`, `PASS`, `SKIP`) to an `(enabled, pattern)` tuple. When a pattern is supplied it is matched against the test `name` field via `re.search`. Default behavior is unchanged: all FAIL, all SKIP, no PASS.
- Six CLI flags parsed by `_parse_outcome_filters()` and threaded into the poll loop: `--include-fail [PATTERN]`, `--no-include-fail`, `--include-skip [PATTERN]`, `--no-include-skip`, `--include-pass [PATTERN]`, `--no-include-pass`.
- SKIP markers retain the `SKIP` label in output regardless of which `--include-pass` form is used.
- `agents/dev_orchestration.md` gains a "Per-test outcome filters" section, a task-relevance validation example (`--include-pass 'MyFeatureTest'`), and PASS/SKIP rows in the outcome vocabulary table.

## Test plan

- [x] `python3 scripts/test_ci_monitor.py` passes (128 tests, 0 failed)
- [x] New test group (r): `parse_fails()` default behavior, `--no-include-fail`, `--no-include-skip`, `--include-pass` with and without pattern, `--include-fail` pattern, `--include-skip` pattern, SKIP label preservation
- [x] New test group (s): `_parse_outcome_filters()` for all six flag combinations; `main()` end-to-end with `--include-pass ''`, no flags, `--no-include-fail`, `--no-include-skip`

---
_Generated by [Claude Code](https://claude.ai/code/session_014d7X7nZrANe4xhvXyFVA5U)_