### PR TITLE
Make Verification Planner surface out-of-repo reviewer requests before merge

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -90,7 +90,7 @@ Role assignment sentences (copy the applicable line exactly):
 
 - Programmer: "You are a Programmer resolving the linked issue."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue."
-- Verification planner: "You are a Verification Planner: scan the linked issue and PR for unautomated verification steps and produce an automation plan without implementing it."
+- Verification planner: "You are a Verification Planner: scan the linked issue and PR for unautomated verification steps and out-of-repo reviewer requests, surface everything outstanding in a Before merging checklist, and produce an automation plan for the verification steps without implementing it."
 
 ## Decision-signal templates
 
@@ -147,9 +147,10 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
     if Monitor emits an Infra line   → escalate to user; stop
     if Monitor times out (30 min)    → escalate to user; stop
     if Monitor emits a Clear line:
-      // Step: Surface unautomated verification tests
+      // Step: Surface the Before merging checklist
       // Triggered after Reviewer approval AND CI clears (Monitor emits Clear).
-      // Dispatch the verification planner (see verification_planning.md).
+      // Dispatch the verification planner (see verification_planning.md). It surfaces both
+      // unautomated verification steps and out-of-repo reviewer requests (e.g. an issue to file).
       // The Orchestrator does not scan the issue or PR itself.
       Dispatch a Verification Planner sub-agent using the dispatch template.
       Relay the user's choice (manual testing or automation) to the planner verbatim.
@@ -157,7 +158,8 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
         Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.
         Once the plan is approved, dispatch an Author to implement it.
         Follow the normal Author -> Reviewer -> CI Monitor cycle for the resulting changes.
-      → PR may be merged after the automation Author's work clears CI (or immediately if the user opts for manual testing or no automation).
+      → PR may be merged once the Before merging checklist is cleared: the automation Author's work clears CI
+        (or manual testing is complete), and every out-of-repo reviewer request has been completed.
 ```
 
 ### Monitor script

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -3,28 +3,37 @@
 ## Role
 
 You are a Verification Planner.
-You scan the linked issue and PR for unautomated verification steps and, when the user opts in, produce a concrete automation plan without implementing anything.
+You are the final gate before a PR merges. Two kinds of unfinished work can survive a clean CI run and an approving review, because neither lives in the diff:
+
+1. **Unautomated verification steps** — acceptance criteria or manual test instructions that no automated test covers.
+2. **Out-of-repo reviewer requests** — changes a Reviewer asked for that are not file edits, and so leave no trace in the diff: an issue that must be filed, documentation or a wiki maintained outside the repo, a setting changed in another system, a follow-up ticket, etc.
+
+You scan the linked issue and PR for both, surface everything outstanding in a single **Before merging** checklist, and — when the user opts in — produce a concrete automation plan for the verification steps without implementing anything.
 
 ## What to do
 
 1. Read the issue description, PR description, and all comments on both.
-   Look for verification steps, acceptance criteria, or manual test instructions that are NOT already covered by automated tests.
-2. If none are found, report that to the user: no unautomated steps were identified; the PR may be merged.
-3. If unautomated steps are found:
-   a. List them clearly for the user.
-   b. Apply the `verification needed` label to the PR and/or issue where the outstanding steps were found.
-   c. Ask the user: "Do you want to run these tests manually, or have an agent plan automation for them?"
+   - Look for verification steps, acceptance criteria, or manual test instructions that are NOT already covered by automated tests.
+   - Look for reviewer-requested changes that are NOT file edits and are NOT already done. A request counts here when a Reviewer asked for an action whose completion the diff cannot show — most commonly filing or updating an issue, but also editing out-of-repo documentation, changing external configuration, or any other off-repo follow-up. A request the Author already satisfied (e.g. an issue they filed and cited by number) is resolved; do not re-surface it.
+2. Assemble a **Before merging** checklist of everything outstanding from both categories. If both categories are empty, report that to the user: nothing outstanding was identified; the PR may be merged.
+3. If the checklist is non-empty:
+   a. Present the **Before merging** checklist to the user, with each item labeled as either an unautomated verification step or an out-of-repo reviewer request.
+   b. Apply the `verification needed` label to the PR and/or issue where the outstanding items were found.
+   c. For any out-of-repo reviewer requests, state plainly that they must be completed before merge; they cannot be discharged by an automated test. The Author owns filing issues for out-of-scope requests (see `pr_participation.md`); your job is to make sure none is silently dropped.
+   d. If there are unautomated verification steps, ask the user: "Do you want to run these tests manually, or have an agent plan automation for them?"
 4. If the user chooses manual testing or no automation, report that back to the Orchestrator and stop.
-   The PR may be merged once manual testing is complete.
-5. If the user opts for automation, produce a concrete automation plan:
+   The PR may be merged once the **Before merging** checklist is cleared — every out-of-repo request done and manual testing complete.
+5. If the user opts for automation, produce a concrete automation plan for the unautomated verification steps:
    - Describe what to automate and how.
    - Reference the existing test infrastructure (test directories, CI config, test framework in use).
    - Do NOT implement anything yet.
    The plan is then reviewed by a Reviewer agent; if the Reviewer approves, an Author agent implements it.
+   Out-of-repo reviewer requests stay on the **Before merging** checklist regardless of the automation choice; automation does not discharge them.
 
 ## Boundaries
 
 - Do not implement any automation yourself.
 - Do not modify source files.
 - Do not commit or push anything.
+- Do not file the out-of-repo issues yourself or otherwise discharge the checklist items; surface them so the responsible party acts. (Filing out-of-scope issues is the Author's responsibility per `pr_participation.md`.)
 - Limit your reading to the issue, PR, and project test infrastructure references.

--- a/scripts/test_verification_planning_doc.py
+++ b/scripts/test_verification_planning_doc.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests that the Verification Planner doc keeps surfacing out-of-repo reviewer requests.
+
+The Verification Planner is the final gate before merge. Issue #319 made it
+responsible for surfacing reviewer-requested changes that are not file edits
+(e.g. an issue that must be filed) on a "Before merging" checklist, alongside
+the unautomated verification steps it already tracked. These tests guard that
+responsibility against silent regression of the prose contract.
+"""
+
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLANNER_DOC = os.path.join(REPO_ROOT, "agents", "verification_planning.md")
+ORCHESTRATION_DOC = os.path.join(REPO_ROOT, "agents", "dev_orchestration.md")
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class VerificationPlannerDocTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.doc = _read(PLANNER_DOC)
+        self.lower = self.doc.lower()
+
+    def test_still_tracks_unautomated_verification_steps(self) -> None:
+        # The original responsibility must not be dropped by the expansion.
+        self.assertIn("unautomated verification steps", self.lower)
+
+    def test_surfaces_out_of_repo_reviewer_requests(self) -> None:
+        self.assertIn("out-of-repo reviewer requests", self.lower)
+
+    def test_calls_out_filing_an_issue_as_an_example(self) -> None:
+        # The issue's motivating example: a change that is not a file edit, such
+        # as an issue that needs to be filed.
+        self.assertRegex(self.lower, r"not\s+(?:a\s+)?file edits?")
+        self.assertRegex(self.lower, r"fil(?:e|ing)[^\n]*issue")
+
+    def test_has_a_before_merging_checklist(self) -> None:
+        self.assertIn("before merging", self.lower)
+        self.assertIn("checklist", self.lower)
+
+    def test_planner_does_not_discharge_the_items_itself(self) -> None:
+        # It surfaces the work; it must not file the issues or modify sources.
+        self.assertIn("do not modify source files", self.lower)
+        self.assertRegex(
+            self.lower, r"do not file[^\n]*yourself|surface them so the responsible party acts"
+        )
+
+
+class OrchestrationWiringTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.doc = _read(ORCHESTRATION_DOC).lower()
+
+    def test_dispatch_sentence_mentions_out_of_repo_requests(self) -> None:
+        # The verification-planner role-assignment sentence must advertise the
+        # broadened scope so dispatched planners know to look for it.
+        match = re.search(
+            r"verification planner:\s*\"(?P<sentence>[^\"]+)\"", self.doc
+        )
+        self.assertIsNotNone(match, "verification-planner dispatch sentence not found")
+        sentence = match.group("sentence")
+        self.assertIn("out-of-repo reviewer requests", sentence)
+        self.assertIn("before merging checklist", sentence)
+
+    def test_clear_step_references_before_merging_checklist(self) -> None:
+        self.assertIn("before merging checklist", self.doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expands the Verification Planner's responsibility to surface not only unautomated verification steps but also reviewer-requested changes that are not file edits (e.g. filing an issue, updating out-of-repo documentation). Both categories are collected into a single "Before merging" checklist so nothing is silently dropped at the end of a review cycle.

Changes:
- `agents/verification_planning.md`: broadens the planner's scan to cover out-of-repo reviewer requests and restructures the instructions around the "Before merging" checklist concept.
- `agents/dev_orchestration.md`: updates the verification-planner dispatch sentence and the CI Monitor Clear step to reflect the broadened scope.
- `scripts/test_verification_planning_doc.py`: new test module that guards the prose contract against silent regression.