### PR TITLE
Skip Python and shell unit tests on docs-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,11 @@ jobs:
           ANDROID_AVD_HOME="$AVD_HOME" $ANDROID_HOME/emulator/emulator -list-avds
 
       - name: Run Python script unit tests
+        if: steps.diff_check.outputs.needs_full_build == 'true'
         run: python3 -m unittest discover -s scripts -p "test_*.py" -v
 
       - name: Run shell script unit tests
+        if: steps.diff_check.outputs.needs_full_build == 'true'
         run: |
           for test_script in scripts/test_*.sh; do
             echo "==> Running $test_script"


### PR DESCRIPTION
Apply the same `needs_full_build` gate that already guards every Kotlin build and test step to the "Run Python script unit tests" and "Run shell script unit tests" steps, so all test execution is skipped when a PR touches only Markdown files.

Fixes #321