### PR TITLE
Wire six dormant instrumented test classes into CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,6 +378,19 @@ jobs:
           path: results/e2e-gallery.ndjson
           retention-days: 14
 
+      - name: Copy E2E test results
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        continue-on-error: true
+        run: |
+          # The E2E Gradle task writes TEST-com.gb4pc.e2e.*.xml into the shared
+          # connected/debug directory (alongside the earlier standard results).
+          # Snapshot only the E2E XML into a dedicated directory so the summary
+          # and issue-filing pipelines see E2E results without the standard ones
+          # mixed in.
+          mkdir -p app/build/outputs/androidTest-results/e2e
+          cp -r app/build/outputs/androidTest-results/connected/debug/TEST-com.gb4pc.e2e.*.xml \
+            app/build/outputs/androidTest-results/e2e/
+
       - name: Pull and upload E2E screenshots on failure
         id: pull_e2e_screenshots
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && (steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure')
@@ -406,7 +419,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: e2e-test-results
-          path: app/build/outputs/androidTest-results/connected/
+          path: app/build/outputs/androidTest-results/e2e/
           retention-days: 14
 
       - name: OCR on E2E screenshots
@@ -431,7 +444,9 @@ jobs:
             app/build/test-results/testDebugUnitTest \
               --suite-label "Unit Tests" \
             app/build/outputs/androidTest-results/standard \
-              --suite-label "Standard Instrumented Tests"
+              --suite-label "Standard Instrumented Tests" \
+            app/build/outputs/androidTest-results/e2e \
+              --suite-label "E2E Tests"
 
   file-issues:
     needs: [build-and-test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,20 +309,20 @@ jobs:
             -a android.media.action.STILL_IMAGE_CAMERA \
             -p com.google.android.GoogleCamera 2>/dev/null || true
 
-      - name: Run standard instrumented tests
+      - name: Run instrumented tests
         # Failures auto-tracked as issues. continue-on-error lets subsequent steps run even on failure.
         id: run_instrumented
         if: steps.diff_check.outputs.needs_full_build == 'true'
         continue-on-error: true
         run: ./gradlew connectedDebugAndroidTest
 
-      - name: Copy standard instrumented test results
+      - name: Copy instrumented test results
         if: steps.diff_check.outputs.needs_full_build == 'true'
         continue-on-error: true
         run: |
-          mkdir -p app/build/outputs/androidTest-results/standard
+          mkdir -p app/build/outputs/androidTest-results/instrumented
           cp -r app/build/outputs/androidTest-results/connected/debug/. \
-            app/build/outputs/androidTest-results/standard/
+            app/build/outputs/androidTest-results/instrumented/
 
       - name: Run PixelCameraOverlayE2ETest
         # Failures auto-tracked as issues. continue-on-error lets subsequent steps run even on failure.
@@ -383,10 +383,10 @@ jobs:
         continue-on-error: true
         run: |
           # The E2E Gradle task writes TEST-com.gb4pc.e2e.*.xml into the shared
-          # connected/debug directory (alongside the earlier standard results).
+          # connected/debug directory (alongside the earlier instrumented results).
           # Snapshot only the E2E XML into a dedicated directory so the summary
-          # and issue-filing pipelines see E2E results without the standard ones
-          # mixed in.
+          # and issue-filing pipelines see E2E results without the instrumented
+          # ones mixed in.
           mkdir -p app/build/outputs/androidTest-results/e2e
           cp -r app/build/outputs/androidTest-results/connected/debug/TEST-com.gb4pc.e2e.*.xml \
             app/build/outputs/androidTest-results/e2e/
@@ -406,12 +406,12 @@ jobs:
           $ANDROID_HOME/platform-tools/adb emu kill 2>/dev/null || true
           [[ -n "${EMULATOR_PID:-}" ]] && kill "$EMULATOR_PID" 2>/dev/null || true
 
-      - name: Upload standard instrumented test results
+      - name: Upload instrumented test results
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: instrumented-test-results
-          path: app/build/outputs/androidTest-results/standard/
+          path: app/build/outputs/androidTest-results/instrumented/
           retention-days: 14
 
       - name: Upload E2E test results
@@ -443,8 +443,8 @@ jobs:
           python3 scripts/summarize_test_results.py \
             app/build/test-results/testDebugUnitTest \
               --suite-label "Unit Tests" \
-            app/build/outputs/androidTest-results/standard \
-              --suite-label "Standard Instrumented Tests" \
+            app/build/outputs/androidTest-results/instrumented \
+              --suite-label "Instrumented Tests" \
             app/build/outputs/androidTest-results/e2e \
               --suite-label "E2E Tests"
 
@@ -472,7 +472,7 @@ jobs:
           path: downloaded-artifacts/e2e-test-results
         continue-on-error: true
 
-      - name: Download standard instrumented test results
+      - name: Download instrumented test results
         uses: actions/download-artifact@v7
         with:
           name: instrumented-test-results
@@ -492,10 +492,10 @@ jobs:
           python3 scripts/file_test_failure_issues.py \
             downloaded-artifacts/unit-test-results \
               --suite-label "Unit Tests" \
-            downloaded-artifacts/e2e-test-results \
-              --suite-label "Instrumented Tests" \
             downloaded-artifacts/instrumented-test-results \
-              --suite-label "Standard Instrumented Tests"
+              --suite-label "Instrumented Tests" \
+            downloaded-artifacts/e2e-test-results \
+              --suite-label "E2E Tests"
 
   # Produce a signed release-config APK on every merge to main for easy sideloading.
   # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,6 +318,7 @@ jobs:
 
       - name: Copy standard instrumented test results
         if: steps.diff_check.outputs.needs_full_build == 'true'
+        continue-on-error: true
         run: |
           mkdir -p app/build/outputs/androidTest-results/standard
           cp -r app/build/outputs/androidTest-results/connected/debug/. \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,20 @@ jobs:
             -a android.media.action.STILL_IMAGE_CAMERA \
             -p com.google.android.GoogleCamera 2>/dev/null || true
 
+      - name: Run standard instrumented tests
+        # Failures auto-tracked as issues. continue-on-error lets subsequent steps run even on failure.
+        id: run_instrumented
+        if: steps.diff_check.outputs.needs_full_build == 'true'
+        continue-on-error: true
+        run: ./gradlew connectedDebugAndroidTest
+
+      - name: Copy standard instrumented test results
+        if: steps.diff_check.outputs.needs_full_build == 'true'
+        run: |
+          mkdir -p app/build/outputs/androidTest-results/standard
+          cp -r app/build/outputs/androidTest-results/connected/debug/. \
+            app/build/outputs/androidTest-results/standard/
+
       - name: Run PixelCameraOverlayE2ETest
         # Failures auto-tracked as issues. continue-on-error lets subsequent steps run even on failure.
         id: run_overlay_e2e
@@ -378,12 +392,20 @@ jobs:
           $ANDROID_HOME/platform-tools/adb emu kill 2>/dev/null || true
           [[ -n "${EMULATOR_PID:-}" ]] && kill "$EMULATOR_PID" 2>/dev/null || true
 
+      - name: Upload standard instrumented test results
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: instrumented-test-results
+          path: app/build/outputs/androidTest-results/standard/
+          retention-days: 14
+
       - name: Upload E2E test results
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-test-results
-          path: app/build/outputs/androidTest-results/
+          path: app/build/outputs/androidTest-results/connected/
           retention-days: 14
 
       - name: OCR on E2E screenshots
@@ -408,7 +430,9 @@ jobs:
             app/build/test-results/testDebugUnitTest \
               --suite-label "Unit Tests" \
             app/build/outputs/androidTest-results/connected/debug \
-              --suite-label "Instrumented Tests"
+              --suite-label "Instrumented Tests" \
+            app/build/outputs/androidTest-results/standard \
+              --suite-label "Standard Instrumented Tests"
 
   file-issues:
     needs: [build-and-test]
@@ -434,6 +458,13 @@ jobs:
           path: downloaded-artifacts/e2e-test-results
         continue-on-error: true
 
+      - name: Download standard instrumented test results
+        uses: actions/download-artifact@v7
+        with:
+          name: instrumented-test-results
+          path: downloaded-artifacts/instrumented-test-results
+        continue-on-error: true
+
       - name: File issues for failed tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -448,7 +479,9 @@ jobs:
             downloaded-artifacts/unit-test-results \
               --suite-label "Unit Tests" \
             downloaded-artifacts/e2e-test-results \
-              --suite-label "Instrumented Tests"
+              --suite-label "Instrumented Tests" \
+            downloaded-artifacts/instrumented-test-results \
+              --suite-label "Standard Instrumented Tests"
 
   # Produce a signed release-config APK on every merge to main for easy sideloading.
   # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,8 +430,6 @@ jobs:
           python3 scripts/summarize_test_results.py \
             app/build/test-results/testDebugUnitTest \
               --suite-label "Unit Tests" \
-            app/build/outputs/androidTest-results/connected/debug \
-              --suite-label "Instrumented Tests" \
             app/build/outputs/androidTest-results/standard \
               --suite-label "Standard Instrumented Tests"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
         versionName = findProperty("versionName") as String? ?: "dev"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        // Exclude E2E tests from the standard instrumented-test run.
+        // Exclude E2E tests from the instrumented-test run.
         // E2E tests live in com.gb4pc.e2e and require a device with Pixel Camera installed.
         // Run them separately with: ./gradlew connectedE2EAndroidTest
         testInstrumentationRunnerArguments["notPackage"] = "com.gb4pc.e2e"

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -421,6 +421,8 @@ def _artifact_name_for_label(label: str) -> str:
     label_lower = label.lower()
     if "unit" in label_lower:
         return "unit-test-results"
+    if "standard" in label_lower:          # must precede the e2e/instrumented branch
+        return "instrumented-test-results"
     if "instrumented" in label_lower or "e2e" in label_lower:
         return "e2e-test-results"
     return label.lower().replace(" ", "-")

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -6,8 +6,9 @@ comments on) a GitHub issue for every failing test case.
 
 Usage:
     python3 scripts/file_test_failure_issues.py \\
-        path/to/unit-results       --suite-label "Unit Tests" \\
-        path/to/e2e-results        --suite-label "Instrumented Tests"
+        path/to/unit-results          --suite-label "Unit Tests" \\
+        path/to/instrumented-results  --suite-label "Instrumented Tests" \\
+        path/to/e2e-results           --suite-label "E2E Tests"
 
 Each directory path must be immediately followed by --suite-label <name>.
 Exit code is always 0 — API failures are logged but do not fail the CI run.
@@ -416,16 +417,24 @@ def parse_args(argv: list[str]) -> list[tuple[Path, str]]:
     return pairs
 
 
+# Canonical suite label -> upload-artifact name. Each suite has exactly one
+# label, one artifact, and one results folder, all named consistently:
+#   "Unit Tests"         -> unit-test-results         (folder: testDebugUnitTest)
+#   "Instrumented Tests" -> instrumented-test-results (folder: androidTest-results/instrumented)
+#   "E2E Tests"          -> e2e-test-results          (folder: androidTest-results/e2e)
+_ARTIFACT_NAME_BY_LABEL = {
+    "Unit Tests": "unit-test-results",
+    "Instrumented Tests": "instrumented-test-results",
+    "E2E Tests": "e2e-test-results",
+}
+
+
 def _artifact_name_for_label(label: str) -> str:
-    """Derive the artifact name from the suite label."""
-    label_lower = label.lower()
-    if "unit" in label_lower:
-        return "unit-test-results"
-    if "standard" in label_lower:          # must precede the e2e/instrumented branch
-        return "instrumented-test-results"
-    if "instrumented" in label_lower or "e2e" in label_lower:
-        return "e2e-test-results"
-    return label.lower().replace(" ", "-")
+    """Derive the artifact name from the suite label.
+
+    Falls back to a slug of the label for any unrecognized suite.
+    """
+    return _ARTIFACT_NAME_BY_LABEL.get(label, label.lower().replace(" ", "-"))
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -7,8 +7,9 @@ back to stdout when the env var is not set).
 
 Usage:
     python3 scripts/summarize_test_results.py \\
-        path/to/unit-results       --suite-label "Unit Tests" \\
-        path/to/e2e-results        --suite-label "Instrumented Tests"
+        path/to/unit-results          --suite-label "Unit Tests" \\
+        path/to/instrumented-results  --suite-label "Instrumented Tests" \\
+        path/to/e2e-results           --suite-label "E2E Tests"
 
 Each directory path must be immediately followed by --suite-label <name>.
 Exit code is always 0 (display only; failures are surfaced by earlier steps).

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -689,25 +689,21 @@ class TestArtifactNameForLabel(unittest.TestCase):
     def test_unit_label_maps_to_unit_test_results(self):
         self.assertEqual(ftfi._artifact_name_for_label("Unit Tests"), "unit-test-results")
 
-    def test_instrumented_label_maps_to_e2e(self):
+    def test_instrumented_label_maps_to_instrumented_test_results(self):
         self.assertEqual(
-            ftfi._artifact_name_for_label("Instrumented Tests"), "e2e-test-results"
-        )
-
-    def test_e2e_label_maps_to_e2e(self):
-        self.assertEqual(ftfi._artifact_name_for_label("E2E Tests"), "e2e-test-results")
-
-    def test_standard_instrumented_label_maps_to_instrumented_test_results(self):
-        self.assertEqual(
-            ftfi._artifact_name_for_label("Standard Instrumented Tests"),
+            ftfi._artifact_name_for_label("Instrumented Tests"),
             "instrumented-test-results",
         )
 
-    def test_standard_branch_precedes_instrumented_branch(self):
-        """'Standard Instrumented Tests' must map to instrumented-test-results, not e2e."""
-        result = ftfi._artifact_name_for_label("Standard Instrumented Tests")
-        self.assertNotEqual(result, "e2e-test-results")
-        self.assertEqual(result, "instrumented-test-results")
+    def test_e2e_label_maps_to_e2e_test_results(self):
+        self.assertEqual(ftfi._artifact_name_for_label("E2E Tests"), "e2e-test-results")
+
+    def test_instrumented_and_e2e_map_to_distinct_artifacts(self):
+        """The two instrumented suites must not collide on one artifact name."""
+        self.assertNotEqual(
+            ftfi._artifact_name_for_label("Instrumented Tests"),
+            ftfi._artifact_name_for_label("E2E Tests"),
+        )
 
     def test_unknown_label_slugified(self):
         self.assertEqual(

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -699,6 +699,18 @@ class TestArtifactNameForLabel(unittest.TestCase):
     def test_e2e_label_maps_to_e2e(self):
         self.assertEqual(ftfi._artifact_name_for_label("E2E Tests"), "e2e-test-results")
 
+    def test_standard_instrumented_label_maps_to_instrumented_test_results(self):
+        self.assertEqual(
+            ftfi._artifact_name_for_label("Standard Instrumented Tests"),
+            "instrumented-test-results",
+        )
+
+    def test_standard_branch_precedes_instrumented_branch(self):
+        """'Standard Instrumented Tests' must map to instrumented-test-results, not e2e."""
+        result = ftfi._artifact_name_for_label("Standard Instrumented Tests")
+        self.assertNotEqual(result, "e2e-test-results")
+        self.assertEqual(result, "instrumented-test-results")
+
     def test_unknown_label_slugified(self):
         self.assertEqual(
             ftfi._artifact_name_for_label("My Custom Suite"), "my-custom-suite"


### PR DESCRIPTION
Fixes #265

The app's standard instrumented tests (the `androidTest` classes outside the `com.gb4pc.e2e` package, such as `MainActivityTest`, `SetupActivityTest`, `PickerActivityTest`, `ThemeTest`, and `SessionTrackerIntegrationTest`) were never executed in CI.
Only the E2E tests ran via `connectedE2EAndroidTest`.
This PR runs `connectedDebugAndroidTest` and wires its results into the existing artifact, summary, and issue-filing pipeline.

The change also establishes a consistent three-tier naming scheme across labels, artifacts, and result folders: `Unit Tests`, `Instrumented Tests`, and `E2E Tests`.

## What changed

**`.github/workflows/build.yml`**

- Adds a `Run instrumented tests` step (`connectedDebugAndroidTest`, `continue-on-error: true`) on the already-booted AVD, so no extra emulator boot is needed.
- Adds a `Copy instrumented test results` step that snapshots `connected/debug/` into a dedicated `androidTest-results/instrumented/` directory immediately after the run, before the E2E tasks write into the same shared directory.
- Adds a `Copy E2E test results` step that snapshots only the E2E XML (`TEST-com.gb4pc.e2e.*.xml`) into `androidTest-results/e2e/`, so the instrumented and E2E results stay separated.
- Adds an `Upload instrumented test results` step, uploading `androidTest-results/instrumented/` as a new `instrumented-test-results` artifact.
- Narrows the existing `Upload E2E test results` path from `androidTest-results/` to `androidTest-results/e2e/`, so the `e2e-test-results` and `instrumented-test-results` artifacts are mutually exclusive.
- Extends the summary and issue-filing invocations to pass all three tiers with their canonical labels: `Unit Tests`, `Instrumented Tests`, and `E2E Tests`.

**`scripts/file_test_failure_issues.py`**

- Replaces the substring-matching `_artifact_name_for_label` with an explicit label-to-artifact map, so `Instrumented Tests` maps to `instrumented-test-results` and `E2E Tests` maps to `e2e-test-results` (previously both collapsed onto `e2e-test-results`).
Unknown labels still fall back to a slug of the label.

**`scripts/summarize_test_results.py`**

- Updates the usage docstring to reflect the three-tier label scheme.

**`scripts/test_file_test_failure_issues.py`**

- Updates the `_artifact_name_for_label` tests for the new mapping and adds a test asserting the instrumented and E2E suites resolve to distinct artifacts.

**`app/build.gradle.kts`**

- Clarifies the comment on the `notPackage = com.gb4pc.e2e` instrumentation argument that keeps E2E tests out of the standard instrumented run.