### PR TITLE
Allow test0_smokeGreenFeedVisible to fail without blocking CI

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -24,6 +24,7 @@ com.gb4pc.ui.MainActivityRedirectTest#mainScreen_showsPixelCameraMissingCard_whe
 com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton                              # issue #304
 com.gb4pc.ui.MainActivityRedirectTest#pickerScreen_loadsApps_andShowsSettingsApp                # issue #305
 
+com.gb4pc.e2e.GalleryButtonVisualE2ETest#test0_smokeGreenFeedVisible                            # issue #336
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231


### PR DESCRIPTION
Fixes #336.

Adds `com.gb4pc.e2e.GalleryButtonVisualE2ETest#test0_smokeGreenFeedVisible` to `.github/allowed-test-failures.txt`, so a red result for this test is tolerated and no longer fails the build (per the allowlist mechanism introduced for issue #309).