### PR TITLE
Remove 'state=open' filter from test-failure-archive query

### DIFF
--- a/scripts/archive_stale_test_failures.py
+++ b/scripts/archive_stale_test_failures.py
@@ -67,7 +67,7 @@ def fetch_stale_issues(repo: str, token: str, cutoff: datetime.datetime) -> list
     page = 1
     while True:
         batch = gh_api(
-            f"repos/{repo}/issues?state=open&labels=test-failure&per_page=100&page={page}",
+            f"repos/{repo}/issues?labels=test-failure&per_page=100&page={page}",
             token=token,
         )
         if not batch:

--- a/scripts/archive_stale_test_failures.py
+++ b/scripts/archive_stale_test_failures.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Archive stale test-failure GitHub issues.
 
-Finds all open issues labelled ``test-failure`` whose ``updated_at``
-timestamp is older than STALE_DAYS (default 21).  For each such issue
-the ``test-failure`` label is removed and ``test-failure-archive`` is
-added, so it falls out of the Phase 4 dedup search scope.
+Finds all issues (open or closed) labelled ``test-failure`` whose
+``updated_at`` timestamp is older than STALE_DAYS (default 21).  For
+each such issue the ``test-failure`` label is removed and
+``test-failure-archive`` is added, so it falls out of the Phase 4
+dedup search scope.  Closed issues are included because a closed
+issue that still carries ``test-failure`` remains within
+``find_existing_issue``'s dedup search and could be reopened by a
+later failure of the same test.
 
 Usage:
     python3 scripts/archive_stale_test_failures.py
@@ -59,7 +63,7 @@ def gh_api(path: str, token: str, method: str = "GET", body: object = None) -> o
 # ---------------------------------------------------------------------------
 
 def fetch_stale_issues(repo: str, token: str, cutoff: datetime.datetime) -> list[dict]:
-    """Return all open test-failure issues last updated before *cutoff*.
+    """Return all test-failure issues, open or closed, last updated before *cutoff*.
 
     Paginates through all pages automatically.
     """

--- a/scripts/test_archive_stale_test_failures.py
+++ b/scripts/test_archive_stale_test_failures.py
@@ -19,13 +19,16 @@ _NOW = datetime(2026, 5, 25, 4, 0, 0, tzinfo=timezone.utc)
 _CUTOFF = _NOW - timedelta(days=21)  # 2026-05-04T04:00:00+00:00
 
 
-def _make_issue(number: int, title: str, updated_at: datetime, labels: list[str]) -> dict:
+def _make_issue(
+    number: int, title: str, updated_at: datetime, labels: list[str], state: str = "open"
+) -> dict:
     """Build a minimal GitHub issue dict as returned by the API."""
     return {
         "number": number,
         "title": title,
         "updated_at": updated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "labels": [{"name": lbl} for lbl in labels],
+        "state": state,
     }
 
 
@@ -174,6 +177,26 @@ class TestFetchStaleIssues(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["number"], 1)
 
+    def test_stale_closed_issue_returned(self):
+        """A closed, stale, test-failure issue is included (not just open ones)."""
+        stale_ts = _CUTOFF - timedelta(days=1)
+        issue = _make_issue(4, "Closed stale failure", stale_ts, ["test-failure"], state="closed")
+
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([[issue], []])):
+            result = astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["number"], 4)
+
+    def test_query_does_not_filter_by_state(self):
+        """The issues query omits state=open so closed issues are also fetched."""
+        with patch.object(astf, "gh_api", side_effect=self._gh_api_side_effect([[], []])) as mock_api:
+            astf.fetch_stale_issues("owner/repo", "tok", _CUTOFF)
+
+        path = mock_api.call_args_list[0][0][0]
+        self.assertNotIn("state=open", path)
+        self.assertIn("labels=test-failure", path)
+
 
 # ---------------------------------------------------------------------------
 # archive_issue tests
@@ -306,6 +329,18 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(result, 0)
         mock_archive.assert_not_called()
+
+    def test_archives_stale_closed_issue(self):
+        """A closed, stale, test-failure issue returned by fetch_stale_issues is archived."""
+        stale_ts = datetime.now(timezone.utc) - timedelta(days=30)
+        closed_issue = _make_issue(12, "Closed stale", stale_ts, ["test-failure"], state="closed")
+
+        with patch.object(astf, "fetch_stale_issues", return_value=[closed_issue]):
+            with patch.object(astf, "archive_issue") as mock_archive:
+                result = astf.main()
+
+        self.assertEqual(result, 0)
+        mock_archive.assert_called_once_with(closed_issue, "owner/repo", "test-token")
 
     def test_continues_after_single_archive_failure(self):
         """An error on one issue does not prevent processing subsequent issues."""


### PR DESCRIPTION
The intended `test-failure` tag process is for issues to be closed as normal, by a PR. The tag will remain in place when the issue is closed. If the same test fails soon thereafter (within a configurable number of archive days), CI will reopen the issue. After that archive duration, a scheduled Action will replace the tag with `test-failure-archive`, which marks the issue as no longer revivable.

That process means that the scheduled archiver process must replace the tags even on issues that are already closed.