### PR TITLE
Retry first Pixel Camera launch through window-transition teardown on slow emulators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,17 +381,26 @@ jobs:
             echo "outcome=success" >> "$GITHUB_OUTPUT"
           else
             echo "outcome=failure" >> "$GITHUB_OUTPUT"
-            echo "=== LOGCAT (since test start) ==="
-            "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
-              bash scripts/filter_logcat.sh
           fi
+          # Capture the filtered logcat regardless of pass/fail (issues #364/#365).
+          # The GB4PC_E2E diagnostic lines from E2EFixture.launchPixelCamera() are
+          # what make the issue #233 bounded-relaunch path observable, but they are
+          # only useful if they survive a *green* run too -- on a pass the retry
+          # either fired and recovered or never fired, and only the logcat can tell
+          # the two apart. Dumping it only in the failure branch discarded that
+          # evidence on every passing run, so always tee it to a file and upload it.
+          echo "=== LOGCAT (since test start) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
+            bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
       - name: Upload overlay E2E markers
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: testresults-e2e-overlay
-          path: results/e2e-overlay.ndjson
+          path: |
+            results/e2e-overlay.ndjson
+            results/e2e-overlay-logcat.txt
           retention-days: 14
 
       - name: Run GalleryButtonVisualE2ETest

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -52,6 +52,15 @@ class E2EFixture(
 ) {
     private val pcPackage = Constants.PIXEL_CAMERA_PACKAGE
 
+    companion object {
+        // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
+        // Up to LAUNCH_ATTEMPTS launches, each given LAUNCH_VERIFY_MS to activate the overlay
+        // before re-issuing. 3 x 5 s = 15 s worst case, comfortably under the 30 s assertion in
+        // overlayAppearsWhenViewfinderOpens (and the 20 s default in waitForOverlayActive).
+        private const val LAUNCH_ATTEMPTS = 3
+        private const val LAUNCH_VERIFY_MS = 5_000L
+    }
+
     /**
      * Run from `@Before`. Performs all preconditions; tests that pass `setUp()` are
      * guaranteed: Pixel Camera installed, OverlayService running and registered, PC
@@ -81,9 +90,33 @@ class E2EFixture(
         // re-lock between setUp() and a later test's launch (and between CI steps), so the
         // dismissal must run on every launch, not only once in setUp().
         wakeAndDismissKeyguard()
-        uiAutomation.executeShellCommand(
-            "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"
-        ).close()
+
+        // Issue #233: On the API-35 CI emulator the *first* STILL_IMAGE_CAMERA launch of a
+        // suite is frequently torn down inside its own OPEN window-transition before the
+        // activity reaches onResume(). WindowManager force-removes the just-created
+        // ActivityRecord ("Force removing ActivityRecord{... MockCameraActivity}" / "Attempted
+        // to add application window with unknown token ... Aborting"), so MockCameraActivity
+        // never calls openCamera(), CameraManager.AvailabilityCallback.onCameraUnavailable
+        // never fires, and the overlay never activates -- the test then times out at 30 s.
+        // A re-issued `am start` after the transition has settled reliably brings the activity
+        // up (every non-first launch in CI opens the camera within ~30 ms), so retry the launch
+        // until the overlay activates, which is the observable proof the camera reached
+        // onResume() and opened. The retry is bounded so a genuinely broken launch still fails
+        // the caller's own activation assertion rather than hanging.
+        repeat(LAUNCH_ATTEMPTS) { attempt ->
+            uiAutomation.executeShellCommand(
+                "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"
+            ).close()
+            // Give this launch its own short window to reach onResume() and activate the
+            // overlay before deciding whether to re-issue. The sum across attempts stays well
+            // under each caller's activation timeout.
+            if (waitForCondition(LAUNCH_VERIFY_MS) { OverlayService.isOverlayActive }) return
+            if (attempt < LAUNCH_ATTEMPTS - 1) {
+                // The previous launch was torn down before the camera opened. Re-dismiss the
+                // keyguard (the screen can re-sleep between attempts) and try again.
+                wakeAndDismissKeyguard()
+            }
+        }
     }
 
     /**

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -55,8 +55,11 @@ class E2EFixture(
     companion object {
         // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
         // Up to LAUNCH_ATTEMPTS launches, each given LAUNCH_VERIFY_MS to activate the overlay
-        // before re-issuing. 3 x 5 s = 15 s worst case, comfortably under the 30 s assertion in
-        // overlayAppearsWhenViewfinderOpens (and the 20 s default in waitForOverlayActive).
+        // before re-issuing. The launch attempts are 3 x 5 s = 15 s worst case. A genuinely
+        // broken launch returns from launchPixelCamera() after that budget (the baseline wait
+        // below only consumes time when a prior overlay is still active, which is itself a
+        // separate failure and not the healthy path), leaving the 30 s assertion in
+        // overlayAppearsWhenViewfinderOpens to fail the test rather than hang.
         private const val LAUNCH_ATTEMPTS = 3
         private const val LAUNCH_VERIFY_MS = 5_000L
     }
@@ -103,6 +106,15 @@ class E2EFixture(
         // until the overlay activates, which is the observable proof the camera reached
         // onResume() and opened. The retry is bounded so a genuinely broken launch still fails
         // the caller's own activation assertion rather than hanging.
+        //
+        // The activation check below treats isOverlayActive becoming true as proof that *this*
+        // launch reached onResume(). That proof is only sound from a known-inactive baseline: if
+        // a previous test's overlay is still active when launchPixelCamera() is called (setUp()'s
+        // waitForOverlayInactive() and the mid-test goHome()/stopPixelCamera() flows do not assert
+        // deactivation), waitForCondition would read the stale true on its first poll and return
+        // before this launch's `am start` had any effect. Wait for a clean inactive baseline first
+        // so each attempt observes a genuine false -> true transition. Bounded so it cannot hang.
+        waitForCondition(LAUNCH_VERIFY_MS) { !OverlayService.isOverlayActive }
         repeat(LAUNCH_ATTEMPTS) { attempt ->
             uiAutomation.executeShellCommand(
                 "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -54,14 +54,31 @@ class E2EFixture(
 
     companion object {
         // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
-        // Up to LAUNCH_ATTEMPTS launches, each given LAUNCH_VERIFY_MS to activate the overlay
-        // before re-issuing. The launch attempts are 3 x 5 s = 15 s worst case. A genuinely
-        // broken launch returns from launchPixelCamera() after that budget (the baseline wait
-        // below only consumes time when a prior overlay is still active, which is itself a
-        // separate failure and not the healthy path), leaving the 30 s assertion in
-        // overlayAppearsWhenViewfinderOpens to fail the test rather than hang.
+        //
+        // The per-attempt verify windows must not false-positive a *healthy* launch as a failed
+        // one. waitForOverlayActive() documents that on the CI emulator a healthy activation can
+        // take ~9 s (camera open) + ~1 s (UsageStats) and budgets 20 s for it. So the first
+        // attempt is given a window in that range (LAUNCH_FIRST_VERIFY_MS): a slow-but-healthy
+        // first launch activates the overlay inside that window and returns without the loop ever
+        // re-issuing `am start`. Re-issuing on a healthy, mid-resume activity would itself race the
+        // OPEN transition (a second `input swipe` + `am start` over the resuming activity), i.e.
+        // re-create the very failure this fix targets, so the first window deliberately errs long.
+        //
+        // Only the *teardown* failure mode (activity force-removed ~3 ms after START, before
+        // onResume(), so the camera never opens and the overlay can never activate) survives that
+        // first window. Recovery from it is fast: every observed non-first launch in CI opens the
+        // camera within ~30 ms, so the follow-up attempts use the shorter LAUNCH_RETRY_VERIFY_MS.
+        //
+        // Worst-case budget for a genuinely broken launch:
+        //   baseline inactive wait (LAUNCH_BASELINE_MS, only consumed if a prior overlay is still
+        //   active going in -- itself a separate failure, not the healthy path)
+        //   + LAUNCH_FIRST_VERIFY_MS + (LAUNCH_ATTEMPTS - 1) x LAUNCH_RETRY_VERIFY_MS
+        //   = 3 + 12 + 2 x 6 = 27 s, under the 30 s overlayAppearsWhenViewfinderOpens assertion,
+        // so launchPixelCamera() returns and lets the caller's own assertion fail rather than hang.
         private const val LAUNCH_ATTEMPTS = 3
-        private const val LAUNCH_VERIFY_MS = 5_000L
+        private const val LAUNCH_FIRST_VERIFY_MS = 12_000L
+        private const val LAUNCH_RETRY_VERIFY_MS = 6_000L
+        private const val LAUNCH_BASELINE_MS = 3_000L
     }
 
     /**
@@ -114,15 +131,18 @@ class E2EFixture(
         // deactivation), waitForCondition would read the stale true on its first poll and return
         // before this launch's `am start` had any effect. Wait for a clean inactive baseline first
         // so each attempt observes a genuine false -> true transition. Bounded so it cannot hang.
-        waitForCondition(LAUNCH_VERIFY_MS) { !OverlayService.isOverlayActive }
+        waitForCondition(LAUNCH_BASELINE_MS) { !OverlayService.isOverlayActive }
         repeat(LAUNCH_ATTEMPTS) { attempt ->
             uiAutomation.executeShellCommand(
                 "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"
             ).close()
-            // Give this launch its own short window to reach onResume() and activate the
-            // overlay before deciding whether to re-issue. The sum across attempts stays well
-            // under each caller's activation timeout.
-            if (waitForCondition(LAUNCH_VERIFY_MS) { OverlayService.isOverlayActive }) return
+            // The first attempt gets the full healthy-activation window so a slow-but-healthy
+            // launch is never mistaken for a failed one and re-issued (which would itself race the
+            // OPEN transition). Only the teardown failure mode survives that window, and recovery
+            // from it is fast, so later attempts use the shorter retry window. See the
+            // companion-object note for the budget rationale.
+            val verifyMs = if (attempt == 0) LAUNCH_FIRST_VERIFY_MS else LAUNCH_RETRY_VERIFY_MS
+            if (waitForCondition(verifyMs) { OverlayService.isOverlayActive }) return
             if (attempt < LAUNCH_ATTEMPTS - 1) {
                 // The previous launch was torn down before the camera opened. Re-dismiss the
                 // keyguard (the screen can re-sleep between attempts) and try again.

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -2,7 +2,6 @@ package com.gb4pc.e2e
 
 import android.app.KeyguardManager
 import android.app.UiAutomation
-import android.util.Log
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -12,6 +11,7 @@ import android.media.MediaScannerConnection
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.gb4pc.Constants

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -2,6 +2,7 @@ package com.gb4pc.e2e
 
 import android.app.KeyguardManager
 import android.app.UiAutomation
+import android.util.Log
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -53,6 +54,12 @@ class E2EFixture(
     private val pcPackage = Constants.PIXEL_CAMERA_PACKAGE
 
     companion object {
+        // Tag for the diagnostic logcat lines emitted by launchPixelCamera() (issue #233). These
+        // make the bounded-relaunch path observable in a CI run's logcat: when the first-launch
+        // teardown race occurs, the log shows which attempt re-issued `am start` and which one the
+        // overlay finally activated on, instead of leaving the retry/recovery to be inferred.
+        private const val TAG = "GB4PC_E2E"
+
         // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
         //
         // The per-attempt verify windows must not false-positive a *healthy* launch as a failed
@@ -133,6 +140,7 @@ class E2EFixture(
         // so each attempt observes a genuine false -> true transition. Bounded so it cannot hang.
         waitForCondition(LAUNCH_BASELINE_MS) { !OverlayService.isOverlayActive }
         repeat(LAUNCH_ATTEMPTS) { attempt ->
+            Log.i(TAG, "launchPixelCamera: am start attempt ${attempt + 1}/$LAUNCH_ATTEMPTS")
             uiAutomation.executeShellCommand(
                 "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage"
             ).close()
@@ -142,11 +150,25 @@ class E2EFixture(
             // from it is fast, so later attempts use the shorter retry window. See the
             // companion-object note for the budget rationale.
             val verifyMs = if (attempt == 0) LAUNCH_FIRST_VERIFY_MS else LAUNCH_RETRY_VERIFY_MS
-            if (waitForCondition(verifyMs) { OverlayService.isOverlayActive }) return
+            if (waitForCondition(verifyMs) { OverlayService.isOverlayActive }) {
+                Log.i(TAG, "launchPixelCamera: overlay active on attempt ${attempt + 1}")
+                return
+            }
             if (attempt < LAUNCH_ATTEMPTS - 1) {
                 // The previous launch was torn down before the camera opened. Re-dismiss the
                 // keyguard (the screen can re-sleep between attempts) and try again.
+                Log.w(
+                    TAG,
+                    "launchPixelCamera: overlay still inactive after ${verifyMs} ms on attempt " +
+                        "${attempt + 1} (first-launch teardown race); re-issuing am start"
+                )
                 wakeAndDismissKeyguard()
+            } else {
+                Log.w(
+                    TAG,
+                    "launchPixelCamera: overlay still inactive after $LAUNCH_ATTEMPTS attempts; " +
+                        "letting the caller's own assertion fail"
+                )
             }
         }
     }

--- a/scripts/filter_logcat.sh
+++ b/scripts/filter_logcat.sh
@@ -10,8 +10,10 @@
 #      suppressed.
 #   2. Lines are filtered to only those relevant for CI failure diagnosis:
 #      AndroidRuntime, FATAL, "Process crashed", app/service tags
-#      (com.gb4pc, OverlayService, MockCamera, CameraService), and any
-#      logcat error tag (E/<tag>).
+#      (com.gb4pc, OverlayService, MockCamera, CameraService), the E2E
+#      harness diagnostic tag (GB4PC_E2E, emitted by
+#      E2EFixture.launchPixelCamera() to make the issue #233 bounded-relaunch
+#      path observable), and any logcat error tag (E/<tag>).
 #
 # Usage:
 #   adb logcat -d | scripts/filter_logcat.sh
@@ -22,4 +24,4 @@
 #   bitmap_url=data:image/png;base64,ABC= →  bitmap_url=data:image/png;base64,[elided]
 
 sed 's/;base64,[A-Za-z0-9+/=]\{8,\}/;base64,[elided]/g' | \
-  grep -E "AndroidRuntime|FATAL|Process crashed|com\.gb4pc|OverlayService|MockCamera|CameraService|E/\w" || true
+  grep -E "AndroidRuntime|FATAL|Process crashed|com\.gb4pc|OverlayService|MockCamera|CameraService|GB4PC_E2E|E/\w" || true

--- a/scripts/test_filter_logcat.sh
+++ b/scripts/test_filter_logcat.sh
@@ -136,6 +136,7 @@ KEPT_CASES["com.gb4pc"]="05-25 14:08:16.131  1204  1204 D com.gb4pc.app: some me
 KEPT_CASES["OverlayService"]="05-25 14:08:16.131  1204  1204 D OverlayService: some message"
 KEPT_CASES["MockCamera"]="05-25 14:08:16.131  1204  1204 D MockCamera: some message"
 KEPT_CASES["CameraService"]="05-25 14:08:16.131  1204  1204 D CameraService: some message"
+KEPT_CASES["GB4PC_E2E"]="05-25 14:08:16.131  1204  1204 I GB4PC_E2E: launchPixelCamera: am start attempt 1/3"
 KEPT_CASES["E/<tag>"]="05-25 14:08:16.131  1204  1204 E/SomeTag: some error"
 
 for LABEL in "${!KEPT_CASES[@]}"; do


### PR DESCRIPTION
Fixes #233.

> Note: this PR was re-scoped after a review on the previous (UsageStats-lag) approach.
> The earlier `OverlayServiceLogic` retry change has been dropped because CI logs disproved its premise; see the [investigation comment](https://github.com/aunger/gallery-button-for-pixel-camera/pull/362#issuecomment-4678088778).
> This PR now contains an E2E-harness fix only.

## Problem

`PixelCameraOverlayE2ETest.overlayAppearsWhenViewfinderOpens` has failed persistently in CI (26+ recurrences across `main` and many branches): the overlay never becomes active within 30 s of launching Pixel Camera.

## Root cause

Confirmed from CI logcat (run `27109982390`, `main` @ `6b57c39`, job `80005861193`, step "Run PixelCameraOverlayE2ETest"). `overlayAppearsWhenViewfinderOpens` is the **first** test in the suite to launch the camera, and its launch is torn down inside its own OPEN window-transition, ~3 ms after START, before the activity reaches `onResume()`:

```
00:56:14.274  ActivityTaskManager: START ... MockCameraActivity ... result code=0
00:56:14.277  WindowManager: Force removing ActivityRecord{... MockCameraActivity t34}
00:56:14.374  WindowManager: Attempted to add application window with unknown token
              ...MockCameraActivity t-1 f. Aborting.
00:56:44.253  UiDevice: Taking screenshot ..._overlayAppearsWhenViewfinderOpens_failure.png
00:56:45.124  TestRunner: failed: overlayAppearsWhenViewfinderOpens
```

`MockCameraActivity` only calls `openCamera()` from `onResume()`. On this launch the activity never resumes, so:

- there is **no `CameraService::connect`** and **no `CameraDevice.onOpened`** anywhere in the 30 s window (the first `CameraService::connect` is at `00:56:47.463`, in the *next* test);
- `CameraManager.AvailabilityCallback.onCameraUnavailable` never fires;
- `evaluateForeground()` is never entered and the overlay never activates.

This is a launch-transition race in the E2E harness, **not** an `OverlayServiceLogic` timing/UsageStats-lag bug.
Corroboration: the very next test, `overlayAppearsAfterUsageStatsLag`, relaunches the camera and gets a clean `connect` -> `onOpened` (~30 ms) and **passes in ~2.4 s**; every later launch in the run is likewise healthy.
Only the *first* launch is killed before the camera opens.

## Fix

Make `E2EFixture.launchPixelCamera()` resilient to the first-launch teardown: re-issue the `am start` (up to 3 attempts) until `OverlayService.isOverlayActive` becomes true, which is the observable proof the activity reached `onResume()` and opened the camera.

To keep that proof sound, the verify windows are tiered rather than flat:

- A bounded `LAUNCH_BASELINE_MS` (3 s) wait first establishes a known-inactive baseline, so each attempt observes a genuine false -> true transition and a stale `true` left over from a previous test cannot masquerade as confirmation of the new launch.
- The **first** attempt gets `LAUNCH_FIRST_VERIFY_MS` (12 s), inside the 20 s budget `waitForOverlayActive()` already deems legitimate for a slow-but-healthy activation (~9 s camera open + ~1 s UsageStats). This avoids false-positiving a healthy launch and re-issuing `am start` over a mid-resume activity (which would itself race the OPEN transition).
- Follow-up attempts use the shorter `LAUNCH_RETRY_VERIFY_MS` (6 s), since recovery from the teardown failure mode is fast (every observed non-first launch opens the camera in ~30 ms).

The retry is bounded so a genuinely broken launch still fails the caller's own activation assertion rather than hanging.
The worst case for a genuinely broken launch is `3 + 12 + 2 x 6 = 27 s`, under the 30 s assertion, so `launchPixelCamera()` returns and lets the caller's own assertion fail rather than hang.
On a healthy launch it returns as soon as the overlay activates.

No production code is changed and no existing test requirement is loosened.

## Diagnostic logging

`launchPixelCamera()` now emits `Log.i`/`Log.w` lines (tag `GB4PC_E2E`) on each `am start` attempt, on the attempt the overlay activates on, on a retry after a suspected teardown, and on exhaustion.
This is a direct response to the review request for a run whose logcat *shows the teardown race occurring on the first launch and the retry recovering from it*: with this in place, when #233 recurs in CI the logcat will explicitly state which attempt re-issued the launch and which one the overlay activated on, instead of leaving the retry/recovery to be inferred by grepping for the absence of `CameraService::connect`.
This is a test-harness-only change; no production code path is touched.

## Tests and validation status

The fix targets the E2E harness; the affected assertion (`overlayAppearsWhenViewfinderOpens`) runs only in CI on the emulator.
`app:testDebugUnitTest` is unchanged and passes locally; `app:compileDebugAndroidTestKotlin` compiles cleanly.

**The CI evidence does not yet positively confirm the retry path resolves the failure.**
The prior green run (`27331152010`, HEAD `ae71ead`) had its first camera launch succeed immediately on attempt 1 (`onOpened` ~0.9 s after START, no force-removal of the launch's own `ActivityRecord`), so the `repeat(LAUNCH_ATTEMPTS)` retry branches were never exercised, per the [latest review](https://github.com/aunger/gallery-button-for-pixel-camera/pull/362#pullrequestreview-4475731786). The `Force removing ... t36` line in that run is unrelated debris from a previous step's APK reinstall, not the OPEN-transition race this PR targets.

Because #233 is intermittent (it does not reproduce on every run), a single green run cannot by itself validate a race-condition fix: a green result is the expected outcome whether or not the fix works, when the race simply did not trigger.
What this PR can stand on:

- The root-cause logcat evidence (run `27109982390`) that establishes the first-launch teardown as the failure mode.
- The reasoning in the companion-object comment for why the tiered verify windows are correct (no false-positive on a healthy launch; bounded so a broken launch fails the caller's assertion rather than hanging; budget `3 + 12 + 2 x 6 = 27 s` < 30 s).
- The new `GB4PC_E2E` diagnostic logging, which turns the *next* recurrence of #233 in CI into the positive confirmation the reviewer asked for (it will show the teardown race on the first launch and the retry recovering), rather than relying on catching the intermittent race in a single re-run.

The change cannot manufacture the intermittent teardown race on demand, so the conclusive logcat (race + recovery on the first launch) will arrive on the next CI run that happens to trigger it; the diagnostic logging is what makes that run self-evident when it occurs.