### PR TITLE
Set xhigh effort and always-thinking in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,6 @@
 {
+  "effortLevel": "xhigh",
+  "alwaysThinkingEnabled": true,
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Closes #328

## Summary

- Adds `effortLevel: "xhigh"` to `.claude/settings.json` so all Claude Code sessions on this project default to maximum reasoning depth.
- Adds `alwaysThinkingEnabled: true` to make the thinking behavior explicit and prevent it from being suppressed by a future default change.

## Test plan

- [ ] Open a new Claude Code session in this repo and confirm `/config` shows `effortLevel: xhigh`.

🦀

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4ECHRCN7HygRFsXvHos1L)_