### PR TITLE
Clarify Orchestrator/Verification-Planner handoff sequencing in agents docs

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -158,8 +158,10 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
       Dispatch a Verification Planner sub-agent using the dispatch template.
-      The planner assembles and presents the before-merging list, then solicits a choice from User: Will User perform manual validation, or should the planner plan an approach to automate the lost items?
-      Once the user responds, relay the user's choice (manual testing or automation) to the planner verbatim, so it can proceed per its own instructions.
+      The planner assembles the before-merging list, then presents it with a question: Will User perform manual validation, or should the planner plan an approach to automate the lost items?
+      If the Planner reports *no work remains*, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
+      Relay any information and questions to the User.
+      Once the user responds, relay the user's choice(s) about the pending work to the planner verbatim, so it can proceed per its own instructions.
       If the user opts for automation and the planner produces a plan:
         Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.
         Once the plan is approved, dispatch an Author to implement it.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -158,7 +158,7 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
       Dispatch a Verification Planner sub-agent using the dispatch template.
-      The Orchestrator does not need a manual-vs-automation choice in hand before this dispatch: the planner first assembles and presents the before-merging list, then solicits that choice from the user itself (see verification_planning.md step 3d).
+      The planner assembles and presents the before-merging list, then solicits a choice from User: Will User perform manual validation, or should the planner plan an approach to automate the lost items?
       Once the user responds, relay the user's choice (manual testing or automation) to the planner verbatim, so it can proceed per its own instructions.
       If the user opts for automation and the planner produces a plan:
         Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -158,7 +158,8 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
       Dispatch a Verification Planner sub-agent using the dispatch template.
-      Relay the user's choice (manual testing or automation) to the planner verbatim.
+      The Orchestrator does not need a manual-vs-automation choice in hand before this dispatch: the planner first assembles and presents the before-merging list, then solicits that choice from the user itself (see verification_planning.md step 3d).
+      Once the user responds, relay the user's choice (manual testing or automation) to the planner verbatim, so it can proceed per its own instructions.
       If the user opts for automation and the planner produces a plan:
         Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.
         Once the plan is approved, dispatch an Author to implement it.


### PR DESCRIPTION
Fixes #335

`agents/dev_orchestration.md`'s CI Monitor loop said, on a `Clear` line:

> Dispatch a Verification Planner sub-agent using the dispatch template.
> Relay the user's choice (manual testing or automation) to the planner verbatim.

This read as if the Orchestrator must already have the user's manual-vs-automation choice in hand before dispatching the planner. But `agents/verification_planning.md` describes the opposite sequencing: the planner itself assembles the before-merging list, presents it to the user, and only then (step 3d) asks the user "Do you want to run these tests manually, or have an agent plan automation for them?"

This PR rewords the relevant step in `agents/dev_orchestration.md` to make the sequencing unambiguous: the Orchestrator dispatches the planner without a pre-collected choice, the planner solicits that choice itself once it has findings to present, and the Orchestrator relays the user's resulting choice back to the planner afterward.

---
_Generated by [Claude Code](https://claude.ai/code/session_011KAycJTfAncDeiLZ1B6gAT)_