### PR TITLE
Document overlayAppearsAfterUsageStatsLag's reduced scope after launchPixelCamera's blocking wait (refs #249, #369)

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -84,39 +84,45 @@ class PixelCameraOverlayE2ETest {
     }
 
     /**
-     * Regression test for the UsageStats-lag retry (DT-06a / Constants.ACTIVATION_RETRY_MS).
+     * Regression test for the UsageStats-lag retry (DT-06a / Constants.ACTIVATION_RETRY_MS)
+     * and a final-state assertion that the overlay is active after [E2EFixture.launchPixelCamera].
      *
      * When Pixel Camera starts, the CameraManager fires onCameraUnavailable almost immediately,
      * but UsageStatsManager may not reflect Pixel Camera as the foreground app for ~800 ms.
      * Without the retry in OverlayServiceLogic, the overlay never appears if the initial
      * evaluateForeground() call finds no foreground package.
      *
-     * This test verifies the overlay still appears within camera-open latency +
-     * ACTIVATION_RETRY_MS + headroom, which is only reliably achievable if the retry
-     * mechanism is in place.
+     * Note on [E2EFixture.launchPixelCamera] (issue #233 / #362): that helper does not return
+     * until `OverlayService.isOverlayActive` is already `true` (or its own ~27 s retry budget is
+     * exhausted). So in the healthy case, the `waitForCondition` call below observes `true` on
+     * its very first poll; the DT-06a retry described above has typically already run to
+     * completion *inside* `launchPixelCamera()`, before this test's own wait begins. This test's
+     * `timeoutMs` therefore mostly provides headroom for the case where the overlay is active but
+     * then deactivates again (e.g. via the debounce/deactivation path) between
+     * `launchPixelCamera()` returning and this check running; it is not the primary mechanism
+     * that exercises the ACTIVATION_RETRY_MS retry (issue #369).
      */
     @Test
     fun overlayAppearsAfterUsageStatsLag() {
         // Launch PC — camera unavailable fires quickly; UsageStats may lag behind.
+        // launchPixelCamera() already waits (internally) for isOverlayActive to become true, so
+        // by the time it returns the DT-06a retry has normally already completed (see the
+        // class-level note on issue #369 above).
         fixture.launchPixelCamera()
 
-        // Generous window: camera-open latency + ACTIVATION_RETRY_MS (1 s) + headroom for
-        // scheduling overhead on loaded CI runners.
-        //
-        // waitForOverlayActive()'s 20 s default budgets ~9 s for camera open plus up to 1 s for
-        // UsageStats detection on CI emulators. This test additionally needs the
-        // ACTIVATION_RETRY_MS (1 s) retry delay to elapse *after* that initial detection window,
-        // since the retry only fires once the first evaluateForeground() finds no foreground
-        // package. Using only ACTIVATION_RETRY_MS + 6 s (7 s total) was tighter than the 9 s
-        // camera-open figure documented elsewhere and flaked under CI load (issue #249).
-        //
-        // 9 s camera-open + ACTIVATION_RETRY_MS (1 s) + 5 s headroom = 15 s. The extra slack
-        // avoids flakiness without defeating the test's purpose (proving the retry fires at all).
+        // Headroom window: covers the unlikely case that the overlay deactivates again between
+        // launchPixelCamera() returning and the check below, e.g. via the debounce/deactivation
+        // path in OverlayServiceLogic. 9 s camera-open + ACTIVATION_RETRY_MS (1 s) +
+        // 5 s headroom = 15 s, matching the budget documented in
+        // E2EFixture.waitForOverlayActive(). This is intentionally generous: a tight timeout here
+        // (e.g. the previous 7 s) risked flaking under CI load (issue #249) without making the
+        // assertion any more meaningful, since launchPixelCamera() has already established
+        // isOverlayActive == true in the common case.
         val timeoutMs = 9000L + Constants.ACTIVATION_RETRY_MS + 5000L
         val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         assertTrue(
-            "Overlay should appear within ${timeoutMs} ms even when UsageStats lags behind " +
-                "the camera callback (requires the ACTIVATION_RETRY_MS retry in OverlayServiceLogic)",
+            "Overlay should be active after launchPixelCamera() (and remain or become active " +
+                "again within ${timeoutMs} ms if it had deactivated)",
             appeared
         )
     }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -91,19 +91,28 @@ class PixelCameraOverlayE2ETest {
      * Without the retry in OverlayServiceLogic, the overlay never appears if the initial
      * evaluateForeground() call finds no foreground package.
      *
-     * This test verifies the overlay still appears within ACTIVATION_RETRY_MS + 1 s, which is
-     * only reliably achievable if the retry mechanism is in place.
+     * This test verifies the overlay still appears within camera-open latency +
+     * ACTIVATION_RETRY_MS + headroom, which is only reliably achievable if the retry
+     * mechanism is in place.
      */
     @Test
     fun overlayAppearsAfterUsageStatsLag() {
         // Launch PC — camera unavailable fires quickly; UsageStats may lag behind.
         fixture.launchPixelCamera()
 
-        // Generous window: ACTIVATION_RETRY_MS (1 s) + 6 s headroom for scheduling overhead on
-        // loaded CI runners. The retry fires at ~1 s; the extra slack avoids flakiness without
-        // defeating the test's purpose (proving the retry fires at all). 6 s headroom is used
-        // because CI emulators can take up to 9 s for camera open + UsageStats detection.
-        val timeoutMs = Constants.ACTIVATION_RETRY_MS + 6000L
+        // Generous window: camera-open latency + ACTIVATION_RETRY_MS (1 s) + headroom for
+        // scheduling overhead on loaded CI runners.
+        //
+        // waitForOverlayActive()'s 20 s default budgets ~9 s for camera open plus up to 1 s for
+        // UsageStats detection on CI emulators. This test additionally needs the
+        // ACTIVATION_RETRY_MS (1 s) retry delay to elapse *after* that initial detection window,
+        // since the retry only fires once the first evaluateForeground() finds no foreground
+        // package. Using only ACTIVATION_RETRY_MS + 6 s (7 s total) was tighter than the 9 s
+        // camera-open figure documented elsewhere and flaked under CI load (issue #249).
+        //
+        // 9 s camera-open + ACTIVATION_RETRY_MS (1 s) + 5 s headroom = 15 s. The extra slack
+        // avoids flakiness without defeating the test's purpose (proving the retry fires at all).
+        val timeoutMs = 9000L + Constants.ACTIVATION_RETRY_MS + 5000L
         val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         assertTrue(
             "Overlay should appear within ${timeoutMs} ms even when UsageStats lags behind " +

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -33,6 +33,19 @@ import org.junit.runner.RunWith
  *   - Package-signature validation (stub installed under same package ID
  *     but not signed the same way as real Pixel Camera)
  * True E2E on a physical Pixel device is tracked in issue #15.
+ *
+ * ### [E2EFixture.launchPixelCamera] already waits for overlay activation (issue #233 / #362 / #369)
+ *
+ * [E2EFixture.launchPixelCamera] does not return until `OverlayService.isOverlayActive` is
+ * already `true` (or its own ~27 s retry budget is exhausted). Every test below that calls
+ * `launchPixelCamera()` and then polls `isOverlayActive` (directly or via
+ * [E2EFixture.waitForOverlayActive]) therefore observes `true` on its very first poll in the
+ * healthy case; `launchPixelCamera()` just finished waiting for exactly that condition. Any
+ * `timeoutMs` passed to that follow-up poll is mostly headroom for the unlikely case that the
+ * overlay deactivates again (e.g. via the debounce/deactivation path in `OverlayServiceLogic`)
+ * between `launchPixelCamera()` returning and the check running, not the primary mechanism that
+ * exercises activation (including the DT-06a `ACTIVATION_RETRY_MS` retry, which has normally
+ * already run to completion inside `launchPixelCamera()`).
  */
 @E2ETest
 @RunWith(AndroidJUnit4::class)
@@ -92,22 +105,16 @@ class PixelCameraOverlayE2ETest {
      * Without the retry in OverlayServiceLogic, the overlay never appears if the initial
      * evaluateForeground() call finds no foreground package.
      *
-     * Note on [E2EFixture.launchPixelCamera] (issue #233 / #362): that helper does not return
-     * until `OverlayService.isOverlayActive` is already `true` (or its own ~27 s retry budget is
-     * exhausted). So in the healthy case, the `waitForCondition` call below observes `true` on
-     * its very first poll; the DT-06a retry described above has typically already run to
-     * completion *inside* `launchPixelCamera()`, before this test's own wait begins. This test's
-     * `timeoutMs` therefore mostly provides headroom for the case where the overlay is active but
-     * then deactivates again (e.g. via the debounce/deactivation path) between
-     * `launchPixelCamera()` returning and this check running; it is not the primary mechanism
-     * that exercises the ACTIVATION_RETRY_MS retry (issue #369).
+     * See the class-level note above on [E2EFixture.launchPixelCamera] (issue #233 / #362 /
+     * #369): in the healthy case the DT-06a retry has normally already completed inside
+     * `launchPixelCamera()`, so the `waitForCondition` call below is mostly a final-state
+     * assertion plus headroom for a deactivate-and-reactivate race.
      */
     @Test
     fun overlayAppearsAfterUsageStatsLag() {
         // Launch PC — camera unavailable fires quickly; UsageStats may lag behind.
-        // launchPixelCamera() already waits (internally) for isOverlayActive to become true, so
-        // by the time it returns the DT-06a retry has normally already completed (see the
-        // class-level note on issue #369 above).
+        // launchPixelCamera() already waits (internally) for isOverlayActive to become true; see
+        // the class-level note above.
         fixture.launchPixelCamera()
 
         // Headroom window: covers the unlikely case that the overlay deactivates again between

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -120,11 +120,14 @@ class PixelCameraOverlayE2ETest {
         // Headroom window: covers the unlikely case that the overlay deactivates again between
         // launchPixelCamera() returning and the check below, e.g. via the debounce/deactivation
         // path in OverlayServiceLogic. 9 s camera-open + ACTIVATION_RETRY_MS (1 s) +
-        // 5 s headroom = 15 s, matching the budget documented in
-        // E2EFixture.waitForOverlayActive(). This is intentionally generous: a tight timeout here
-        // (e.g. the previous 7 s) risked flaking under CI load (issue #249) without making the
-        // assertion any more meaningful, since launchPixelCamera() has already established
-        // isOverlayActive == true in the common case.
+        // 5 s headroom = 15 s. This is deliberately smaller than the 20 s default in
+        // E2EFixture.waitForOverlayActive(), because that method's budget covers a primary wait
+        // for activation, whereas launchPixelCamera() has already established
+        // isOverlayActive == true here in the common case; this window only needs to cover a
+        // re-activation after a deactivation, not the original 9 s camera-open latency from a
+        // cold start. Even so, it is intentionally generous: a tight timeout here (e.g. the
+        // previous 7 s) risked flaking under CI load (issue #249) without making the assertion
+        // any more meaningful.
         val timeoutMs = 9000L + Constants.ACTIVATION_RETRY_MS + 5000L
         val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         assertTrue(


### PR DESCRIPTION
Refs #249. Refs #369.

## This PR is documentation-only; it does not fix #249

Per review, this PR's diff (a `7000L` -> `9000L + ACTIVATION_RETRY_MS + 5000L` timeout change plus comment/docstring rewording) does not change whether or when `overlayAppearsAfterUsageStatsLag` can fail the way issue #249 describes. It should not auto-close #249 on merge, so this description intentionally avoids the "Fixes" keyword.

## Background

PR #362 (issue #233), merged into `main` before this PR's base, changed `E2EFixture.launchPixelCamera()` so that it does not return until `OverlayService.isOverlayActive` is already `true` (or its own ~27 s retry budget is exhausted).

By the time `overlayAppearsAfterUsageStatsLag()` reaches:

```kotlin
val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
```

`isOverlayActive` is, in the healthy case, already `true`, so `waitForCondition` returns `true` on its first poll regardless of `timeoutMs`. Widening the timeout from 7 s to 15 s does not change whether this assertion passes in that case.

All four historical failures recorded in issue #249 predate the #233/#362 merge, so they reflect a failure mode (no `launchPixelCamera()` gating) that no longer exists on current `main`.

## What this PR does

- Keeps the widened 15 s timeout (`9000L + ACTIVATION_RETRY_MS + 5000L`, matching `E2EFixture.waitForOverlayActive()`'s documented budget) as harmless headroom for the case where the overlay deactivates again between `launchPixelCamera()` returning and this check.
- Rewrites the test's docstring and assertion message to accurately describe its current role: a final-state assertion plus headroom, not the primary mechanism that exercises the DT-06a `ACTIVATION_RETRY_MS` retry (which normally already completed inside `launchPixelCamera()`).
- Moves the shared "`launchPixelCamera()` already waits for activation" context to a class-level comment, since `overlayAppearsWhenViewfinderOpens` and `overlayDisappearsWhenViewfinderCloses` share the same property.

No production code changes; single test file, comment and assertion-message updates only.

## What this PR does not do

- It does not investigate or fix whether `overlayAppearsAfterUsageStatsLag` can still fail post-#362, or what the correct fix would be if so. That investigation is tracked in #369 and is left open.
- Issue #249 should remain open until #369's questions are answered with an actual fix (or a determination that none is needed).

## Test plan

- [x] `./gradlew :app:compileDebugAndroidTestKotlin` succeeds.
- [x] `./gradlew :app:testDebugUnitTest --tests "com.gb4pc.service.OverlayServiceLogicTest"` - all tests pass, confirming the underlying retry logic is correct.
- [x] CI run of `overlayAppearsAfterUsageStatsLag` on the connected E2E suite passes (run 27431984123), though per #369 this is expected regardless of this diff and is not evidence of a fix for #249.
