### PR TITLE
Remove ci and for-ai-to-do labels from auto-filed test-failure issues

### DIFF
--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -217,7 +217,7 @@ def _github_headers(token: str) -> dict[str, str]:
     }
 
 
-LABELS = ["test-failure", "ci", "for ai to do"]
+LABELS = ["test-failure"]
 
 
 def find_existing_issue(

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -437,9 +437,7 @@ class TestCreateIssue(unittest.TestCase):
         ftfi.create_issue("token", "owner/repo", "Title", "Body")
         call_kwargs = mock_requests.post.call_args
         payload = call_kwargs[1]["json"]
-        self.assertIn("test-failure", payload["labels"])
-        self.assertIn("ci", payload["labels"])
-        self.assertIn("for ai to do", payload["labels"])
+        self.assertEqual(["test-failure"], payload["labels"])
 
 
 class TestAddIssueComment(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Removes `"ci"` and `"for ai to do"` from `LABELS` in `scripts/file_test_failure_issues.py`, leaving only `["test-failure"]`.
- Updates `test_sends_correct_labels` to assert the correct new label list.

Modified test `test_sends_correct_labels` to expect only `["test-failure"]`, because the `"ci"` and `"for ai to do"` labels are no longer applied to auto-filed issues.

Fixes #295

---
_Generated by [Claude Code](https://claude.ai/code/session_018iBAbk3JWQLsVKaAnRHRs1)_