### PR TITLE
Fix setup screen test for non-Grant first-step button labels

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,8 +20,6 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton                              # issue #304
-
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231

--- a/app/src/androidTest/java/com/gb4pc/ui/SetupActivityTest.kt
+++ b/app/src/androidTest/java/com/gb4pc/ui/SetupActivityTest.kt
@@ -2,13 +2,16 @@ package com.gb4pc.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.gb4pc.R
 import com.gb4pc.data.PrefsManager
 import com.gb4pc.ui.setup.SetupActivity
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,9 +44,28 @@ class SetupActivityTest {
     }
 
     @Test
-    fun setupScreen_showsGrantButton() {
-        // Every step has a "Grant …" button — at least one should be present
-        composeRule.onNodeWithText("Grant", substring = true).assertIsDisplayed()
+    fun setupScreen_showsActionButton() {
+        // Every step has a primary action button, but its label depends on
+        // the step (e.g. "Allow Notifications", "Grant Usage Access", "Grant
+        // Overlay Permission", "Exclude from Battery Optimization"); not all
+        // of them say "Grant". Whichever step is shown first, its button
+        // should be present.
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val possibleButtonTexts = listOf(
+            R.string.setup_notification_button,
+            R.string.setup_usage_access_button,
+            R.string.setup_overlay_button,
+            R.string.setup_battery_button,
+        ).map { context.getString(it) }
+
+        val displayedButtons = possibleButtonTexts.filter { text ->
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertTrue(
+            "Expected one of $possibleButtonTexts to be displayed, but none were found",
+            displayedButtons.isNotEmpty()
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #304.

`SetupActivityTest.setupScreen_showsGrantButton` asserted that a node with text containing "Grant" is displayed on the setup screen. On API 33+ emulators, the setup flow's first step is `NOTIFICATION`, whose button label is "Allow Notifications" (it does not contain "Grant"). Similarly, the `BATTERY` step's button reads "Exclude from Battery Optimization". When either of these is the first displayed step, the substring assertion fails with:

```
java.lang.AssertionError: Assert failed: The component is not displayed!
```

## Fix

Renamed the test to `setupScreen_showsActionButton` and changed it to check whether any of the four possible step-button labels (`setup_notification_button`, `setup_usage_access_button`, `setup_overlay_button`, `setup_battery_button`) is currently displayed. This makes the test pass regardless of which step is shown first, while still asserting that the setup screen renders its primary action button.

Also removed the now-resolved `com.gb4pc.ui.MainActivityRedirectTest#setupScreen_showsGrantButton` entry from `.github/allowed-test-failures.txt` (the entry's class name was a mislabeling from the auto-filed issue; the actual failing test is `com.gb4pc.ui.SetupActivityTest`, per the reported stack trace).

## Test plan

- [x] `./gradlew compileDebugKotlin compileDebugAndroidTestKotlin` succeeds
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Instrumented test `com.gb4pc.ui.SetupActivityTest#setupScreen_showsActionButton` passes on CI (requires emulator)
