### PR TITLE
Make the Reviewer verdict binary: LGTM or Changes requested

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -98,9 +98,8 @@ When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
-- `Approved`
+- `LGTM`
 - `Changes requested`
-- `Approved, pending: {verbatim instruction}`
 
 Orchestrator-to-user terminal CI lines:
 - `CI cleared on PR #{N}.`
@@ -137,8 +136,7 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
 
 ```
   if Reviewer requested changes → goto newAuthor
-  if Reviewer gave conditional approval → route to Author (dispatch template); then goto newReviewer (full Reviewer turn, same as changes-requested)
-  if Reviewer gave full approval:
+  if Reviewer gave LGTM:
     Orchestrator launches a Monitor tool call running `python3 scripts/ci_monitor.py --pr <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000)
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.
     Act only on the terminal lines Clear, Blocked, or Infra. Relay in_progress lines to the user as brief status updates (the script suppresses these unless no other output has been emitted for over 120 seconds).

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -13,6 +13,7 @@
   Even small errors can cause misunderstandings down the road, so don't skip "nits".
 - The Reviewer need not enforce expectations written with "should" language.
 - Although **bylines** (Claude attribution, links) are prohibited, the Reviewer must not mention them in reviews.
+- The Reviewer may mention positive aspects of the code under review, but must be blunt and brief.
 - Our agents share the User's GitHub account, so you won't use GitHub's code review features, which require separate accounts. Leave your evaluation as an ordinary comment, and tell the Orchestrator your decision. The user and other agents know to expect this.
 - **If CI results are already available** when you complete your review, you may note them in your review text, but do not block on them.
   The Orchestrator runs the CI Monitor script after you exit; you do not need to poll.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -22,18 +22,11 @@
   post review: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```
 
-- After posting your review, tell the Orchestrator your decision using the fixed decision-signal vocabulary from `dev_orchestration.md`: one of `Approved`, `Changes requested`, or `Approved, pending: {verbatim instruction}`.
+- After posting your review, tell the Orchestrator your decision using the fixed decision-signal vocabulary from `dev_orchestration.md`: one of `LGTM` or `Changes requested`.
   The Orchestrator routes this signal verbatim; it does not relay your review prose to the Author.
   The Author reads your review from GitHub directly.
 
-- A Reviewer **may** give conditional approval: an approval combined with minimal and specific instructions for the Author to take before merging.
-  - This is only appropriate when the request is unlikely to be contested.
-  - The remaining change must be simple: a single mechanical edit (rename, deletion, reword, or move) at one location, requiring no design judgment. If the remaining change is more complex than this, request changes instead so the full review cycle continues.
-  - Clearly separate the approval signal from the instruction so the Orchestrator can parse both.
-  - Phrase it unambiguously, e.g. "Approved, pending [specific change]." or "Approved, please [specific action] before merging."
-  - Do not bury the approval or the instruction inside other prose; make each a distinct sentence.
-  - After a conditional approval, the Author addresses the instruction, and then a full Reviewer turn confirms the change before the CI Monitor runs.
-    There is no shortcut; the follow-up uses the same full review cycle as a "changes requested" round.
+- Your verdict is binary: either the PR is good to merge (`LGTM`) or it needs more work (`Changes requested`). There is no middle option. If you want any change made before merge, request changes so the full review cycle continues.
 
 ## Author / Programmer
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -8,12 +8,14 @@
 
 - A *Reviewer* must not make code changes itself, but should communicate discoveries clearly enough to convince an Author of the need to change the PR.
 - A Reviewer should be explicit and fully explain any problems, but should not spend tokens to design their solutions.
-- The Reviewer may mention positive aspects of the code under review, but must be blunt and brief.
+- The Reviewer must not hold back.
+  The Reviewer may be the only one equipped to notice inconsistencies and inaccuracies.
+  Even small errors can cause misunderstandings down the road, so don't skip "nits".
 - The Reviewer need not enforce expectations written with "should" language.
-- Although **bylines** (Claude attribution, links) are prohibited, the Reviewer should not mention them in reviews.
+- Although **bylines** (Claude attribution, links) are prohibited, the Reviewer must not mention them in reviews.
 - Our agents share the User's GitHub account, so you won't use GitHub's code review features, which require separate accounts. Leave your evaluation as an ordinary comment, and tell the Orchestrator your decision. The user and other agents know to expect this.
-- **Do not wait for CI.** Review the diff, form your verdict, and post your review immediately. The Orchestrator runs the CI Monitor script after you exit; you do not need to poll.
 - **If CI results are already available** when you complete your review, you may note them in your review text, but do not block on them.
+  The Orchestrator runs the CI Monitor script after you exit; you do not need to poll.
 - **Do not return before posting your review.** Posting your review is the only valid exit condition. After forming your verdict, call the review-submission tool before stopping.
 
   Review pattern:
@@ -26,7 +28,9 @@
   The Orchestrator routes this signal verbatim; it does not relay your review prose to the Author.
   The Author reads your review from GitHub directly.
 
-- Your verdict is binary: either the PR is good to merge (`LGTM`) or it needs more work (`Changes requested`). There is no middle option. If you want any change made before merge, request changes so the full review cycle continues.
+- Your verdict is binary: either the PR is good to merge (`LGTM`) or it needs more work (`Changes requested`).
+  There is no middle option.
+  If you want any change made before merge, request changes so the full review cycle continues.
 
 ## Author / Programmer
 


### PR DESCRIPTION
Fixes #318.

Removes the conditional-approval option from the agents documentation.
The Reviewer's verdict is now binary: `LGTM` or `Changes requested`.
There is no middle option; any change the Reviewer wants before merge is requested via `Changes requested`, which continues the full review cycle.

## Changes

`agents/pr_participation.md`
- Replaced the verbose conditional-approval guidance block (when it is appropriate, the single-mechanical-edit constraints, phrasing rules, and the follow-up-cycle note) with one sentence stating the verdict is binary.
- Updated the decision-signal vocabulary the Reviewer reports to `LGTM` or `Changes requested`.

`agents/dev_orchestration.md`
- Updated the Reviewer-to-Orchestrator outcome vocabulary from three signals (`Approved`, `Changes requested`, `Approved, pending: {instruction}`) to two (`LGTM`, `Changes requested`).
- Removed the conditional-approval branch from the CI Monitor loop, so the loop now routes only on `Changes requested` (new Author round) versus `LGTM` (run the Monitor).

## Simplification unlocked

Dropping the third verdict collapses the Monitor-loop routing to a single binary branch and removes the special-case rules that governed when a conditional approval was permitted and how its follow-up round worked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvF1ZfU1ywi5V2K6bvxtBk)_