### PR TITLE
Dismiss swipe keyguard before camera launch to fix flaky green-feed smoke test

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -24,7 +24,6 @@ com.gb4pc.ui.MainActivityRedirectTest#mainScreen_showsPixelCameraMissingCard_whe
 com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton                              # issue #304
 com.gb4pc.ui.MainActivityRedirectTest#pickerScreen_loadsApps_andShowsSettingsApp                # issue #305
 
-com.gb4pc.e2e.GalleryButtonVisualE2ETest#test0_smokeGreenFeedVisible                            # issue #336
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -59,9 +59,9 @@ class E2EFixture(
      */
     fun setUp() {
         ensurePixelCameraInstalled()
-        // Wake the display so screenshots during tests capture actual UI, not a black screen.
-        uiAutomation.executeShellCommand("input keyevent 224").close()  // KEYCODE_WAKEUP
-        Thread.sleep(300)
+        // Wake the display and dismiss the swipe keyguard so screenshots during tests
+        // capture actual UI, not a black screen or the gray (#E9E8EF) lock screen.
+        wakeAndDismissKeyguard()
         startServiceWithSetupCompleted()
         // Allow the service time to register camera callbacks.
         Thread.sleep(1000)
@@ -74,9 +74,36 @@ class E2EFixture(
     }
 
     fun launchPixelCamera() {
+        // Wake and dismiss the swipe keyguard first. STILL_IMAGE_CAMERA is a non-secure
+        // launch, so if the keyguard is up the activity starts behind it and screenshots
+        // capture the gray (#E9E8EF) lock screen instead of the green camera View--the
+        // root cause of the test0 smoke flake (issue #235). The screen can re-sleep or
+        // re-lock between setUp() and a later test's launch (and between CI steps), so the
+        // dismissal must run on every launch, not only once in setUp().
+        wakeAndDismissKeyguard()
         uiAutomation.executeShellCommand(
             "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"
         ).close()
+    }
+
+    /**
+     * Wakes the display and dismisses the emulator's swipe-style lock screen.
+     *
+     * Sends KEYCODE_WAKEUP (224) to turn the screen on regardless of API level, then performs
+     * an upward swipe to dismiss the swipe keyguard the CI emulator shows after boot or after
+     * the display sleeps. This mirrors the CI pre-flight smoke check (`build.yml`), which uses
+     * the same wake + swipe sequence; `wm dismiss-keyguard` did not reliably dismiss the
+     * swipe-type lock screen on the API-35 CI emulator. When the screen is already unlocked the
+     * swipe is a harmless gesture over the foreground activity.
+     *
+     * An upward swipe is preferred over KEYCODE_MENU (82): KEYCODE_MENU can open a foreground
+     * activity's options/overflow menu, obscuring the camera View.
+     */
+    fun wakeAndDismissKeyguard() {
+        uiAutomation.executeShellCommand("input keyevent 224").close()  // KEYCODE_WAKEUP
+        Thread.sleep(300)
+        uiAutomation.executeShellCommand("input swipe 300 1000 300 300").close()
+        Thread.sleep(300)
     }
 
     fun goHome() {


### PR DESCRIPTION
Fixes #235.

## Problem

`GalleryButtonVisualE2ETest.test0_smokeGreenFeedVisible` was flaky, passing a little over half the time.
On failure it reported `GREEN coverage in central 60% of screen is 0.0% — expected > 70%`.

## Root cause

`launchPixelCamera()` started the mock camera with a non-secure `STILL_IMAGE_CAMERA` intent.
When the CI emulator's swipe keyguard was still up, the activity launched behind the lock screen, so the screenshot captured the gray (`#E9E8EF`) lock screen instead of the green camera View, yielding 0.0% green coverage.
The original `setUp()` only sent `KEYCODE_WAKEUP`, which turns the display on but does not dismiss the swipe keyguard, and it only ran once, so the screen could re-sleep or re-lock before a later launch.

## Fix

Add a `wakeAndDismissKeyguard()` helper in `E2EFixture` that sends `KEYCODE_WAKEUP` followed by an upward swipe (the same wake + swipe sequence the CI pre-flight smoke check uses in `build.yml`; `wm dismiss-keyguard` did not reliably dismiss the swipe-type lock screen on the API-35 CI emulator).
An upward swipe is preferred over `KEYCODE_MENU`, which can open a foreground activity's options menu and obscure the camera View.
The helper is called on every `launchPixelCamera()` as well as in `setUp()`, since the screen can re-sleep or re-lock between `setUp()` and a later test's launch. When the screen is already unlocked the swipe is a harmless gesture over the foreground activity.

This replaces the temporary mitigation in #337, which only allowed the test to fail without blocking CI rather than fixing the underlying race.

## Verification

`./gradlew :app:compileDebugAndroidTestKotlin` compiles cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_011KAycJTfAncDeiLZ1B6gAT)_