### PR TITLE
Fix adb shell date quoting so busybox receives a single argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
-          LOGCAT_SINCE=$("$ADB" shell date +'%m-%d %H:%M:%S.000')
+          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'")
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.PixelCameraOverlayE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-overlay.ndjson) || {
@@ -345,7 +345,7 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
-          LOGCAT_SINCE=$("$ADB" shell date +'%m-%d %H:%M:%S.000')
+          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'")
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.GalleryButtonVisualE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-gallery.ndjson) || {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
-          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'")
+          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.PixelCameraOverlayE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-overlay.ndjson) || {
@@ -345,7 +345,7 @@ jobs:
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p results
           set -o pipefail
-          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'")
+          LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')
           ./gradlew connectedE2EAndroidTest \
             -Pe2eClass=com.gb4pc.e2e.GalleryButtonVisualE2ETest \
             | tee >(grep '^##GB4PC_TEST##' > results/e2e-gallery.ndjson) || {


### PR DESCRIPTION
The format string '+%m-%d %H:%M:%S.000' contains a space. Passing it as
a bare argument to 'adb shell date' causes the device shell to split it
into two tokens, giving busybox date two arguments and triggering
"Max 1 argument". Quoting the entire command inside double quotes means
adb shell passes the string to the device sh as-is, which then gives
date a single quoted argument.

Fixes #307

https://claude.ai/code/session_01MsQvwKA11rxct9wjZh5CtE