### PR TITLE
Fix Pixel Camera missing-card test for mock-camera CI environment

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,7 +20,6 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-com.gb4pc.ui.MainActivityRedirectTest#mainScreen_showsPixelCameraMissingCard_whenNotInstalled   # issue #303
 com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton                              # issue #304
 com.gb4pc.ui.MainActivityRedirectTest#pickerScreen_loadsApps_andShowsSettingsApp                # issue #305
 

--- a/app/src/androidTest/java/com/gb4pc/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/gb4pc/ui/MainActivityTest.kt
@@ -11,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.gb4pc.data.PrefsManager
 import com.gb4pc.ui.settings.MainActivity
 import com.gb4pc.ui.setup.SetupActivity
+import com.gb4pc.util.PermissionHelper
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -76,9 +77,19 @@ class MainSettingsScreenTest {
     }
 
     @Test
-    fun mainScreen_showsPixelCameraMissingCard_whenNotInstalled() {
-        // On an emulator Pixel Camera is never present — the error card must be visible
-        composeRule.onNodeWithText("Pixel Camera is not installed", substring = true)
-            .assertIsDisplayed()
+    fun mainScreen_showsPixelCameraMissingCard_matchingInstalledState() {
+        // The e2e-mock-camera stub shares Pixel Camera's applicationId, so on CI
+        // (and on any device where it has been side-loaded) isPixelCameraInstalled
+        // is true and the missing-camera card must be hidden. On a real device
+        // without Pixel Camera (or its stub) installed, the card must be shown.
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val cameraInstalled = PermissionHelper.isPixelCameraInstalled(context)
+
+        val cardNode = composeRule.onNodeWithText("Pixel Camera is not installed", substring = true)
+        if (cameraInstalled) {
+            cardNode.assertDoesNotExist()
+        } else {
+            cardNode.assertIsDisplayed()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #303.

`MainSettingsScreenTest#mainScreen_showsPixelCameraMissingCard_whenNotInstalled` asserted that the "Pixel Camera is not installed" card is always displayed, based on the comment "On an emulator Pixel Camera is never present." That assumption is no longer true: `e2e-mock-camera` installs a stub APK under Pixel Camera's applicationId (`com.google.android.GoogleCamera`) before the instrumented test suite runs (see the "CI pre-flight" and "Run E2E emulator setup" steps in `.github/workflows/build.yml`). As a result, `PermissionHelper.isPixelCameraInstalled()` returns `true` on CI, `MainSettingsScreen` correctly hides the missing-camera card, and the old assertion that it must be displayed always failed.

## Changes

- Renamed and rewrote the test as `mainScreen_showsPixelCameraMissingCard_matchingInstalledState`: it now reads `PermissionHelper.isPixelCameraInstalled()` at runtime and asserts the card is shown only when Pixel Camera (or its CI stub) is *not* installed, and hidden (`assertDoesNotExist()`) when it *is* installed. This makes the test correct both on CI (mock camera installed) and on a real device without Pixel Camera.
- Removed the test from `.github/allowed-test-failures.txt` (issue #303 entry), since it should now pass.

## Test plan

- [x] `./gradlew assembleDebug assembleDebugAndroidTest testDebugUnitTest` passes locally.
- [ ] CI instrumented test run confirms `MainSettingsScreenTest#mainScreen_showsPixelCameraMissingCard_matchingInstalledState` passes (mock camera installed -> card hidden).

