### PR TITLE
Make the DT-06a activation retry bounded-but-multi-attempt for long UsageStats lag

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -97,13 +97,15 @@ class PixelCameraOverlayE2ETest {
     }
 
     /**
-     * Regression test for the UsageStats-lag retry (DT-06a / Constants.ACTIVATION_RETRY_MS)
-     * and a final-state assertion that the overlay is active after [E2EFixture.launchPixelCamera].
+     * Regression test for the UsageStats-lag retry (DT-06a / Constants.ACTIVATION_RETRY_MS) and a
+     * final-state assertion that the overlay is active after [E2EFixture.launchPixelCamera].
      *
      * When Pixel Camera starts, the CameraManager fires onCameraUnavailable almost immediately,
-     * but UsageStatsManager may not reflect Pixel Camera as the foreground app for ~800 ms.
-     * Without the retry in OverlayServiceLogic, the overlay never appears if the initial
-     * evaluateForeground() call finds no foreground package.
+     * but UsageStatsManager may not reflect Pixel Camera as the foreground app for ~800 ms (and
+     * longer under CI load). Without the retry in OverlayServiceLogic, the overlay never appears if
+     * the initial evaluateForeground() call finds no foreground package. The retry re-schedules
+     * itself up to Constants.ACTIVATION_RETRY_MAX_ATTEMPTS times (issue #249), so lag longer than a
+     * single ACTIVATION_RETRY_MS interval is tolerated rather than permanently dropping activation.
      *
      * See the class-level note above on [E2EFixture.launchPixelCamera] (issue #233 / #362 /
      * #369): in the healthy case the DT-06a retry has normally already completed inside
@@ -119,16 +121,17 @@ class PixelCameraOverlayE2ETest {
 
         // Headroom window: covers the unlikely case that the overlay deactivates again between
         // launchPixelCamera() returning and the check below, e.g. via the debounce/deactivation
-        // path in OverlayServiceLogic. 9 s camera-open + ACTIVATION_RETRY_MS (1 s) +
-        // 5 s headroom = 15 s. This is deliberately smaller than the 20 s default in
-        // E2EFixture.waitForOverlayActive(), because that method's budget covers a primary wait
-        // for activation, whereas launchPixelCamera() has already established
-        // isOverlayActive == true here in the common case; this window only needs to cover a
-        // re-activation after a deactivation, not the original 9 s camera-open latency from a
-        // cold start. Even so, it is intentionally generous: a tight timeout here (e.g. the
-        // previous 7 s) risked flaking under CI load (issue #249) without making the assertion
-        // any more meaningful.
-        val timeoutMs = 9000L + Constants.ACTIVATION_RETRY_MS + 5000L
+        // path in OverlayServiceLogic. 9 s camera-open + the full activation-retry budget
+        // (ACTIVATION_RETRY_MS x ACTIVATION_RETRY_MAX_ATTEMPTS) + 5 s headroom. This is deliberately
+        // smaller than the 20 s default in E2EFixture.waitForOverlayActive(), because that method's
+        // budget covers a primary wait for activation, whereas launchPixelCamera() has already
+        // established isOverlayActive == true here in the common case; this window only needs to
+        // cover a re-activation after a deactivation, not the original 9 s camera-open latency from
+        // a cold start. Even so, it is intentionally generous: a tight timeout here (e.g. the
+        // previous 7 s) risked flaking under CI load (issue #249) without making the assertion any
+        // more meaningful.
+        val timeoutMs =
+            9000L + Constants.ACTIVATION_RETRY_MS * Constants.ACTIVATION_RETRY_MAX_ATTEMPTS + 5000L
         val appeared = fixture.waitForCondition(timeoutMs) { OverlayService.isOverlayActive }
         assertTrue(
             "Overlay should be active after launchPixelCamera() (and remain or become active " +

--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -23,6 +23,12 @@ object Constants {
     // Retry delay when UsageStats hasn't caught up with the foreground app yet (DT-06a)
     const val ACTIVATION_RETRY_MS = 1000L
 
+    // Maximum number of activation retries per camera-open event (DT-06a). UsageStats can lag the
+    // camera callback by more than a single ACTIVATION_RETRY_MS interval, especially on slow
+    // emulators, so the retry re-schedules itself up to this many times (a total retry budget of
+    // ACTIVATION_RETRY_MS x ACTIVATION_RETRY_MAX_ATTEMPTS) instead of giving up after one attempt.
+    const val ACTIVATION_RETRY_MAX_ATTEMPTS = 5
+
     // Debug log buffer size (UI-10)
     const val DEBUG_LOG_BUFFER_SIZE = 200
 

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -39,11 +39,19 @@ class OverlayServiceLogic(
         private set
 
     private var deactivateRunnable: Runnable? = null
-    // DT-06a: Retry runnable for UsageStats lag — fires if foreground not detected on first check.
-    // activationRetryPending gates re-scheduling: it stays true while the runnable is executing
-    // so that evaluateForeground() inside the runnable cannot queue a second retry.
+    // DT-06a: Retry runnable for UsageStats lag -- fires if foreground not detected on first check.
+    // activationRetryPending gates re-scheduling: it is true exactly while a retry runnable is
+    // posted to the handler, so a burst of evaluateForeground() calls (e.g. several camera events)
+    // cannot stack multiple retries for the same lag.
+    //
+    // UsageStats can lag the camera callback by more than one ACTIVATION_RETRY_MS interval, so the
+    // retry is not one-shot: when a fired retry still finds no foreground package, it re-schedules
+    // itself until the overlay activates, the camera is released, or
+    // Constants.ACTIVATION_RETRY_MAX_ATTEMPTS attempts have been made. activationRetryAttempts
+    // counts attempts made in the current camera-open sequence and is reset by cancelActivationRetry().
     private var activationRetryRunnable: Runnable? = null
     private var activationRetryPending = false
+    private var activationRetryAttempts = 0
 
     // ── Camera callback delegation ──────────────────────────────────────────
 
@@ -214,18 +222,31 @@ class OverlayServiceLogic(
         }
     }
 
-    // DT-06a: Retry activation after UsageStats lag — one shot per camera-open event.
+    // DT-06a: Retry activation after UsageStats lag. Re-schedules itself up to
+    // ACTIVATION_RETRY_MAX_ATTEMPTS times per camera-open event so that UsageStats lag longer than
+    // a single ACTIVATION_RETRY_MS interval is still tolerated.
     private fun scheduleActivationRetry() {
-        if (activationRetryPending) return  // already scheduled or currently executing
-        DebugLog.log("Logic: scheduling activation retry in ${Constants.ACTIVATION_RETRY_MS}ms")
+        if (activationRetryPending) return  // a retry is already posted for this lag
+        if (activationRetryAttempts >= Constants.ACTIVATION_RETRY_MAX_ATTEMPTS) {
+            DebugLog.log(
+                "Logic: activation retry budget exhausted after $activationRetryAttempts attempts; " +
+                    "giving up until the next camera-open event"
+            )
+            return
+        }
+        activationRetryAttempts++
+        DebugLog.log(
+            "Logic: scheduling activation retry ${activationRetryAttempts}/" +
+                "${Constants.ACTIVATION_RETRY_MAX_ATTEMPTS} in ${Constants.ACTIVATION_RETRY_MS}ms"
+        )
         activationRetryPending = true
         val runnable = Runnable {
             activationRetryRunnable = null
-            DebugLog.log("Logic: activation retry firing")
-            // activationRetryPending stays true while evaluateForeground() runs, so any
-            // scheduleActivationRetry() call inside cannot queue a second retry.
-            evaluateForeground()
+            // Clear the pending flag before evaluating so that, if UsageStats still has not caught
+            // up, evaluateForeground() can schedule the next attempt (up to the attempt cap).
             activationRetryPending = false
+            DebugLog.log("Logic: activation retry firing (attempt $activationRetryAttempts)")
+            evaluateForeground()
         }
         activationRetryRunnable = runnable
         handler.postDelayed(runnable, Constants.ACTIVATION_RETRY_MS)
@@ -238,6 +259,7 @@ class OverlayServiceLogic(
             activationRetryRunnable = null
         }
         activationRetryPending = false
+        activationRetryAttempts = 0
     }
 
     /** Called from onDestroy to clean up mutable state. */

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -357,14 +357,13 @@ class OverlayServiceLogicTest {
     }
 
     /**
-     * When the retry fires but UsageStats still has not caught up, no second retry must be
-     * scheduled — the retry is strictly one-shot per camera-open event.
-     *
-     * Without the activationRetryPending flag, scheduleActivationRetry() re-schedules on every
-     * evaluateForeground() call triggered by the runnable, creating a 1 Hz polling loop.
+     * When the retry fires but UsageStats still has not caught up, the retry re-schedules itself
+     * (UsageStats can lag the camera callback by more than one ACTIVATION_RETRY_MS interval). Each
+     * fired retry that still finds no foreground schedules at most one follow-up, so the loop runs
+     * at exactly 1 Hz (one pending postDelayed at a time) rather than fanning out.
      */
     @Test
-    fun `DT-06a retry does not re-schedule when foreground still not detected after firing`() {
+    fun `DT-06a retry re-schedules once per firing when foreground still not detected`() {
         whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
         cameraState.setCameraUnavailable("0")
         logic.evaluateForeground()
@@ -374,9 +373,80 @@ class OverlayServiceLogicTest {
         verify(handler).postDelayed(runnableCaptor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
         runnableCaptor.firstValue.run()
 
-        // Foreground still not detected — must NOT schedule a second postDelayed
-        verify(handler, times(1)).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
+        // Foreground still not detected -- exactly one follow-up retry is scheduled (2 total).
+        verify(handler, times(2)).postDelayed(any(), eq(Constants.ACTIVATION_RETRY_MS))
         assertFalse("Overlay must not be active when foreground was never detected", logic.isOverlayActive)
+    }
+
+    /**
+     * The self-rescheduling retry is bounded: across a single camera-open event it fires at most
+     * ACTIVATION_RETRY_MAX_ATTEMPTS times when UsageStats never catches up, then stops. This proves
+     * the loop cannot poll forever (e.g. if onCameraAvailable's cancel path is somehow missed).
+     */
+    @Test
+    fun `DT-06a retry stops after ACTIVATION_RETRY_MAX_ATTEMPTS when foreground never detected`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        val scheduled = drainActivationRetries()
+
+        // The chain self-terminates after exactly ACTIVATION_RETRY_MAX_ATTEMPTS schedules.
+        assertEquals(Constants.ACTIVATION_RETRY_MAX_ATTEMPTS, scheduled)
+        assertFalse("Overlay must not be active when foreground was never detected", logic.isOverlayActive)
+    }
+
+    /**
+     * A fresh camera-open event resets the retry attempt budget: after a sequence that exhausts the
+     * retries (foreground never detected), releasing and re-opening the camera lets the retry run
+     * the full ACTIVATION_RETRY_MAX_ATTEMPTS again.
+     */
+    @Test
+    fun `DT-06a attempt budget resets on a new camera-open event`() {
+        whenever(foregroundDetector.getForegroundPackage()).thenReturn(null)
+
+        // First sequence: exhaust the budget.
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        val first = drainActivationRetries()
+        assertEquals(Constants.ACTIVATION_RETRY_MAX_ATTEMPTS, first)
+
+        // Camera released, then re-opened: this resets the budget via cancelActivationRetry().
+        logic.onCameraAvailable("0")
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+
+        // The full budget is available again for the new camera-open event. Baseline past the
+        // posts already fired by the first drain so only the second sequence's retries are counted.
+        val second = drainActivationRetries(baseline = first)
+        assertEquals(Constants.ACTIVATION_RETRY_MAX_ATTEMPTS, second)
+    }
+
+    /**
+     * Runs the activation-retry chain to completion and returns the number of retries scheduled in
+     * this drain (i.e. since [baseline] cumulative posts).
+     *
+     * Each fired retry that still finds no foreground package schedules the next one via a new
+     * handler.postDelayed(). This drains that chain by, on each step, capturing every posted
+     * runnable and running the latest one, until a step posts nothing new. The cumulative captor
+     * count grows monotonically, so [baseline] lets a second drain in the same test ignore the
+     * runnables already fired by an earlier drain. Bounded so a non-terminating loop fails the test.
+     */
+    private fun drainActivationRetries(baseline: Int = 0): Int {
+        var total = baseline
+        while (true) {
+            val captor = argumentCaptor<Runnable>()
+            verify(handler, atLeastOnce())
+                .postDelayed(captor.capture(), eq(Constants.ACTIVATION_RETRY_MS))
+            if (captor.allValues.size <= total) break  // no new retry was posted -> chain terminated
+            captor.allValues.last().run()
+            total = captor.allValues.size
+            assertTrue(
+                "Activation retry did not terminate within a bounded number of attempts",
+                total - baseline <= Constants.ACTIVATION_RETRY_MAX_ATTEMPTS * 4
+            )
+        }
+        return total - baseline
     }
 
     /**


### PR DESCRIPTION
Fixes #249.

## Problem

`overlayAppearsAfterUsageStatsLag` exercises the DT-06a UsageStats-lag retry: when Pixel Camera opens, `CameraManager` fires `onCameraUnavailable` almost immediately, but `UsageStatsManager` may not report Pixel Camera as the foreground app until later.
The overlay only activates once that foreground lookup succeeds.

`OverlayServiceLogic` scheduled exactly **one** retry at `ACTIVATION_RETRY_MS` (1 s) and then gave up (the retry was strictly one-shot; a unit test even pinned that behavior).
When the lag exceeded that single interval, the lone retry fired while UsageStats was still behind, found no foreground package, and the overlay then **never** activated.
That lag routinely exceeds 1 s on the slow CI emulator, where `launchPixelCamera()` budgets up to ~9 s for camera-open plus UsageStats detection, which is why this test kept failing.

## Fix

Make the retry re-schedule itself, one pending runnable at a time, up to `Constants.ACTIVATION_RETRY_MAX_ATTEMPTS` (5) times per camera-open event.
The attempt budget resets via `cancelActivationRetry()` whenever the camera is released or the overlay activates, so:

- a healthy activation cancels the retry immediately (unchanged behavior), and
- the loop is strictly bounded and can never poll forever.

## Tests

- Modified the test `DT-06a retry does not re-schedule when foreground still not detected after firing` to assert the new bounded re-scheduling instead. This test's requirement encoded the bug being fixed (it required the retry to give up after a single attempt), so changing it was necessary.
- Added `DT-06a retry stops after ACTIVATION_RETRY_MAX_ATTEMPTS when foreground never detected` (proves the cap).
- Added `DT-06a attempt budget resets on a new camera-open event` (proves a fresh camera-open gets the full budget again).
- Widened the E2E test's headroom window to the full retry budget (`ACTIVATION_RETRY_MS x ACTIVATION_RETRY_MAX_ATTEMPTS`) so its arithmetic and comment stay accurate.

Full `:app:testDebugUnitTest` passes and `:app:compileDebugAndroidTestSources` compiles locally.