### PR TITLE
Make the final validation reviewer surface changes outside the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@
 - If participating in a PR or review (as Author, Reviewer, or Orchestrator), read `./agents/pr_participation.md`.
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.
-- If scanning for or planning automation of unautomated verification steps, read `./agents/verification_planning.md`.
+- If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -145,7 +145,8 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
     if Monitor emits an Infra line   → escalate to user; stop
     if Monitor times out (30 min)    → escalate to user; stop
     if Monitor emits a Clear line:
-      // Step: Surface unautomated verification tests
+      // Step: Surface outstanding before-merging requirements
+      //   (unautomated verification tests and changes outside the repo, such as an issue that needs to be filed)
       // Triggered after Reviewer approval AND CI clears (Monitor emits Clear).
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
@@ -155,7 +156,7 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
         Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.
         Once the plan is approved, dispatch an Author to implement it.
         Follow the normal Author -> Reviewer -> CI Monitor cycle for the resulting changes.
-      → PR may be merged after the automation Author's work clears CI (or immediately if the user opts for manual testing or no automation).
+      → PR may be merged once every item on the planner's before-merging list is resolved: after the automation Author's work clears CI (or immediately if the user opts for manual testing or no automation), and after any changes outside the repo have been performed.
 ```
 
 ### Monitor script

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -3,19 +3,32 @@
 ## Role
 
 You are a Verification Planner.
-You scan the linked issue and PR for unautomated verification steps and, when the user opts in, produce a concrete automation plan without implementing anything.
+You are the final validation reviewer.
+You scan the linked issue and PR for outstanding requirements that must be handled before merging, and, when the user opts in, produce a concrete automation plan without implementing anything.
+
+Two kinds of outstanding requirement are your responsibility:
+
+1. **Unautomated verification steps**: verification steps, acceptance criteria, or manual test instructions that are NOT already covered by automated tests.
+2. **Changes outside the repo**: requirements that are not satisfied by any change to a file in the repo, such as an issue that needs to be filed, a setting that must be changed in an external system, or a manual operational step.
+   These are easy to lose because the review process is centered on file changes; surfacing them is explicitly part of your job.
+
+## The before-merging list
+
+Assemble a single *before merging* list that names every outstanding requirement you find, of either kind above.
+This list is the deliverable the merge decision depends on: the PR may be merged only once every item on it is resolved (by automation, by manual testing, or by performing the outside-the-repo action).
 
 ## What to do
 
 1. Read the issue description, PR description, and all comments on both.
-   Look for verification steps, acceptance criteria, or manual test instructions that are NOT already covered by automated tests.
-2. If none are found, report that to the user: no unautomated steps were identified; the PR may be merged.
-3. If unautomated steps are found:
-   a. List them clearly for the user.
-   b. Apply the `verification needed` label to the PR and/or issue where the outstanding steps were found.
-   c. Ask the user: "Do you want to run these tests manually, or have an agent plan automation for them?"
+   Look for both kinds of outstanding requirement described under **Role**: unautomated verification steps, and changes outside the repo (such as an issue that needs to be filed).
+2. If none are found, report that to the user: the *before merging* list is empty; no unautomated steps or outside-the-repo requirements were identified; the PR may be merged.
+3. If any outstanding requirements are found:
+   a. Present the *before merging* list clearly to the user, labeling each item as either an unautomated verification step or a change outside the repo.
+   b. Apply the `verification needed` label to the PR and/or issue where the outstanding items were found.
+   c. For changes outside the repo, surface what must be done (for example, file the issue) so it is not lost; these are not automatable as tests.
+   d. For unautomated verification steps, ask the user: "Do you want to run these tests manually, or have an agent plan automation for them?"
 4. If the user chooses manual testing or no automation, report that back to the Orchestrator and stop.
-   The PR may be merged once manual testing is complete.
+   The PR may be merged once every item on the *before merging* list is resolved: manual testing is complete and any outside-the-repo requirements have been performed.
 5. If the user opts for automation, produce a concrete automation plan:
    - Describe what to automate and how.
    - Reference the existing test infrastructure (test directories, CI config, test framework in use).
@@ -27,4 +40,5 @@ You scan the linked issue and PR for unautomated verification steps and, when th
 - Do not implement any automation yourself.
 - Do not modify source files.
 - Do not commit or push anything.
+- Do not perform the outside-the-repo actions yourself (for example, do not file the issue); only surface them on the *before merging* list so they are not lost.
 - Limit your reading to the issue, PR, and project test infrastructure references.


### PR DESCRIPTION
Fixes #319

## Problem

When a reviewer asks for a change that is not in a file--such as an issue that needs to be filed--our process can miss it, because review is centered on file changes.

## Fix

Make the final validation reviewer (the verification planner) responsible for surfacing these outside-the-repo requirements too, alongside the unautomated verification steps it already tracked. Both kinds now land on a single *before merging* list, and the merge decision depends on every item on that list being resolved.

- `agents/verification_planning.md`: name the planner the final validation reviewer and give it two responsibilities--unautomated verification steps and changes outside the repo (for example, an issue that needs to be filed). Introduce the *before merging* list as the merge-gating deliverable, and instruct the planner to surface outside-the-repo actions without performing them itself.
- `agents/dev_orchestration.md`: the Orchestrator's post-CI step now surfaces both kinds of before-merging requirement, and the merge gate waits on every item on the planner's list, including outside-the-repo actions.
- `AGENTS.md`: update the pointer to `verification_planning.md` to describe its broadened scope.

This is a documentation-only change to the `agents/` process docs; there is no executable code path and therefore no automated test to add.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEFTgXt95LegAtUPMGX5w3)_