### PR TITLE
Render skipped test suites as skipped, not green, in the CI summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -459,8 +459,10 @@ jobs:
               --suite-label "Unit Tests" \
             app/build/outputs/androidTest-results/instrumented \
               --suite-label "Instrumented Tests" \
+              --outcome "${{ steps.run_instrumented.outcome }}" \
             app/build/outputs/androidTest-results/e2e \
-              --suite-label "E2E Tests"
+              --suite-label "E2E Tests" \
+              --outcome "${{ (steps.run_overlay_e2e.outcome == 'skipped' && steps.run_gallery_e2e.outcome == 'skipped') && 'skipped' || ((steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure') && 'failure' || 'success') }}"
 
       # Single authority on whether the test phase passed (issue #309). Replaces
       # the old blanket `continue-on-error` on the test steps: any failing test

--- a/.github/workflows/simulate-preflight-failure.yml
+++ b/.github/workflows/simulate-preflight-failure.yml
@@ -1,0 +1,81 @@
+name: Simulate pre-flight failure
+
+# Manually-triggered regression check for issue #255: when a pre-flight failure
+# implicitly skips the test phase, the test-result summary must report SKIPPED
+# rather than a misleading "all green" / "no test results found" outcome.
+#
+# This workflow reproduces production's *implicit* skip mechanism: a failed
+# preflight step puts the job into a failed state, which skips all subsequent
+# non-`always()` steps (the same mechanism by which build.yml's test steps are
+# skipped). It does NOT use an explicit `if` guard on the test steps.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  simulate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Fails the job (no continue-on-error), so every subsequent step that is
+      # not marked `if: always()` is implicitly skipped.
+      - name: Pre-flight check
+        id: preflight
+        run: exit 1
+
+      # The three simulated test steps below carry NO `if` guard. They are
+      # implicitly skipped because the job is already in a failed state. This
+      # mirrors build.yml, whose real test steps are gated only on
+      # `needs_full_build`, not on the preflight outcome.
+      - name: Run instrumented tests
+        id: run_instrumented
+        run: echo "instrumented tests ran"
+
+      - name: Run PixelCameraOverlayE2ETest
+        id: run_overlay_e2e
+        run: echo "overlay e2e ran"
+
+      - name: Run GalleryButtonVisualE2ETest
+        id: run_gallery_e2e
+        run: echo "gallery e2e ran"
+
+      # DRIFT NOTE: the summarize_test_results.py invocation below is a copy of
+      # build.yml's "Write test-result summary" step and must be kept in sync
+      # with it (e.g. if a fourth suite is added, or the E2E outcome expression
+      # changes). It is pointed at guaranteed-absent result directories so the
+      # summary reflects the skipped outcomes, and its output is tee'd to
+      # /tmp/summary.md for the assertion step to read.
+      - name: Write test-result summary
+        if: always()
+        run: |
+          env -u GITHUB_STEP_SUMMARY python3 scripts/summarize_test_results.py \
+            /nonexistent/unit \
+              --suite-label "Unit Tests" \
+            /nonexistent/instrumented \
+              --suite-label "Instrumented Tests" \
+              --outcome "${{ steps.run_instrumented.outcome }}" \
+            /nonexistent/e2e \
+              --suite-label "E2E Tests" \
+              --outcome "${{ (steps.run_overlay_e2e.outcome == 'skipped' && steps.run_gallery_e2e.outcome == 'skipped') && 'skipped' || ((steps.run_overlay_e2e.outcome == 'failure' || steps.run_gallery_e2e.outcome == 'failure') && 'failure' || 'success') }}" \
+            | tee /tmp/summary.md
+
+      - name: Assert summary reports SKIPPED, not green
+        if: always()
+        run: |
+          echo "=== Captured summary ==="
+          cat /tmp/summary.md
+          echo "========================"
+          if ! grep -qF "⏭ SKIPPED" /tmp/summary.md; then
+            echo "FAIL: summary did not report '⏭ SKIPPED' for the skipped test phase."
+            exit 1
+          fi
+          if sed -n '/### Instrumented Tests/,$p' /tmp/summary.md | grep -qF "_No test results found._"; then
+            echo "FAIL: summary contains misleading '_No test results found._'."
+            exit 1
+          fi
+          echo "PASS: summary correctly reports the skipped test phase as SKIPPED."

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -8,10 +8,16 @@ back to stdout when the env var is not set).
 Usage:
     python3 scripts/summarize_test_results.py \\
         path/to/unit-results          --suite-label "Unit Tests" \\
-        path/to/instrumented-results  --suite-label "Instrumented Tests" \\
-        path/to/e2e-results           --suite-label "E2E Tests"
+        path/to/instrumented-results  --suite-label "Instrumented Tests" --outcome failure \\
+        path/to/e2e-results           --suite-label "E2E Tests"        --outcome skipped
 
-Each directory path must be immediately followed by --suite-label <name>.
+Each directory path must be immediately followed by --suite-label <name>, with
+an optional trailing --outcome <value> carrying the GitHub Actions step outcome
+for the step that produced those results.  When a step was skipped (for example
+because a CI pre-flight failure skipped the whole test phase) it leaves no JUnit
+XML behind; reporting that empty suite as "no results" reads as if nothing was
+wrong, so the outcome lets the summary render it as skipped instead.
+
 Exit code is always 0 (display only; failures are surfaced by earlier steps).
 """
 
@@ -41,6 +47,19 @@ class TestClass:
     @property
     def any_failed(self) -> bool:
         return any(not tc.passed and not tc.skipped for tc in self.cases)
+
+
+@dataclass(frozen=True)
+class SuiteSpec:
+    """One test suite to summarize: where its results live and how its step fared."""
+    directory: Path
+    label: str
+    # The GitHub Actions step ``outcome`` for the step that produced these
+    # results (``success``, ``failure``, ``skipped`` or empty/unknown). When a
+    # step is ``skipped`` (e.g. a CI pre-flight failure skipped the whole test
+    # phase) it writes no JUnit XML, so the suite is rendered as skipped rather
+    # than as an empty/green "no results" suite. Empty means "outcome unknown".
+    outcome: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -91,13 +110,25 @@ def parse_directory(directory: Path) -> dict[str, TestClass]:
 # Markdown rendering
 # ---------------------------------------------------------------------------
 
-def render_suite(label: str, classes: dict[str, TestClass]) -> list[str]:
-    """Render one suite as Markdown lines (header + table rows + totals)."""
+def render_suite(label: str, classes: dict[str, TestClass], outcome: str = "") -> list[str]:
+    """Render one suite as Markdown lines (header + table rows + totals).
+
+    *outcome* is the GitHub Actions step outcome for the step that produced
+    these results.  When it is ``skipped`` and there are no results, the suite
+    is rendered as skipped rather than as an empty "no results" suite, so a
+    skipped test phase (e.g. after a pre-flight failure) never reads as green.
+    """
     lines: list[str] = []
     lines.append(f"### {label}")
 
     if not classes:
-        lines.append("_No test results found._")
+        if outcome == "skipped":
+            lines.append(
+                "⏭ SKIPPED -- the test step did not run "
+                "(e.g. a pre-flight failure skipped the test phase)."
+            )
+        else:
+            lines.append("_No test results found._")
         lines.append("")
         return lines
 
@@ -137,11 +168,15 @@ def render_suite(label: str, classes: dict[str, TestClass]) -> list[str]:
     return lines
 
 
-def build_markdown(suite_data: list[tuple[str, dict[str, TestClass]]]) -> str:
-    """Build the full Markdown document for all suites."""
+def build_markdown(suite_data: list[tuple[str, dict[str, TestClass], str]]) -> str:
+    """Build the full Markdown document for all suites.
+
+    Each suite tuple is ``(label, classes, outcome)`` where *outcome* is the
+    GitHub Actions step outcome (empty when unknown).
+    """
     lines: list[str] = ["## Test Results", ""]
-    for label, classes in suite_data:
-        lines.extend(render_suite(label, classes))
+    for label, classes, outcome in suite_data:
+        lines.extend(render_suite(label, classes, outcome))
     return "\n".join(lines)
 
 
@@ -151,14 +186,16 @@ def build_markdown(suite_data: list[tuple[str, dict[str, TestClass]]]) -> str:
 
 _USAGE = (
     "usage: summarize_test_results.py "
-    "<dir> --suite-label <name> [<dir> --suite-label <name> ...]"
+    "<dir> --suite-label <name> [--outcome <value>] "
+    "[<dir> --suite-label <name> [--outcome <value>] ...]"
 )
 
 
-def parse_args(argv: list[str]) -> list[tuple[Path, str]]:
-    """Parse argv into a list of (directory, label) pairs.
+def parse_args(argv: list[str]) -> list[SuiteSpec]:
+    """Parse argv into a list of SuiteSpec.
 
-    Expected pattern: <dir> --suite-label <name> [<dir> --suite-label <name> ...]
+    Each suite is ``<dir> --suite-label <name>`` with an optional trailing
+    ``--outcome <value>`` carrying the GitHub Actions step outcome.
 
     Raises SystemExit(2) on bad input (matching argparse convention).
     """
@@ -167,37 +204,42 @@ def parse_args(argv: list[str]) -> list[tuple[Path, str]]:
         print(_USAGE)
         raise SystemExit(0)
 
-    pairs: list[tuple[Path, str]] = []
+    specs: list[SuiteSpec] = []
     tokens = list(argv)
     i = 0
     while i < len(tokens):
         directory = tokens[i]
         # We need tokens[i], tokens[i+1], and tokens[i+2] to all be present.
-        if i + 3 > len(tokens):
+        if i + 3 > len(tokens) or tokens[i + 1] != "--suite-label":
             print(
                 f"error: expected --suite-label <name> after '{directory}'\n{_USAGE}",
                 file=sys.stderr,
             )
             raise SystemExit(2)
-        flag = tokens[i + 1]
         label = tokens[i + 2]
-        if flag != "--suite-label":
-            print(
-                f"error: expected --suite-label after '{directory}', got '{flag}'\n{_USAGE}",
-                file=sys.stderr,
-            )
-            raise SystemExit(2)
-        pairs.append((Path(directory), label))
         i += 3
 
-    if not pairs:
+        outcome = ""
+        if i < len(tokens) and tokens[i] == "--outcome":
+            if i + 1 >= len(tokens):
+                print(
+                    f"error: --outcome requires a value (suite '{label}')\n{_USAGE}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+            outcome = tokens[i + 1]
+            i += 2
+
+        specs.append(SuiteSpec(Path(directory), label, outcome))
+
+    if not specs:
         print(
-            f"error: at least one <directory> --suite-label <name> pair is required\n{_USAGE}",
+            f"error: at least one <directory> --suite-label <name> spec is required\n{_USAGE}",
             file=sys.stderr,
         )
         raise SystemExit(2)
 
-    return pairs
+    return specs
 
 
 # ---------------------------------------------------------------------------
@@ -208,23 +250,24 @@ def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
-    pairs = parse_args(argv)
+    specs = parse_args(argv)
 
-    suite_data: list[tuple[str, dict[str, TestClass]]] = []
-    for directory, label in pairs:
+    suite_data: list[tuple[str, dict[str, TestClass], str]] = []
+    for spec in specs:
+        directory = spec.directory
         if not directory.exists():
             print(
                 f"Note: result directory not found, skipping: {directory}",
                 file=sys.stderr,
             )
-            suite_data.append((label, {}))
+            suite_data.append((spec.label, {}, spec.outcome))
             continue
         if not directory.is_dir():
             print(
                 f"Note: path is not a directory, skipping: {directory}",
                 file=sys.stderr,
             )
-            suite_data.append((label, {}))
+            suite_data.append((spec.label, {}, spec.outcome))
             continue
 
         classes = parse_directory(directory)
@@ -233,7 +276,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"Note: no TEST-*.xml files found in {directory}",
                 file=sys.stderr,
             )
-        suite_data.append((label, classes))
+        suite_data.append((spec.label, classes, spec.outcome))
 
     markdown = build_markdown(suite_data)
 

--- a/scripts/test_summarize_preflight_integration.sh
+++ b/scripts/test_summarize_preflight_integration.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# test_summarize_preflight_integration.sh — Integration test for
+# summarize_test_results.py exercised through the exact multi-suite CLI
+# argument shape that build.yml's "Write test-result summary" step passes.
+#
+# The Python logic itself is covered by test_summarize_test_results.py; the
+# novel value here is invoking the summarizer with the three-suite,
+# --outcome-bearing argument vector that CI uses, confirming that a skipped
+# test phase (e.g. after a pre-flight failure) renders as SKIPPED rather than
+# as a misleading "no test results found" suite (issue #255).
+#
+# Covers:
+#   (A) Direct CLI invocation in the three-suite shape build.yml uses
+#   (B) The GITHUB_STEP_SUMMARY write path
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUMMARIZER="$SCRIPT_DIR/summarize_test_results.py"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# ── (A) Direct CLI invocation in the three-suite shape build.yml uses ─────────
+echo ""
+echo "=== (A) Direct CLI invocation in the three-suite shape build.yml uses ==="
+
+# The Unit Tests suite is passed with no --outcome, exactly as build.yml does;
+# with no XML it renders "_No test results found._". The skipped-suite contract
+# of issue #255 concerns the suites whose steps were skipped (Instrumented and
+# E2E, passed --outcome "skipped"), so the negative assertion below is scoped to
+# the SKIPPED-suite portion of the output rather than the whole document.
+# Run with GITHUB_STEP_SUMMARY unset so the summarizer prints to stdout. In CI
+# that variable is always set, which would otherwise divert the rendered
+# markdown to a file and leave $OUTPUT empty.
+OUTPUT=$(env -u GITHUB_STEP_SUMMARY python3 "$SUMMARIZER" \
+    /nonexistent/unit         --suite-label "Unit Tests" \
+    /nonexistent/instrumented --suite-label "Instrumented Tests" \
+                              --outcome "skipped" \
+    /nonexistent/e2e          --suite-label "E2E Tests" \
+                              --outcome "skipped")
+
+# Portion of the output from the first skipped suite onward.
+SKIPPED_PORTION=$(echo "$OUTPUT" | sed -n '/### Instrumented Tests/,$p')
+
+if echo "$OUTPUT" | grep -qF "⏭ SKIPPED"; then
+  pass "output contains '⏭ SKIPPED'"
+else
+  fail "output missing '⏭ SKIPPED': '$OUTPUT'"
+fi
+
+if echo "$SKIPPED_PORTION" | grep -qF "_No test results found._"; then
+  fail "skipped suites contain misleading '_No test results found._': '$OUTPUT'"
+else
+  pass "skipped suites do not contain '_No test results found._'"
+fi
+
+# ── (B) GITHUB_STEP_SUMMARY write path ────────────────────────────────────────
+echo ""
+echo "=== (B) GITHUB_STEP_SUMMARY write path ==="
+
+SUMMARY_FILE="$TMPDIR_TESTS/step_summary.md"
+: > "$SUMMARY_FILE"
+
+GITHUB_STEP_SUMMARY="$SUMMARY_FILE" python3 "$SUMMARIZER" \
+    /nonexistent/unit         --suite-label "Unit Tests" \
+    /nonexistent/instrumented --suite-label "Instrumented Tests" \
+                              --outcome "skipped" \
+    /nonexistent/e2e          --suite-label "E2E Tests" \
+                              --outcome "skipped"
+
+if [[ -s "$SUMMARY_FILE" ]]; then
+  pass "GITHUB_STEP_SUMMARY file exists and is non-empty"
+else
+  fail "GITHUB_STEP_SUMMARY file missing or empty: '$SUMMARY_FILE'"
+fi
+
+if grep -qF "⏭ SKIPPED" "$SUMMARY_FILE"; then
+  pass "summary file contains '⏭ SKIPPED'"
+else
+  fail "summary file missing '⏭ SKIPPED': '$(cat "$SUMMARY_FILE")'"
+fi
+
+if sed -n '/### Instrumented Tests/,$p' "$SUMMARY_FILE" | grep -qF "_No test results found._"; then
+  fail "skipped suites in summary file contain misleading '_No test results found._'"
+else
+  pass "skipped suites in summary file do not contain '_No test results found._'"
+fi
+
+unset GITHUB_STEP_SUMMARY
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -203,6 +203,23 @@ class TestRenderSuite(unittest.TestCase):
         self.assertIn("No test results found", combined)
         self.assertNotIn("| Status |", combined)
 
+    def test_empty_suite_skipped_outcome_shows_skipped(self):
+        """When the producing step was skipped, an empty suite reads as skipped."""
+        lines = srt.render_suite("Instrumented Tests", {}, outcome="skipped")
+        combined = "\n".join(lines)
+        self.assertIn("SKIPPED", combined.upper())
+        self.assertNotIn("No test results found", combined)
+        # It must never read as if the suite passed.
+        self.assertNotIn("PASS", combined.upper())
+        self.assertNotIn("| Status |", combined)
+
+    def test_empty_suite_failure_outcome_keeps_no_results_note(self):
+        """A non-skipped outcome with no results still shows the plain note."""
+        lines = srt.render_suite("Unit Tests", {}, outcome="failure")
+        combined = "\n".join(lines)
+        self.assertIn("No test results found", combined)
+        self.assertNotIn("SKIPPED", combined.upper())
+
     def test_passing_class_shows_green(self):
         classes = {
             "com.example.Foo": srt.TestClass(
@@ -321,13 +338,21 @@ class TestBuildMarkdown(unittest.TestCase):
 
     def test_multiple_suites_appear_in_order(self):
         suite_data = [
-            ("Unit Tests", {}),
-            ("Instrumented Tests", {}),
+            ("Unit Tests", {}, ""),
+            ("Instrumented Tests", {}, ""),
         ]
         md = srt.build_markdown(suite_data)
         unit_pos = md.index("Unit Tests")
         instrumented_pos = md.index("Instrumented Tests")
         self.assertLess(unit_pos, instrumented_pos)
+
+    def test_skipped_suite_renders_skipped_not_green(self):
+        """A skipped step with no results must read as skipped, never as passing."""
+        suite_data = [("Instrumented Tests", {}, "skipped")]
+        md = srt.build_markdown(suite_data)
+        self.assertIn("SKIPPED", md.upper())
+        self.assertNotIn("PASS", md.upper())
+        self.assertNotIn("No test results found", md)
 
 
 # ---------------------------------------------------------------------------
@@ -337,18 +362,19 @@ class TestBuildMarkdown(unittest.TestCase):
 class TestParseArgs(unittest.TestCase):
 
     def test_single_pair(self):
-        pairs = srt.parse_args(["path/to/unit", "--suite-label", "Unit Tests"])
-        self.assertEqual(len(pairs), 1)
-        self.assertEqual(pairs[0][0], Path("path/to/unit"))
-        self.assertEqual(pairs[0][1], "Unit Tests")
+        specs = srt.parse_args(["path/to/unit", "--suite-label", "Unit Tests"])
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0].directory, Path("path/to/unit"))
+        self.assertEqual(specs[0].label, "Unit Tests")
+        self.assertEqual(specs[0].outcome, "")
 
     def test_two_pairs(self):
-        pairs = srt.parse_args([
+        specs = srt.parse_args([
             "dir1", "--suite-label", "Label1",
             "dir2", "--suite-label", "Label2",
         ])
-        self.assertEqual(len(pairs), 2)
-        self.assertEqual(pairs[1][1], "Label2")
+        self.assertEqual(len(specs), 2)
+        self.assertEqual(specs[1].label, "Label2")
 
     def test_missing_suite_label_flag_raises(self):
         with self.assertRaises(SystemExit):
@@ -362,6 +388,26 @@ class TestParseArgs(unittest.TestCase):
         # directory without --suite-label following
         with self.assertRaises(SystemExit):
             srt.parse_args(["dir1"])
+
+    def test_outcome_parsed_when_present(self):
+        specs = srt.parse_args([
+            "dir1", "--suite-label", "Label1", "--outcome", "skipped",
+        ])
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0].outcome, "skipped")
+
+    def test_outcome_optional_between_suites(self):
+        specs = srt.parse_args([
+            "dir1", "--suite-label", "Label1", "--outcome", "failure",
+            "dir2", "--suite-label", "Label2",
+        ])
+        self.assertEqual(len(specs), 2)
+        self.assertEqual(specs[0].outcome, "failure")
+        self.assertEqual(specs[1].outcome, "")
+
+    def test_outcome_without_value_raises(self):
+        with self.assertRaises(SystemExit):
+            srt.parse_args(["dir1", "--suite-label", "Label1", "--outcome"])
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +450,25 @@ class TestMain(unittest.TestCase):
         missing = self.tmpdir / "nonexistent"
         result = srt.main([str(missing), "--suite-label", "Unit"])
         self.assertEqual(result, 0)
+
+    def test_skipped_step_renders_skipped_not_green(self):
+        """End to end: a skipped test step (no XML) reports skipped, not green.
+
+        Reproduces issue #255: a pre-flight failure skips the test phase, the
+        result directory is absent, and the summary previously read as if the
+        suite had run.  With --outcome skipped it must read as skipped.
+        """
+        missing = self.tmpdir / "nonexistent"
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            result = srt.main([
+                str(missing), "--suite-label", "Instrumented Tests",
+                "--outcome", "skipped",
+            ])
+        self.assertEqual(result, 0)
+        output = captured.getvalue()
+        self.assertIn("SKIPPED", output.upper())
+        self.assertNotIn("PASS", output.upper())
 
     def test_writes_to_github_step_summary(self):
         _write_xml(self.tmpdir, "TEST-foo.xml", PASSING_XML)


### PR DESCRIPTION
Fixes #255.

## Problem

When the CI pre-flight check fails, GitHub Actions skips the test steps (they have no `if: always()`), so those steps write no JUnit XML.
The "Write test-result summary" step still runs (`if: always()`) and calls `summarize_test_results.py` against the now-empty/absent result directories.
The summarizer rendered such empty suites with a neutral "_No test results found._" note that did not convey that the tests never ran, so the build-and-test job summary did not surface the skipped state.

Scope: this PR addresses only the misleading summary. The pre-flight failure itself is out of scope (tracked by #256).

## Fix

- Thread each producing step's GitHub Actions `outcome` through the summarizer via an optional `--outcome` flag, mirroring the existing `SuiteSpec` / `--outcome` pattern already used by `check_allowed_failures.py` (issue #309).
- When a suite has no results and its step `outcome` was `skipped`, the summary now renders the suite as `SKIPPED` (explaining the test step did not run) instead of as a plain no-results note. A skipped test phase can no longer read as green.
- Wire the workflow's "Write test-result summary" step to pass the instrumented and E2E step outcomes (using the step-level `steps.<id>.outcome` context, which reports `skipped` when the step never ran).

`parse_args` now returns `SuiteSpec` objects instead of `(dir, label)` tuples; the existing `parse_args` tests were updated to read the new attributes (no requirement was loosened).

## Tests

- New unit tests cover: `--outcome` parsing (present, optional between suites, missing-value error), `render_suite` rendering skipped vs. no-results, `build_markdown` for a skipped suite, and an end-to-end `main()` test reproducing the issue #255 scenario (missing directory + `--outcome skipped`) that asserts the output reads as skipped and never as passing.
- `scripts/test_summarize_preflight_integration.sh`: a shell integration test that runs the summarizer with skipped suites and asserts the rendered summary reports SKIPPED (and not the no-results note). It captures the rendered output with `env -u GITHUB_STEP_SUMMARY` so it works both locally and under CI (where `GITHUB_STEP_SUMMARY` is set).
- `.github/workflows/simulate-preflight-failure.yml`: a standalone regression workflow that reproduces the implicit preflight-skip summary scenario.
- Local run: full `python3 -m unittest discover -s scripts -p "test_*.py"` passes (179 tests). Both workflow YAMLs validated.