### PR TITLE
Collapse test results table by class using details/summary

### DIFF
--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -110,14 +110,14 @@ def parse_directory(directory: Path) -> dict[str, TestClass]:
 # Markdown rendering
 # ---------------------------------------------------------------------------
 
-def render_class(cls: "TestClass") -> tuple[list[str], str, int, int, int]:
+def render_class(cls: "TestClass") -> tuple[list[str], int, int, int]:
     """Render one class as a collapsible ``<details>`` block.
 
-    Returns ``(lines, class_icon, pass_count, fail_count, skip_count)``.
+    Returns ``(lines, pass_count, fail_count, skip_count)``.
 
     Classes that fully succeeded start collapsed; classes with any failures
     start expanded (``<details open>``), so attention is drawn to them without
-    the User needing to click through every class.
+    the user needing to click through every class.
     """
     any_passed = any(tc.passed for tc in cls.cases)
     if cls.any_failed:
@@ -154,7 +154,7 @@ def render_class(cls: "TestClass") -> tuple[list[str], str, int, int, int]:
     lines.append("")
     lines.append("</details>")
     lines.append("")
-    return lines, class_icon, pass_count, fail_count, skip_count
+    return lines, pass_count, fail_count, skip_count
 
 
 def render_suite(label: str, classes: dict[str, TestClass], outcome: str = "") -> list[str]:
@@ -184,7 +184,7 @@ def render_suite(label: str, classes: dict[str, TestClass], outcome: str = "") -
     total_skip = 0
 
     for cls in classes.values():
-        class_lines, _class_icon, pass_count, fail_count, skip_count = render_class(cls)
+        class_lines, pass_count, fail_count, skip_count = render_class(cls)
         lines.extend(class_lines)
         total_pass += pass_count
         total_fail += fail_count

--- a/scripts/summarize_test_results.py
+++ b/scripts/summarize_test_results.py
@@ -110,8 +110,55 @@ def parse_directory(directory: Path) -> dict[str, TestClass]:
 # Markdown rendering
 # ---------------------------------------------------------------------------
 
+def render_class(cls: "TestClass") -> tuple[list[str], str, int, int, int]:
+    """Render one class as a collapsible ``<details>`` block.
+
+    Returns ``(lines, class_icon, pass_count, fail_count, skip_count)``.
+
+    Classes that fully succeeded start collapsed; classes with any failures
+    start expanded (``<details open>``), so attention is drawn to them without
+    the User needing to click through every class.
+    """
+    any_passed = any(tc.passed for tc in cls.cases)
+    if cls.any_failed:
+        class_icon = "❌ FAIL"
+    elif not any_passed:
+        class_icon = "⏭ SKIP"
+    else:
+        class_icon = "✅ PASS"
+
+    open_attr = " open" if cls.any_failed else ""
+
+    lines: list[str] = []
+    lines.append(f"<details{open_attr}>")
+    lines.append(f"<summary>{class_icon} <strong>{cls.name}</strong></summary>")
+    lines.append("")
+    lines.append("| Status | Test |")
+    lines.append("|--------|------|")
+
+    pass_count = 0
+    fail_count = 0
+    skip_count = 0
+    for tc in cls.cases:
+        if tc.skipped:
+            tc_icon = "⏭ SKIP"
+            skip_count += 1
+        elif tc.passed:
+            tc_icon = "✅ PASS"
+            pass_count += 1
+        else:
+            tc_icon = "❌ FAIL"
+            fail_count += 1
+        lines.append(f"| {tc_icon} | `{tc.name}` |")
+
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return lines, class_icon, pass_count, fail_count, skip_count
+
+
 def render_suite(label: str, classes: dict[str, TestClass], outcome: str = "") -> list[str]:
-    """Render one suite as Markdown lines (header + table rows + totals).
+    """Render one suite as Markdown lines (header + collapsible class blocks + totals).
 
     *outcome* is the GitHub Actions step outcome for the step that produced
     these results.  When it is ``skipped`` and there are no results, the suite
@@ -132,33 +179,16 @@ def render_suite(label: str, classes: dict[str, TestClass], outcome: str = "") -
         lines.append("")
         return lines
 
-    lines.append("| Status | Suite / Test |")
-    lines.append("|--------|--------------|")
-
     total_pass = 0
     total_fail = 0
     total_skip = 0
 
     for cls in classes.values():
-        any_passed = any(tc.passed for tc in cls.cases)
-        if cls.any_failed:
-            class_icon = "❌ FAIL"
-        elif not any_passed:
-            class_icon = "⏭ SKIP"
-        else:
-            class_icon = "✅ PASS"
-        lines.append(f"| {class_icon} | **{cls.name}** |")
-        for tc in cls.cases:
-            if tc.skipped:
-                tc_icon = "⏭ SKIP"
-                total_skip += 1
-            elif tc.passed:
-                tc_icon = "✅ PASS"
-                total_pass += 1
-            else:
-                tc_icon = "❌ FAIL"
-                total_fail += 1
-            lines.append(f"| {tc_icon} |     `{tc.name}` |")
+        class_lines, _class_icon, pass_count, fail_count, skip_count = render_class(cls)
+        lines.extend(class_lines)
+        total_pass += pass_count
+        total_fail += fail_count
+        total_skip += skip_count
 
     total = total_pass + total_fail + total_skip
     skip_str = f", {total_skip} skipped" if total_skip else ""

--- a/scripts/test_summarize_test_results.py
+++ b/scripts/test_summarize_test_results.py
@@ -271,12 +271,12 @@ class TestRenderSuite(unittest.TestCase):
         }
         lines = srt.render_suite("Suite", classes)
         combined = "\n".join(lines)
-        # The class row must contain FAIL
-        class_row = next(
+        # The class summary line must contain FAIL
+        summary_line = next(
             line for line in lines
-            if "com.example.Mixed" in line and "**" in line
+            if "com.example.Mixed" in line and "<summary>" in line
         )
-        self.assertIn("❌ FAIL", class_row)
+        self.assertIn("❌ FAIL", summary_line)
 
     def test_skipped_case_shows_skip_icon(self):
         classes = {
@@ -318,12 +318,71 @@ class TestRenderSuite(unittest.TestCase):
             )
         }
         lines = srt.render_suite("Suite", classes)
-        class_row = next(
+        summary_line = next(
             line for line in lines
-            if "com.example.AllSkip" in line and "**" in line
+            if "com.example.AllSkip" in line and "<summary>" in line
         )
-        self.assertIn("⏭ SKIP", class_row)
-        self.assertNotIn("✅ PASS", class_row)
+        self.assertIn("⏭ SKIP", summary_line)
+        self.assertNotIn("✅ PASS", summary_line)
+
+    def test_passing_class_renders_as_collapsed_details(self):
+        """A class that fully passed starts collapsed (no ``open`` attribute)."""
+        classes = {
+            "com.example.Foo": srt.TestClass(
+                name="com.example.Foo",
+                cases=[srt.TestCase("testA", True), srt.TestCase("testB", True)],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("<details>", combined)
+        self.assertNotIn("<details open>", combined)
+        self.assertIn("<summary>✅ PASS <strong>com.example.Foo</strong></summary>", combined)
+
+    def test_failing_class_renders_as_expanded_details(self):
+        """A class with any failure starts expanded (``<details open>``)."""
+        classes = {
+            "com.example.Bar": srt.TestClass(
+                name="com.example.Bar",
+                cases=[srt.TestCase("testA", True), srt.TestCase("testB", False)],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("<details open>", combined)
+        self.assertIn("<summary>❌ FAIL <strong>com.example.Bar</strong></summary>", combined)
+
+    def test_all_skipped_class_renders_as_collapsed_details(self):
+        """A class with only skipped tests (no failures) starts collapsed."""
+        classes = {
+            "com.example.Skippy": srt.TestClass(
+                name="com.example.Skippy",
+                cases=[srt.TestCase("s1", False, skipped=True)],
+            )
+        }
+        lines = srt.render_suite("Unit Tests", classes)
+        combined = "\n".join(lines)
+        self.assertIn("<details>", combined)
+        self.assertNotIn("<details open>", combined)
+
+    def test_each_class_gets_its_own_details_block(self):
+        """Multiple classes each render as independent collapsible blocks."""
+        classes = {
+            "com.example.Alpha": srt.TestClass(
+                name="com.example.Alpha",
+                cases=[srt.TestCase("a1", True)],
+            ),
+            "com.example.Beta": srt.TestClass(
+                name="com.example.Beta",
+                cases=[srt.TestCase("b1", False)],
+            ),
+        }
+        lines = srt.render_suite("Suite", classes)
+        combined = "\n".join(lines)
+        self.assertEqual(combined.count("<details"), 2)
+        self.assertEqual(combined.count("</details>"), 2)
+        self.assertEqual(combined.count("<details open>"), 1)
+        self.assertEqual(combined.count("<details>"), 1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #332

## What changed

The CI test-results summary previously rendered every test class and its
test cases as one long flat Markdown table, which made it hard to scan
suites with many classes.

This change renders each class as a collapsible ``<details>``/``<summary>``
block (supported in GitHub Flavored Markdown):

- Classes that fully passed start **collapsed**, so the user does not
  have to scroll past a wall of green rows.
- Classes with any failures start **expanded** (``<details open>``), so
  attention is drawn directly to the failing tests.

Each block's `<summary>` line shows the class-level status icon
(✅ PASS / ❌ FAIL / ⏭ SKIP) and the class name, matching the icons
already used for individual test cases. The per-class table of
individual test cases (`Status` / `Test`) is preserved inside each
block, and the suite-level totals line is unchanged.

## Testing

- Added unit tests in `scripts/test_summarize_test_results.py` covering:
  - passing classes render collapsed (`<details>`, no `open`)
  - failing classes render expanded (`<details open>`)
  - all-skipped classes render collapsed
  - each class gets its own independent `<details>` block
- Updated two existing tests (`test_mixed_class_icon_is_fail_when_any_case_fails`,
  `test_all_skipped_class_icon_is_skip`) to look for the new `<summary>`
  line instead of the old bolded table-row marker (`**`).
- Ran the full `scripts/test_summarize_test_results.py` suite (46 tests,
  all passing) and `scripts/test_summarize_preflight_integration.sh`
  (5 checks, all passing).
