### PR TITLE
Apply wake+swipe keyguard-dismiss fix to all CI test-launch sites

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,10 +222,13 @@ jobs:
           echo "=== $(date -u '+%Y-%m-%d %H:%M:%S UTC') === Services ready (${SVCWAIT}s after boot flag)."
 
           # Wake, unlock, keep on, and disable animations now that services are up.
-          # KEYCODE_WAKEUP (224) is more reliable than KEYCODE_MENU (82) for waking
-          # the display from sleep; KEYCODE_MENU then dismisses the lock screen.
+          # Use the same wake + upward-swipe sequence as the pre-flight step and
+          # E2EFixture.wakeAndDismissKeyguard(): KEYCODE_MENU (82) could not reliably
+          # dismiss the swipe-type lock screen on the API-35 CI emulator (issue #341).
           "$ADB" shell input keyevent 224
-          "$ADB" shell input keyevent 82
+          sleep 1
+          "$ADB" shell input swipe 300 1000 300 300
+          sleep 1
           # Prevent the screen from sleeping while the emulator is "plugged in"
           # (value 7 = stay on for AC/USB/wireless charging combined).
           # Without this the screen can time out between the unlock here and the
@@ -328,6 +331,15 @@ jobs:
         id: run_instrumented
         if: steps.diff_check.outputs.needs_full_build == 'true'
         run: |
+          ADB="$ANDROID_HOME/platform-tools/adb"
+          # Wake and dismiss the swipe keyguard before starting the test suite.
+          # The E2E setup (including mock-camera install) can take 10-30 s, and the
+          # screen may sleep or re-lock in that window. This mirrors
+          # E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
+          "$ADB" shell input keyevent 224
+          sleep 1
+          "$ADB" shell input swipe 300 1000 300 300
+          sleep 1
           if ./gradlew connectedDebugAndroidTest; then
             echo "outcome=success" >> "$GITHUB_OUTPUT"
           else
@@ -349,6 +361,14 @@ jobs:
         if: steps.diff_check.outputs.needs_full_build == 'true'
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
+          # Wake and dismiss the swipe keyguard before starting the test suite.
+          # The instrumented tests can run for several minutes, and the screen may
+          # sleep or re-lock before this step starts. This mirrors
+          # E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
+          "$ADB" shell input keyevent 224
+          sleep 1
+          "$ADB" shell input swipe 300 1000 300 300
+          sleep 1
           mkdir -p results
           set -o pipefail
           LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')
@@ -378,6 +398,14 @@ jobs:
         if: steps.diff_check.outputs.needs_full_build == 'true'
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
+          # Wake and dismiss the swipe keyguard before starting the test suite.
+          # The previous E2E suite (PixelCameraOverlayE2ETest) can run for several
+          # minutes, and the screen may sleep or re-lock before this step starts.
+          # This mirrors E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
+          "$ADB" shell input keyevent 224
+          sleep 1
+          "$ADB" shell input swipe 300 1000 300 300
+          sleep 1
           mkdir -p results
           set -o pipefail
           LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,10 +225,11 @@ jobs:
           # Use the same wake + upward-swipe sequence as the pre-flight step and
           # E2EFixture.wakeAndDismissKeyguard(): KEYCODE_MENU (82) could not reliably
           # dismiss the swipe-type lock screen on the API-35 CI emulator (issue #341).
-          "$ADB" shell input keyevent 224
-          sleep 1
+          # sleep 2 lets the swipe animation complete before subsequent commands fire
+          # (same reasoning as the pre-flight step's post-swipe sleep 2).
+          "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
-          sleep 1
+          sleep 2
           # Prevent the screen from sleeping while the emulator is "plugged in"
           # (value 7 = stay on for AC/USB/wireless charging combined).
           # Without this the screen can time out between the unlock here and the
@@ -336,10 +337,11 @@ jobs:
           # The E2E setup (including mock-camera install) can take 10-30 s, and the
           # screen may sleep or re-lock in that window. This mirrors
           # E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
-          "$ADB" shell input keyevent 224
-          sleep 1
+          # sleep 2 lets the swipe animation complete before Gradle's am start fires
+          # (same reasoning as the pre-flight step's post-swipe sleep 2).
+          "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
-          sleep 1
+          sleep 2
           if ./gradlew connectedDebugAndroidTest; then
             echo "outcome=success" >> "$GITHUB_OUTPUT"
           else
@@ -365,10 +367,11 @@ jobs:
           # The instrumented tests can run for several minutes, and the screen may
           # sleep or re-lock before this step starts. This mirrors
           # E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
-          "$ADB" shell input keyevent 224
-          sleep 1
+          # sleep 2 lets the swipe animation complete before Gradle's am start fires
+          # (same reasoning as the pre-flight step's post-swipe sleep 2).
+          "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
-          sleep 1
+          sleep 2
           mkdir -p results
           set -o pipefail
           LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')
@@ -402,10 +405,11 @@ jobs:
           # The previous E2E suite (PixelCameraOverlayE2ETest) can run for several
           # minutes, and the screen may sleep or re-lock before this step starts.
           # This mirrors E2EFixture.wakeAndDismissKeyguard() (issue #344 / #341).
-          "$ADB" shell input keyevent 224
-          sleep 1
+          # sleep 2 lets the swipe animation complete before Gradle's am start fires
+          # (same reasoning as the pre-flight step's post-swipe sleep 2).
+          "$ADB" shell input keyevent KEYCODE_WAKEUP
           "$ADB" shell input swipe 300 1000 300 300
-          sleep 1
+          sleep 2
           mkdir -p results
           set -o pipefail
           LOGCAT_SINCE=$("$ADB" shell "date '+%m-%d %H:%M:%S.000'" | tr -d '\r')


### PR DESCRIPTION
Fixes #344.

The fix from #341 (KEYCODE_WAKEUP + upward swipe to dismiss the swipe-type lock screen) is now applied to every CI step that starts a test suite or the emulator.

## Changes

**`build.yml` -- "Wait for emulator service readiness":** Replace the old `input keyevent 82` (KEYCODE_MENU) call with `sleep 1; input swipe 300 1000 300 300; sleep 1`, matching the pre-flight smoke check step and `E2EFixture.wakeAndDismissKeyguard()`.
KEYCODE_MENU could not reliably dismiss the swipe-type lock screen on the API-35 CI emulator (root cause documented in #341).

**`build.yml` -- "Run instrumented tests":** Add ADB variable + wake + swipe before the Gradle invocation.

**`build.yml` -- "Run PixelCameraOverlayE2ETest":** Add wake + swipe before the Gradle invocation.

**`build.yml` -- "Run GalleryButtonVisualE2ETest":** Add wake + swipe before the Gradle invocation.

## Why each site

Each E2E test step can be preceded by 10-30 s of other CI work (mock-camera install, previous test suite, etc.) during which the emulator screen may sleep or re-lock.
The pre-step unlock prevents the first `launchPixelCamera()` in each suite from landing behind the lock screen and capturing the gray (`#E9E8EF`) keyguard instead of the green camera View.

The Kotlin-side fix (`E2EFixture.wakeAndDismissKeyguard()` called in `setUp()` and `launchPixelCamera()`) was already applied in #341.
This PR closes the remaining gap at the CI-shell level.

## Test plan

- [ ] CI passes on this PR (all three E2E suites run after a wake+swipe unlock).
- [ ] Python unit tests: `python3 -m unittest discover -s scripts -p "test_*.py"` -- 208 tests pass (verified locally).

https://claude.ai/code/session_017M4NzZ1oJW4g5jTDMDVCDM

---
_Generated by [Claude Code](https://claude.ai/code/session_017M4NzZ1oJW4g5jTDMDVCDM)_