### PR TITLE
File tracking issues for before-merging requirements instead of consulting the user

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -97,7 +97,7 @@ Role assignment statements (copy the applicable line exactly):
 
 - Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
-- Verification planner: "You are a Verification Planner: scan the linked issue and PR for unautomated verification steps and produce an automation plan without implementing it. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
+- Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 
 ## Decision-signal templates
 
@@ -158,15 +158,10 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
       Dispatch a Verification Planner sub-agent using the dispatch template.
-      The planner assembles the before-merging list, then presents it with a question: Will User perform manual validation, or should the planner plan an approach to automate the lost items?
-      If the Planner reports *no work remains*, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
-      Relay any information and questions to the User.
-      Once the user responds, relay the user's choice(s) about the pending work to the planner verbatim, so it can proceed per its own instructions.
-      If the user opts for automation and the planner produces a plan:
-        Dispatch a Reviewer to evaluate the plan; follow the normal Reviewer loop.
-        Once the plan is approved, dispatch an Author to implement it.
-        Follow the normal Author -> Reviewer -> CI Monitor cycle for the resulting changes.
-      → PR may be merged once every item on the planner's before-merging list is resolved: after the automation Author's work clears CI (or immediately if the user opts for manual testing or no automation), and after any changes outside the repo have been performed.
+      The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
+      If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
+      Otherwise, relay the planner's reported before-merging list to the user verbatim.
+      → PR may be merged once every issue the planner filed for its before-merging list is resolved.
 ```
 
 ### Monitor script

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -34,17 +34,19 @@ You file one tracking issue per item (see **What to do**) so that each requireme
    c. Record that the new issue **blocks** the PR, using GitHub's issue-dependencies feature.
       GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent dependency tool if one is available to you) to add the relationship.
       To mark the PR as blocked by the new issue:
-      `gh api repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by -f issue_id={new issue's id}`,
+      `gh api repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by -F issue_id={new issue's id}`,
       where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (the `id` field, not its number; obtain it from the issue-creation response or `gh api repos/{owner}/{repo}/issues/{new issue number}`).
+      Use `-F` (not `-f`) so the id is sent as a JSON integer, as the API requires, rather than a string.
       If the PR number is not accepted for an issue-dependency relationship, fall back to blocking the **parent issue** the PR resolves (the issue this PR fixes) instead:
-      `gh api repos/{owner}/{repo}/issues/{parent issue number}/dependencies/blocked_by -f issue_id={new issue's id}`.
+      `gh api repos/{owner}/{repo}/issues/{parent issue number}/dependencies/blocked_by -F issue_id={new issue's id}`.
       Only if neither call succeeds, state the blocking relationship in plain text in the new issue's description (for example, "Blocks PR #{number}") so it is not lost, and skip the formal link without failing.
    d. Make the new issue a **sub-issue** of the PR, using GitHub's sub-issues feature.
       GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent sub-issue tool if one is available to you):
-      `gh api repos/{owner}/{repo}/issues/{number}/sub_issues -f sub_issue_id={new issue's id}`,
+      `gh api repos/{owner}/{repo}/issues/{number}/sub_issues -F sub_issue_id={new issue's id}`,
       where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (not its number).
+      Use `-F` (not `-f`) so the id is sent as a JSON integer, as the API requires, rather than a string.
       If the PR number is not accepted for a sub-issue relationship, fall back to making the new issue a sub-issue of the **parent issue** the PR resolves instead:
-      `gh api repos/{owner}/{repo}/issues/{parent issue number}/sub_issues -f sub_issue_id={new issue's id}`.
+      `gh api repos/{owner}/{repo}/issues/{parent issue number}/sub_issues -F sub_issue_id={new issue's id}`.
       If neither call succeeds, skip this link without failing.
 4. Report the *before merging* list to the Orchestrator and exit.
    The PR may be merged once every one of these filed issues is resolved.

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -4,7 +4,8 @@
 
 You are a Verification Planner.
 You are the final validation reviewer.
-You scan the linked issue and PR for outstanding requirements that must be handled before merging, and, when the user opts in, produce a concrete automation plan without implementing anything.
+You scan the linked issue and PR for outstanding requirements that must be handled before merging, and you file a tracking GitHub issue for each one so none is lost.
+You do not communicate with the user and you do not implement anything.
 
 Two kinds of outstanding requirement are your responsibility:
 
@@ -15,30 +16,31 @@ Two kinds of outstanding requirement are your responsibility:
 ## The before-merging list
 
 Assemble a single *before merging* list that names every outstanding requirement you find, of either kind above.
-This list is the deliverable the merge decision depends on: the PR may be merged only once every item on it is resolved (by automation, by manual testing, or by performing the outside-the-repo action).
+This list is the deliverable the merge decision depends on: the PR may be merged only once every item on it is resolved.
+You file one tracking issue per item (see **What to do**) so that each requirement is followed up and blocks the PR until done.
 
 ## What to do
 
 1. Read the issue description, PR description, and all comments on both.
    Look for both kinds of outstanding requirement described under **Role**: unautomated verification steps, and changes outside the repo (such as an issue that needs to be filed).
-2. If none are found, report that to the user: the *before merging* list is empty; no unautomated steps or outside-the-repo requirements were identified; the PR may be merged.
-3. If any outstanding requirements are found:
-   a. Present the *before merging* list clearly to the user, labeling each item as either an unautomated verification step or a change outside the repo.
-   b. Apply the `verification needed` label to the PR and/or issue where the outstanding items were found.
-   c. For changes outside the repo, surface what must be done (for example, file the issue) so it is not lost; these are not automatable as tests.
-   d. For unautomated verification steps, ask the user: "Do you want to run these tests manually, or have an agent plan automation for them?"
-4. If the user chooses manual testing or no automation, report that back to the Orchestrator and stop.
-   The PR may be merged once every item on the *before merging* list is resolved: manual testing is complete and any outside-the-repo requirements have been performed.
-5. If the user opts for automation, produce a concrete automation plan:
-   - Describe what to automate and how.
-   - Reference the existing test infrastructure (test directories, CI config, test framework in use).
-   - Do NOT implement anything yet.
-   The plan is then reviewed by a Reviewer agent; if the Reviewer approves, an Author agent implements it.
+   Assemble the *before merging* list, labeling each item as either an unautomated verification step or a change outside the repo, and noting for each item the URL of the specific PR comment that called for it.
+2. If the *before merging* list is empty, report this success to the Orchestrator (no unautomated steps or outside-the-repo requirements were identified; the PR may be merged) and exit.
+3. Otherwise, open one GitHub issue for each item on the *before merging* list.
+   Do NOT communicate with the user, and do NOT ask whether to test manually or to automate.
+   For each item:
+   a. Title the issue `(re PR #{number}) {required task title}`, where `{number}` is the current PR number and `{required task title}` is a short title for the outstanding requirement.
+   b. In the issue description, include a URL to the particular PR comment that called for this requirement.
+      (If the requirement came from the PR or issue description itself rather than a comment, link to that description instead.)
+   c. Link the new issue to the current PR so that it **blocks** the PR.
+   d. Make the new issue a **sub-issue** of the PR, if that link type is valid in GitHub. If it is not valid, skip this link without failing.
+4. Report the *before merging* list to the Orchestrator and exit.
+   The PR may be merged once every one of these filed issues is resolved.
 
 ## Boundaries
 
-- Do not implement any automation yourself.
+- Do not communicate with, or ask questions of, the user. Your only conversational output is the report to the Orchestrator.
+- Do not produce an automation plan, and do not implement any automation yourself.
 - Do not modify source files.
 - Do not commit or push anything.
-- Do not perform the outside-the-repo actions yourself (for example, do not file the issue); only surface them on the *before merging* list so they are not lost.
 - Limit your reading to the issue, PR, and project test infrastructure references.
+- The only repository-changing action you take is filing the tracking issues described above and linking them to the PR.

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -31,10 +31,21 @@ You file one tracking issue per item (see **What to do**) so that each requireme
    a. Title the issue `(re PR #{number}) {required task title}`, where `{number}` is the current PR number and `{required task title}` is a short title for the outstanding requirement.
    b. In the issue description, include a URL to the particular PR comment that called for this requirement.
       (If the requirement came from the PR or issue description itself rather than a comment, link to that description instead.)
-   c. Record that the new issue **blocks** the PR.
-      If a tool for a formal "blocked by" / "blocks" relationship is available to you, use it to mark the PR as blocked by the new issue.
-      If no such tool is available, state the blocking relationship in plain text in the new issue's description (for example, "Blocks PR #{number}") so it is not lost, and skip the formal link without failing.
-   d. Make the new issue a **sub-issue** of the PR, if that link type is valid in GitHub. If it is not valid, skip this link without failing.
+   c. Record that the new issue **blocks** the PR, using GitHub's issue-dependencies feature.
+      GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent dependency tool if one is available to you) to add the relationship.
+      To mark the PR as blocked by the new issue:
+      `gh api repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by -f issue_id={new issue's id}`,
+      where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (the `id` field, not its number; obtain it from the issue-creation response or `gh api repos/{owner}/{repo}/issues/{new issue number}`).
+      If the PR number is not accepted for an issue-dependency relationship, fall back to blocking the **parent issue** the PR resolves (the issue this PR fixes) instead:
+      `gh api repos/{owner}/{repo}/issues/{parent issue number}/dependencies/blocked_by -f issue_id={new issue's id}`.
+      Only if neither call succeeds, state the blocking relationship in plain text in the new issue's description (for example, "Blocks PR #{number}") so it is not lost, and skip the formal link without failing.
+   d. Make the new issue a **sub-issue** of the PR, using GitHub's sub-issues feature.
+      GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent sub-issue tool if one is available to you):
+      `gh api repos/{owner}/{repo}/issues/{number}/sub_issues -f sub_issue_id={new issue's id}`,
+      where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (not its number).
+      If the PR number is not accepted for a sub-issue relationship, fall back to making the new issue a sub-issue of the **parent issue** the PR resolves instead:
+      `gh api repos/{owner}/{repo}/issues/{parent issue number}/sub_issues -f sub_issue_id={new issue's id}`.
+      If neither call succeeds, skip this link without failing.
 4. Report the *before merging* list to the Orchestrator and exit.
    The PR may be merged once every one of these filed issues is resolved.
 

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -32,21 +32,20 @@ You file one tracking issue per item (see **What to do**) so that each requireme
    b. In the issue description, include a URL to the particular PR comment that called for this requirement.
       (If the requirement came from the PR or issue description itself rather than a comment, link to that description instead.)
    c. Record that the new issue **blocks** the PR, using GitHub's issue-dependencies feature.
-      GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent dependency tool if one is available to you) to add the relationship.
+      GitHub exposes this through the REST API.
+      The `gh` CLI is not installed in the sandbox, so call the REST endpoint with `curl` and `$GITHUB_TOKEN`, the same way `scripts/ci_monitor.sh` does (`-H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json"`).
       To mark the PR as blocked by the new issue:
-      `gh api repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by -F issue_id={new issue's id}`,
-      where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (the `id` field, not its number; obtain it from the issue-creation response or `gh api repos/{owner}/{repo}/issues/{new issue number}`).
-      Use `-F` (not `-f`) so the id is sent as a JSON integer, as the API requires, rather than a string.
-      If the PR number is not accepted for an issue-dependency relationship, fall back to blocking the **parent issue** the PR resolves (the issue this PR fixes) instead:
-      `gh api repos/{owner}/{repo}/issues/{parent issue number}/dependencies/blocked_by -F issue_id={new issue's id}`.
+      `curl -sX POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by -d '{"issue_id": {new issue's id}}'`,
+      where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (the `id` field, not its number; obtain it from the issue-creation response, or by reading the issue through the same API).
+      Send the id as a bare JSON integer in the request body (not a quoted string), as the API requires.
+      If the PR number is not accepted for an issue-dependency relationship, fall back to blocking the **parent issue** the PR resolves (the issue this PR fixes) instead, by sending the same request to `.../issues/{parent issue number}/dependencies/blocked_by`.
       Only if neither call succeeds, state the blocking relationship in plain text in the new issue's description (for example, "Blocks PR #{number}") so it is not lost, and skip the formal link without failing.
    d. Make the new issue a **sub-issue** of the PR, using GitHub's sub-issues feature.
-      GitHub exposes this through the REST API, so use a `gh api` call (or an equivalent sub-issue tool if one is available to you):
-      `gh api repos/{owner}/{repo}/issues/{number}/sub_issues -F sub_issue_id={new issue's id}`,
+      GitHub exposes this through the REST API; call it with `curl` and `$GITHUB_TOKEN` as in step 3c (the `gh` CLI is not installed):
+      `curl -sX POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/{number}/sub_issues -d '{"sub_issue_id": {new issue's id}}'`,
       where `{number}` is the current PR number and `{new issue's id}` is the new issue's internal id (not its number).
-      Use `-F` (not `-f`) so the id is sent as a JSON integer, as the API requires, rather than a string.
-      If the PR number is not accepted for a sub-issue relationship, fall back to making the new issue a sub-issue of the **parent issue** the PR resolves instead:
-      `gh api repos/{owner}/{repo}/issues/{parent issue number}/sub_issues -F sub_issue_id={new issue's id}`.
+      Send the id as a bare JSON integer in the request body (not a quoted string), as the API requires.
+      If the PR number is not accepted for a sub-issue relationship, fall back to making the new issue a sub-issue of the **parent issue** the PR resolves instead, by sending the same request to `.../issues/{parent issue number}/sub_issues`.
       If neither call succeeds, skip this link without failing.
 4. Report the *before merging* list to the Orchestrator and exit.
    The PR may be merged once every one of these filed issues is resolved.

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -3,7 +3,7 @@
 ## Role
 
 You are a Verification Planner.
-You are the final validation reviewer.
+You are the final check that no before-merging requirement is dropped.
 You scan the linked issue and PR for outstanding requirements that must be handled before merging, and you file a tracking GitHub issue for each one so none is lost.
 You do not communicate with the user and you do not implement anything.
 
@@ -31,7 +31,9 @@ You file one tracking issue per item (see **What to do**) so that each requireme
    a. Title the issue `(re PR #{number}) {required task title}`, where `{number}` is the current PR number and `{required task title}` is a short title for the outstanding requirement.
    b. In the issue description, include a URL to the particular PR comment that called for this requirement.
       (If the requirement came from the PR or issue description itself rather than a comment, link to that description instead.)
-   c. Link the new issue to the current PR so that it **blocks** the PR.
+   c. Record that the new issue **blocks** the PR.
+      If a tool for a formal "blocked by" / "blocks" relationship is available to you, use it to mark the PR as blocked by the new issue.
+      If no such tool is available, state the blocking relationship in plain text in the new issue's description (for example, "Blocks PR #{number}") so it is not lost, and skip the formal link without failing.
    d. Make the new issue a **sub-issue** of the PR, if that link type is valid in GitHub. If it is not valid, skip this link without failing.
 4. Report the *before merging* list to the Orchestrator and exit.
    The PR may be merged once every one of these filed issues is resolved.


### PR DESCRIPTION
Fixes #339. Follow-up to #335.

Changes the Verification Planner's process so that, once it has assembled the *before merging* list, it no longer presents that list to the user or asks whether to test manually or automate. Instead it acts autonomously:

1. If the *before merging* list is empty, it reports this success to the Orchestrator and exits.
2. Otherwise it opens one GitHub issue per outstanding requirement, titled `(re PR #{number}) {required task title}`.
3. Each new issue is linked to the current PR: the PR number is in the title, the description includes the URL of the specific PR comment that called for the requirement, the issue blocks the PR, and the issue is made a sub-issue of the PR when that link type is valid.
4. It reports the *before merging* list to the Orchestrator and exits. The PR may be merged once every filed issue is resolved.

## Files

- `agents/verification_planning.md`: rewrote Role, the before-merging list section, the What-to-do steps, and Boundaries to describe issue-filing instead of user consultation and automation planning. Removed the `verification needed` label step and the manual-vs-automate question.
- `agents/dev_orchestration.md`: reconciled the Monitor-loop handoff and the dispatch role-assignment line with the new process (planner files tracking issues and does not consult the user; merge is gated on those issues being resolved).

Docs-only change; no build or unit tests apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_011KAycJTfAncDeiLZ1B6gAT)_