### PR TITLE
Fix picker instrumented test for default photo-app filter

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -21,7 +21,6 @@
 # removed from this list as it is fixed.
 
 com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton                              # issue #304
-com.gb4pc.ui.MainActivityRedirectTest#pickerScreen_loadsApps_andShowsSettingsApp                # issue #305
 
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230

--- a/app/src/androidTest/java/com/gb4pc/ui/picker/PickerActivityTest.kt
+++ b/app/src/androidTest/java/com/gb4pc/ui/picker/PickerActivityTest.kt
@@ -1,8 +1,10 @@
 package com.gb4pc.ui.picker
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -31,14 +33,28 @@ class PickerActivityTest {
 
     @Test
     fun pickerScreen_loadsApps_andShowsSettingsApp() {
-        // "Settings" is present on every Android device/emulator.
-        // Waiting up to 10 s covers the async IO query introduced in issue #8.
+        // The picker defaults to a "photo-related apps" filter (UI-09), which "Settings"
+        // never matches. Wait for the async app-list query introduced in issue #8 to
+        // finish, then switch to the full app list (always present on every Android
+        // device/emulator) so "Settings" is shown.
         composeRule.waitUntil(timeoutMillis = 10_000) {
             composeRule
-                .onAllNodes(androidx.compose.ui.test.hasText("Settings"))
+                .onAllNodes(hasText("Settings") or hasText("Show all apps"))
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+
+        val showAllButton = composeRule.onAllNodes(hasText("Show all apps")).fetchSemanticsNodes()
+        if (showAllButton.isNotEmpty()) {
+            composeRule.onNodeWithText("Show all apps").performClick()
+            composeRule.waitUntil(timeoutMillis = 10_000) {
+                composeRule
+                    .onAllNodes(hasText("Settings"))
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        }
+
         composeRule.onNodeWithText("Settings").assertIsDisplayed()
     }
 }


### PR DESCRIPTION
Fixes #305.

`PickerActivityTest.pickerScreen_loadsApps_andShowsSettingsApp` waited for "Settings" to appear in the picker's app list and then timed out after 10 s.

The picker now defaults to a "photo-related apps" filter (UI-09), introduced after this test was written. "Settings" never matches that filter, so it never appears unless the user taps "Show all apps". The "Show all apps" button is shown whenever `showAll` is false; `showAll` auto-flips to true only when `AppListFilter.buildPhotoRelatedPackages` returns an empty candidate set, in which case the full app list (including "Settings") is shown directly without the button.

The test now:
1. Waits for either "Settings" or the "Show all apps" toggle to appear (covering the async app-list query from #8).
2. If "Show all apps" is present (the photo-related candidate set was non-empty), clicks it and waits for "Settings" to appear in the full list.
3. Asserts "Settings" is displayed.

This covers both cases: an emulator where the photo-related candidate set is empty (picker auto-shows all apps) and one where it is non-empty (test switches to the full list via "Show all apps").
