### PR TITLE
Add CodeQL workflow that skips language-specific jobs when no changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,7 @@ jobs:
     if: needs.detect-changes.outputs.kotlin == 'true'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     steps:
@@ -101,6 +102,7 @@ jobs:
     if: needs.detect-changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,7 +85,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           # Use the default query suite. To add extra queries, uncomment:
@@ -98,7 +98,7 @@ jobs:
           ./gradlew assembleDebug -PversionName=codeql.$BUILD_NUMBER
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: kotlin
 
@@ -114,12 +114,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: python
 
@@ -135,12 +135,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: actions
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       kotlin: ${{ steps.check.outputs.kotlin }}
       python: ${{ steps.check.outputs.python }}
+      actions: ${{ steps.check.outputs.actions }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,6 +34,7 @@ jobs:
             # Always scan on push to main and on scheduled runs.
             echo "kotlin=true" >> $GITHUB_OUTPUT
             echo "python=true" >> $GITHUB_OUTPUT
+            echo "actions=true" >> $GITHUB_OUTPUT
           else
             BASE_REF="${{ github.base_ref }}"
             git fetch origin "$BASE_REF" --depth=1
@@ -44,6 +46,9 @@ jobs:
 
             PYTHON_CHANGED=$(echo "$CHANGED" | grep -E '\.py$' || true)
             echo "python=$([ -n "$PYTHON_CHANGED" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+            ACTIONS_CHANGED=$(echo "$CHANGED" | grep -E '^\.github/(workflows|actions)/' || true)
+            echo "actions=$([ -n "$ACTIONS_CHANGED" ] && echo true || echo false)" >> $GITHUB_OUTPUT
           fi
 
   analyze-kotlin:
@@ -117,3 +122,25 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: python
+
+  analyze-actions:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.actions == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
-          ./gradlew assembleDebug -PversionName=codeql.${{ github.run_number }}
+          ./gradlew assembleDebug -PversionName=codeql.$BUILD_NUMBER
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,117 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 08:00 UTC to catch newly-published queries.
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  # Detect which languages have changed so language-specific CodeQL jobs can
+  # skip themselves when no relevant files are modified.
+  # On push to main or a scheduled run, all languages are always scanned.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      kotlin: ${{ steps.check.outputs.kotlin }}
+      python: ${{ steps.check.outputs.python }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect language changes
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            # Always scan on push to main and on scheduled runs.
+            echo "kotlin=true" >> $GITHUB_OUTPUT
+            echo "python=true" >> $GITHUB_OUTPUT
+          else
+            BASE_REF="${{ github.base_ref }}"
+            git fetch origin "$BASE_REF" --depth=1
+
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+
+            KOTLIN_CHANGED=$(echo "$CHANGED" | grep -E '\.(kt|kts|java)$' || true)
+            echo "kotlin=$([ -n "$KOTLIN_CHANGED" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+            PYTHON_CHANGED=$(echo "$CHANGED" | grep -E '\.py$' || true)
+            echo "python=$([ -n "$PYTHON_CHANGED" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          fi
+
+  analyze-kotlin:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.kotlin == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          # Use the default query suite. To add extra queries, uncomment:
+          # queries: security-extended
+
+      - name: Build for CodeQL
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          ./gradlew assembleDebug -PversionName=codeql.${{ github.run_number }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: kotlin
+
+  analyze-python:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: python


### PR DESCRIPTION
Fixes #347

Adds a new `codeql.yml` workflow with a `detect-changes` job that examines which language files changed on a pull request.
The language-specific analysis jobs (`analyze-kotlin`, `analyze-python`, `analyze-actions`) each have an `if:` condition that checks the corresponding output: they skip themselves entirely when no relevant files were modified.

On a push to `main` or a scheduled run, all languages are always scanned regardless of what changed.

The default CodeQL setup has been disabled in repository settings (Settings > Code security > CodeQL analysis, switched from "Default" to "Advanced"). GitHub's auto-generated "Advanced setup" template scans three languages: `java-kotlin`, `python`, and `actions`. This PR's `codeql.yml` now covers all three with the same skip-on-no-changes logic:

- `analyze-kotlin`: skipped when no `.kt`, `.kts`, or `.java` files changed.
- `analyze-python`: skipped when no `.py` files changed.
- `analyze-actions`: skipped when no files under `.github/workflows/` or `.github/actions/` changed.