### PR TITLE
Report empty CodeQL results for skipped categories to unblock merges

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -144,3 +144,71 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: actions
+
+  # A language whose analyze job is skipped still needs code-scanning results
+  # for its category, or the PR is stuck forever on "Code scanning is waiting
+  # for results from CodeQL" and cannot merge (issue #358). For each skipped
+  # category, upload an empty (zero-result) CodeQL SARIF run so code scanning
+  # reports a result for that category on this commit. Always runs so it can
+  # report whichever subset of categories was skipped.
+  report-skipped:
+    needs: [detect-changes, analyze-kotlin, analyze-python, analyze-actions]
+    if: always() && needs.detect-changes.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build empty SARIF for skipped categories
+        env:
+          KOTLIN: ${{ needs.detect-changes.outputs.kotlin }}
+          PYTHON: ${{ needs.detect-changes.outputs.python }}
+          ACTIONS: ${{ needs.detect-changes.outputs.actions }}
+        run: |
+          # Emit one empty CodeQL run per skipped category. A category maps to a
+          # run's automationDetails.id, so code scanning records a separate
+          # result for each. The runs array must be non-empty to upload, but
+          # each run may carry zero results.
+          runs=""
+          add_run() {
+            local category="$1"
+            runs="${runs:+$runs,}$(cat <<JSON
+          {
+            "tool": { "driver": { "name": "CodeQL", "rules": [] } },
+            "automationDetails": { "id": "$category/" },
+            "results": [],
+            "columnKind": "utf16CodeUnits"
+          }
+          JSON
+          )"
+          }
+
+          [ "$KOTLIN" != "true" ] && add_run kotlin
+          [ "$PYTHON" != "true" ] && add_run python
+          [ "$ACTIONS" != "true" ] && add_run actions
+
+          if [ -z "$runs" ]; then
+            echo "All categories were analyzed; nothing to report."
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cat > empty.sarif <<JSON
+          {
+            "\$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [ $runs ]
+          }
+          JSON
+
+          python3 -c "import json,sys; json.load(open('empty.sarif'))"
+          echo "upload=true" >> "$GITHUB_OUTPUT"
+        id: build
+
+      - name: Upload empty CodeQL results for skipped categories
+        if: steps.build.outputs.upload == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: empty.sarif


### PR DESCRIPTION
Fixes #358

## Problem

PR #349 added the CodeQL workflow and made each language-specific analyze job (`analyze-kotlin`, `analyze-python`, `analyze-actions`) skip itself when no relevant files changed in a PR.

Skipping the *jobs* is fine for the workflow status checks (a conditionally-skipped job reports success). But code-scanning **merge protection** is a separate gate: it expects code-scanning *results* for every configured category on the PR head commit. CodeQL results are reported by the `analyze` action uploading SARIF. When the analyze job is skipped, no SARIF is uploaded for that category, so code scanning never reports a result and the PR is stuck forever on:

> Merging is blocked
> Code scanning is waiting for results from CodeQL for the commits ...

A PR that touches neither Kotlin, Python, nor Actions files (for example a docs-only or agents-doc PR like #348) skips all three analyze jobs and can never merge.

## Fix

Add a `report-skipped` job that runs after `detect-changes`. For each category whose analyze job was skipped, it uploads an empty (zero-result) CodeQL SARIF run via `github/codeql-action/upload-sarif`. A category maps to a SARIF run's `automationDetails.id`, so a single uploaded file with one empty run per skipped category makes code scanning record a result for each, and merge protection clears.

Properties that keep this safe:

- It uploads **only** for categories that were skipped. A category that actually ran is never given an empty run, so real findings are never masked.
- The SARIF `runs` array is non-empty (an empty `runs: []` is rejected on upload), but each run carries zero `results`.
- When every category was analyzed there is nothing to report, and the upload step is skipped.
- The job uses `if: always()` so it reports whichever subset of categories was skipped even if a sibling analyze job ran or failed; a failed analyze job means that category *was* changed, so no empty run is uploaded for it.

On push to `main` and scheduled runs `detect-changes` marks all languages as changed, so `report-skipped` uploads nothing there.

## Test plan

- [x] Python unit tests: `python3 -m unittest discover -s scripts -p "test_*.py"` -- 242 tests pass (no Python source changed; sanity check only).
- [x] `codeql.yml` parses as valid YAML; the `report-skipped` run-block was extracted and executed under `bash -e` for all skip combinations (all-analyzed, all-skipped, mixed), producing valid SARIF with the expected per-category runs and the correct `upload` output.
- [ ] CI on this PR: confirm the previously-blocked merge-protection state clears once `report-skipped` uploads results for the skipped categories.