### PR TITLE
Post a sticky PR comment linking to the CI build-and-test summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
     # ubuntu-latest has KVM hardware acceleration (available since April 2024).
     runs-on: ubuntu-latest
 
+    outputs:
+      # Surfaced so link-pr-to-ci-summary (issue #331) can tell whether the
+      # "Write test-result summary" step actually ran--on docs-only PRs it is
+      # skipped, and the job's "Summary" section has nothing to link to.
+      needs_full_build: ${{ steps.diff_check.outputs.needs_full_build }}
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -543,6 +549,11 @@ jobs:
   # Reviewers can then jump straight to the test summary instead of hunting
   # through the Checks tab. Runs regardless of build outcome so the link is
   # always available, including on red builds.
+  #
+  # Docs-only PRs skip the "Write test-result summary" step entirely (see
+  # needs_full_build), so the job's "Summary" section has nothing to link to;
+  # SUMMARY_WRITTEN tells the script to say so rather than post a misleading
+  # link.
   link-pr-to-ci-summary:
     needs: [build-and-test]
     runs-on: ubuntu-latest
@@ -561,6 +572,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_PR_URL: ${{ github.event.pull_request.html_url }}
+          SUMMARY_WRITTEN: ${{ needs.build-and-test.outputs.needs_full_build }}
         run: python3 scripts/post_pr_ci_summary_link.py
 
   # Produce a signed release-config APK on every merge to main for easy sideloading.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -537,6 +537,32 @@ jobs:
             downloaded-artifacts/e2e-test-results \
               --suite-label "E2E Tests"
 
+  # Surface the build-and-test job's pass/fail summary directly on the PR
+  # (issue #331): post or update a sticky comment linking to the job's
+  # "Summary" section, e.g. .../actions/runs/<run_id>#summary-<job_id>.
+  # Reviewers can then jump straight to the test summary instead of hunting
+  # through the Checks tab. Runs regardless of build outcome so the link is
+  # always available, including on red builds.
+  link-pr-to-ci-summary:
+    needs: [build-and-test]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'pull_request' && needs.build-and-test.result != 'cancelled'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Post CI summary link on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_PR_URL: ${{ github.event.pull_request.html_url }}
+        run: python3 scripts/post_pr_ci_summary_link.py
+
   # Produce a signed release-config APK on every merge to main for easy sideloading.
   # Named gb4pc-dev.<run_number>.apk to distinguish from tagged releases.
   # Waits for the full test suite (unit + E2E) before producing an artifact.

--- a/scripts/post_pr_ci_summary_link.py
+++ b/scripts/post_pr_ci_summary_link.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""post_pr_ci_summary_link.py--Link a PR to its build-and-test job summary.
+
+CI produces a rich pass/fail summary in the `build-and-test` job's "Summary"
+section (see `summarize_test_results.py`), but nothing on the PR points at it:
+reviewers must hunt through the Checks tab to find it. This script posts (or
+updates) a single sticky comment on the triggering PR with a direct link to
+that job's summary anchor, e.g.:
+
+    https://github.com/<owner>/<repo>/actions/runs/<run_id>#summary-<job_id>
+
+It looks up the numeric job ID via the REST Jobs API (the anchor embeds the
+job ID, not the run ID), matching on job name and the current run attempt so
+re-runs don't pick up a stale job from a previous attempt.
+
+The comment is "sticky": a hidden HTML marker lets subsequent runs on the same
+PR find and edit the existing comment in place rather than piling up a new one
+per push.
+
+Usage:
+    python3 scripts/post_pr_ci_summary_link.py
+
+Environment:
+    GITHUB_TOKEN          GitHub token for REST calls (required).
+    GITHUB_REPOSITORY     "owner/repo" (required).
+    GITHUB_SERVER_URL     Server base URL, e.g. "https://github.com".
+    GITHUB_RUN_ID         Workflow run ID.
+    GITHUB_RUN_ATTEMPT    Run attempt number (disambiguates re-runs).
+    WORKFLOW_RUN_PR_URL   The triggering PR's html_url (empty on a plain push).
+    JOB_NAME              Name of the job whose summary to link (default
+                          "build-and-test").
+
+Exit code is always 0 (display only; a missing link must never fail the build).
+"""
+
+import os
+import re
+import sys
+
+import requests
+
+MARKER = "<!-- gb4pc-ci-summary-link -->"
+
+DEFAULT_JOB_NAME = "build-and-test"
+
+
+def _github_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def find_job_id(
+    token: str,
+    repository: str,
+    run_id: str,
+    run_attempt: str,
+    job_name: str,
+) -> str | None:
+    """Return the numeric ID of *job_name* in this run's current attempt.
+
+    Filters on `run_attempt` (when known) so a re-run picks the job from the
+    attempt actually in flight, not a stale one from an earlier attempt.
+    """
+    url = f"https://api.github.com/repos/{repository}/actions/runs/{run_id}/jobs"
+    try:
+        resp = requests.get(
+            url,
+            headers=_github_headers(token),
+            params={"per_page": 100},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: failed to list jobs for run {run_id}: {exc}", file=sys.stderr)
+        return None
+
+    candidates = [j for j in data.get("jobs", []) if j.get("name") == job_name]
+    if run_attempt:
+        attempt_matches = [
+            j for j in candidates if str(j.get("run_attempt", "")) == str(run_attempt)
+        ]
+        if attempt_matches:
+            candidates = attempt_matches
+
+    if not candidates:
+        return None
+    return str(candidates[0]["id"])
+
+
+def build_comment_body(summary_url: str) -> str:
+    return (
+        f"{MARKER}\n"
+        f"### CI test summary\n\n"
+        f"[View the build-and-test summary for this PR's latest run]({summary_url}).\n"
+    )
+
+
+def find_existing_comment(token: str, repository: str, pr_number: str) -> int | None:
+    """Return the ID of our prior sticky comment on the PR, if any."""
+    url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
+    try:
+        resp = requests.get(
+            url,
+            headers=_github_headers(token),
+            params={"per_page": 100},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        for comment in resp.json():
+            if MARKER in (comment.get("body") or ""):
+                return comment["id"]
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: failed to list comments on PR #{pr_number}: {exc}", file=sys.stderr)
+    return None
+
+
+def upsert_comment(token: str, repository: str, pr_number: str, body: str) -> bool:
+    """Create the sticky comment, or edit it in place if it already exists."""
+    existing = find_existing_comment(token, repository, pr_number)
+    headers = _github_headers(token)
+    try:
+        if existing is not None:
+            url = f"https://api.github.com/repos/{repository}/issues/comments/{existing}"
+            resp = requests.patch(url, headers=headers, json={"body": body}, timeout=30)
+        else:
+            url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
+            resp = requests.post(url, headers=headers, json={"body": body}, timeout=30)
+        resp.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        verb = "update" if existing is not None else "post"
+        print(f"Warning: failed to {verb} CI summary link comment: {exc}", file=sys.stderr)
+        return False
+
+
+def pr_number_from_url(pr_url: str) -> str | None:
+    """Extract the PR number from its html_url, e.g. ".../pull/42" -> "42"."""
+    match = re.search(r"/pull/(\d+)/?$", pr_url)
+    return match.group(1) if match else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # No CLI arguments; configuration comes entirely from the environment.
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    pr_url = os.environ.get("WORKFLOW_RUN_PR_URL", "")
+    job_name = os.environ.get("JOB_NAME", DEFAULT_JOB_NAME)
+
+    if not token or not repository:
+        print("Note: GITHUB_TOKEN/GITHUB_REPOSITORY not set--skipping CI summary link.", file=sys.stderr)
+        return 0
+    if not run_id:
+        print("Note: GITHUB_RUN_ID not set--skipping CI summary link.", file=sys.stderr)
+        return 0
+    if not pr_url:
+        print("Note: not a pull_request run--skipping CI summary link.", file=sys.stderr)
+        return 0
+
+    pr_number = pr_number_from_url(pr_url)
+    if pr_number is None:
+        print(f"Note: could not parse PR number from '{pr_url}'--skipping.", file=sys.stderr)
+        return 0
+
+    job_id = find_job_id(token, repository, run_id, run_attempt, job_name)
+    run_url = f"{server_url}/{repository}/actions/runs/{run_id}"
+    summary_url = f"{run_url}#summary-{job_id}" if job_id else run_url
+
+    body = build_comment_body(summary_url)
+    if upsert_comment(token, repository, pr_number, body):
+        print(f"Posted CI summary link to PR #{pr_number}: {summary_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/post_pr_ci_summary_link.py
+++ b/scripts/post_pr_ci_summary_link.py
@@ -27,6 +27,12 @@ Environment:
     GITHUB_RUN_ID         Workflow run ID.
     GITHUB_RUN_ATTEMPT    Run attempt number (disambiguates re-runs).
     WORKFLOW_RUN_PR_URL   The triggering PR's html_url (empty on a plain push).
+    SUMMARY_WRITTEN       "true" when build-and-test actually wrote the
+                          pass/fail summary (its needs_full_build output).
+                          Docs-only PRs skip that step, so the job's
+                          "Summary" section has nothing to link to, and the
+                          comment says so instead of posting a misleading
+                          link.
     JOB_NAME              Name of the job whose summary to link (default
                           "build-and-test").
 
@@ -91,12 +97,18 @@ def find_job_id(
     return str(candidates[0]["id"])
 
 
-def build_comment_body(summary_url: str) -> str:
-    return (
-        f"{MARKER}\n"
-        f"### CI test summary\n\n"
-        f"[View the build-and-test summary for this PR's latest run]({summary_url}).\n"
-    )
+def build_comment_body(summary_url: str, summary_written: bool) -> str:
+    if summary_written:
+        link_text = "View the build-and-test summary for this PR"
+    else:
+        link_text = "View this PR's build-and-test run"
+    body = f"{MARKER}\n### CI test summary\n\n[{link_text}]({summary_url}).\n"
+    if not summary_written:
+        body += (
+            "\n(This PR did not need a full build, so no pass/fail summary "
+            "was written; the link above goes to the run itself.)\n"
+        )
+    return body
 
 
 def find_existing_comment(token: str, repository: str, pr_number: str) -> int | None:
@@ -152,6 +164,7 @@ def main(argv: list[str] | None = None) -> int:
     run_id = os.environ.get("GITHUB_RUN_ID", "")
     run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
     pr_url = os.environ.get("WORKFLOW_RUN_PR_URL", "")
+    summary_written = os.environ.get("SUMMARY_WRITTEN", "") == "true"
     job_name = os.environ.get("JOB_NAME", DEFAULT_JOB_NAME)
 
     if not token or not repository:
@@ -169,11 +182,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Note: could not parse PR number from '{pr_url}'--skipping.", file=sys.stderr)
         return 0
 
-    job_id = find_job_id(token, repository, run_id, run_attempt, job_name)
     run_url = f"{server_url}/{repository}/actions/runs/{run_id}"
-    summary_url = f"{run_url}#summary-{job_id}" if job_id else run_url
+    if summary_written:
+        job_id = find_job_id(token, repository, run_id, run_attempt, job_name)
+        summary_url = f"{run_url}#summary-{job_id}" if job_id else run_url
+    else:
+        # No summary was written for this run (for example, a docs-only PR
+        # skips the heavy build/test steps); link to the bare run instead of
+        # an anchor that has nothing meaningful behind it.
+        summary_url = run_url
 
-    body = build_comment_body(summary_url)
+    body = build_comment_body(summary_url, summary_written)
     if upsert_comment(token, repository, pr_number, body):
         print(f"Posted CI summary link to PR #{pr_number}: {summary_url}")
     return 0

--- a/scripts/test_post_pr_ci_summary_link.py
+++ b/scripts/test_post_pr_ci_summary_link.py
@@ -38,10 +38,19 @@ class TestPrNumberFromUrl(unittest.TestCase):
 
 class TestBuildCommentBody(unittest.TestCase):
 
-    def test_includes_marker_and_link(self):
-        body = link.build_comment_body("https://example.com/run#summary-1")
+    def test_includes_marker_and_link_when_summary_written(self):
+        body = link.build_comment_body("https://example.com/run#summary-1", True)
         self.assertIn(link.MARKER, body)
         self.assertIn("https://example.com/run#summary-1", body)
+        self.assertIn("View the build-and-test summary for this PR", body)
+
+    def test_notes_missing_summary_when_not_written(self):
+        body = link.build_comment_body("https://example.com/run", False)
+        self.assertIn(link.MARKER, body)
+        self.assertIn("https://example.com/run", body)
+        # Should not claim there is a pass/fail summary to view.
+        self.assertNotIn("build-and-test summary", body)
+        self.assertIn("did not need a full build", body)
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +194,7 @@ class TestMain(unittest.TestCase):
             "GITHUB_RUN_ID": "999",
             "GITHUB_RUN_ATTEMPT": "1",
             "WORKFLOW_RUN_PR_URL": "https://github.com/owner/repo/pull/42",
+            "SUMMARY_WRITTEN": "true",
         }
         env.update(overrides)
         return env
@@ -209,6 +219,36 @@ class TestMain(unittest.TestCase):
         body = mock_upsert.call_args[0][3]
         self.assertIn("https://github.com/owner/repo/actions/runs/999", body)
         self.assertNotIn("#summary-", body)
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.find_job_id")
+    def test_links_to_bare_run_and_explains_when_summary_not_written(
+        self, mock_find_job, mock_upsert
+    ):
+        """Docs-only PRs skip the summary step; do not claim one exists."""
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(SUMMARY_WRITTEN="false"), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("https://github.com/owner/repo/actions/runs/999", body)
+        self.assertNotIn("#summary-", body)
+        self.assertNotIn("build-and-test summary", body)
+        self.assertIn("did not need a full build", body)
+        # The job-ID lookup is unnecessary work when there's no summary to
+        # link to anyway.
+        mock_find_job.assert_not_called()
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.find_job_id")
+    def test_treats_missing_summary_written_as_false(self, mock_find_job, mock_upsert):
+        mock_upsert.return_value = True
+        env = self._env()
+        del env["SUMMARY_WRITTEN"]
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertNotIn("#summary-", body)
+        mock_find_job.assert_not_called()
 
     @patch("post_pr_ci_summary_link.upsert_comment")
     def test_skips_when_not_a_pull_request_run(self, mock_upsert):

--- a/scripts/test_post_pr_ci_summary_link.py
+++ b/scripts/test_post_pr_ci_summary_link.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Unit tests for post_pr_ci_summary_link.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import post_pr_ci_summary_link as link  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# pr_number_from_url
+# ---------------------------------------------------------------------------
+
+class TestPrNumberFromUrl(unittest.TestCase):
+
+    def test_extracts_number_from_pull_url(self):
+        url = "https://github.com/owner/repo/pull/42"
+        self.assertEqual(link.pr_number_from_url(url), "42")
+
+    def test_extracts_number_with_trailing_slash(self):
+        url = "https://github.com/owner/repo/pull/7/"
+        self.assertEqual(link.pr_number_from_url(url), "7")
+
+    def test_returns_none_for_non_pull_url(self):
+        url = "https://github.com/owner/repo/issues/9"
+        self.assertIsNone(link.pr_number_from_url(url))
+
+    def test_returns_none_for_empty_url(self):
+        self.assertIsNone(link.pr_number_from_url(""))
+
+
+# ---------------------------------------------------------------------------
+# build_comment_body
+# ---------------------------------------------------------------------------
+
+class TestBuildCommentBody(unittest.TestCase):
+
+    def test_includes_marker_and_link(self):
+        body = link.build_comment_body("https://example.com/run#summary-1")
+        self.assertIn(link.MARKER, body)
+        self.assertIn("https://example.com/run#summary-1", body)
+
+
+# ---------------------------------------------------------------------------
+# find_job_id
+# ---------------------------------------------------------------------------
+
+class TestFindJobId(unittest.TestCase):
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_id_for_matching_job_name(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {"id": 111, "name": "build-and-test", "run_attempt": 1},
+                {"id": 222, "name": "file-issues", "run_attempt": 1},
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job_id("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertEqual(result, "111")
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_filters_by_run_attempt_when_jobs_repeat(self, mock_requests):
+        """A re-run leaves a stale job from a prior attempt; pick the live one."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {"id": 111, "name": "build-and-test", "run_attempt": 1},
+                {"id": 333, "name": "build-and-test", "run_attempt": 2},
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job_id("token", "owner/repo", "999", "2", "build-and-test")
+        self.assertEqual(result, "333")
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_falls_back_to_unfiltered_match_when_attempt_unknown(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [{"id": 111, "name": "build-and-test", "run_attempt": 1}]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job_id("token", "owner/repo", "999", "", "build-and-test")
+        self.assertEqual(result, "111")
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_when_no_matching_job(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"jobs": [{"id": 222, "name": "file-issues", "run_attempt": 1}]}
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job_id("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertIsNone(result)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_on_api_error(self, mock_requests):
+        mock_requests.get.side_effect = Exception("network error")
+        result = link.find_job_id("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# find_existing_comment / upsert_comment
+# ---------------------------------------------------------------------------
+
+class TestFindExistingComment(unittest.TestCase):
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_id_of_comment_with_marker(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"id": 1, "body": "unrelated comment"},
+            {"id": 2, "body": f"{link.MARKER}\nold link"},
+        ]
+        mock_requests.get.return_value = mock_resp
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertEqual(result, 2)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_when_no_marker_present(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [{"id": 1, "body": "unrelated comment"}]
+        mock_requests.get.return_value = mock_resp
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertIsNone(result)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_on_api_error(self, mock_requests):
+        mock_requests.get.side_effect = Exception("network error")
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertIsNone(result)
+
+
+class TestUpsertComment(unittest.TestCase):
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_creates_comment_when_none_exists(self, mock_requests, mock_find):
+        mock_find.return_value = None
+        mock_resp = MagicMock()
+        mock_requests.post.return_value = mock_resp
+        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        self.assertTrue(result)
+        mock_requests.post.assert_called_once()
+        mock_requests.patch.assert_not_called()
+        url = mock_requests.post.call_args[0][0]
+        self.assertIn("/issues/42/comments", url)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_edits_existing_comment_in_place(self, mock_requests, mock_find):
+        mock_find.return_value = 99
+        mock_resp = MagicMock()
+        mock_requests.patch.return_value = mock_resp
+        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        self.assertTrue(result)
+        mock_requests.patch.assert_called_once()
+        mock_requests.post.assert_not_called()
+        url = mock_requests.patch.call_args[0][0]
+        self.assertIn("/issues/comments/99", url)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_false_on_api_error(self, mock_requests, mock_find):
+        mock_find.return_value = None
+        mock_requests.post.side_effect = Exception("server error")
+        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+
+    def _env(self, **overrides):
+        env = {
+            "GITHUB_TOKEN": "token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_RUN_ID": "999",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "WORKFLOW_RUN_PR_URL": "https://github.com/owner/repo/pull/42",
+        }
+        env.update(overrides)
+        return env
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.find_job_id")
+    def test_posts_link_with_summary_anchor_when_job_id_found(self, mock_find_job, mock_upsert):
+        mock_find_job.return_value = "111"
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("https://github.com/owner/repo/actions/runs/999#summary-111", body)
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.find_job_id")
+    def test_falls_back_to_run_url_when_job_id_missing(self, mock_find_job, mock_upsert):
+        mock_find_job.return_value = None
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("https://github.com/owner/repo/actions/runs/999", body)
+        self.assertNotIn("#summary-", body)
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    def test_skips_when_not_a_pull_request_run(self, mock_upsert):
+        with patch.dict(os.environ, self._env(WORKFLOW_RUN_PR_URL=""), clear=True):
+            self.assertEqual(link.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    def test_skips_when_token_missing(self, mock_upsert):
+        with patch.dict(os.environ, self._env(GITHUB_TOKEN=""), clear=True):
+            self.assertEqual(link.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    def test_skips_when_run_id_missing(self, mock_upsert):
+        with patch.dict(os.environ, self._env(GITHUB_RUN_ID=""), clear=True):
+            self.assertEqual(link.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    def test_skips_when_pr_url_unparseable(self, mock_upsert):
+        with patch.dict(os.environ, self._env(WORKFLOW_RUN_PR_URL="not-a-url"), clear=True):
+            self.assertEqual(link.main([]), 0)
+        mock_upsert.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #331.

CI already writes a rich pass/fail summary to the `build-and-test` job's "Summary" section (see `summarize_test_results.py`), but nothing on the PR points at it. Reviewers have to dig through the Checks tab to find it.

This adds a new `link-pr-to-ci-summary` job (depends on `build-and-test`, runs on `pull_request` events regardless of build outcome) that posts or updates a single sticky comment on the PR linking directly to the job's summary anchor, e.g.:

```
https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/<run_id>#summary-<job_id>
```

This matches the link format requested in the issue.

## How it works

`scripts/post_pr_ci_summary_link.py`:
- Looks up the numeric `build-and-test` job ID via the REST Jobs API (the anchor embeds the job ID, not the run ID), filtering by the current `run_attempt` so re-runs don't pick up a stale job from an earlier attempt.
- Builds the summary URL `#summary-<job_id>` (falling back to the bare run URL if the job ID can't be found).
- Creates a comment on the PR, or edits its prior comment in place (found via a hidden HTML marker), so repeated pushes update the same comment instead of piling up new ones.
- Checks `build-and-test`'s new `needs_full_build` job-level output (passed through as `SUMMARY_WRITTEN`): docs-only PRs skip the "Write test-result summary" step, so the job's "Summary" section has nothing to link to. In that case the comment links to the bare run and says plainly that no pass/fail summary was written, instead of claiming there's a summary to view.

The job is granted `pull-requests: write` (overriding the workflow's default `contents: read`), matching how `file-issues` already overrides with `issues: write`.

## Tests

Added `scripts/test_post_pr_ci_summary_link.py` (25 tests) covering PR-number extraction, job-ID lookup (including run-attempt disambiguation and API-error handling), comment body construction (both the normal and no-summary-written cases), sticky-comment lookup/create/edit, and the `main` entry point's environment handling and skip conditions. Full `python3 -m unittest discover -s scripts -p "test_*.py"` suite passes (204 tests).