### PR TITLE
Add FLAG_LAYOUT_IN_SCREEN to fix overlay vertical position offset

### DIFF
--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -375,13 +375,23 @@ class OverlayManager(
         // FLAG_NOT_TOUCH_MODAL is also set to keep touch events outside the overlay's bounds
         // passing through to the camera app. Trade-off: the focusable window may steal
         // volume/power key events from the camera app even when dispatchKeyEvent returns false.
+        //
+        // FLAG_LAYOUT_IN_SCREEN: without this flag, a TYPE_APPLICATION_OVERLAY window's
+        // Gravity.TOP|START origin is offset below the system status bar, so x/y (computed
+        // above relative to the full display size) land the overlay too far down the screen
+        // (Issue #229 — the overlay rendered ~128 px lower than the configured yPercent).
+        // Combined with FLAG_LAYOUT_NO_LIMITS, this makes (x, y) relative to the true
+        // physical-screen origin (0, 0), matching calculateOverlayXPx/calculateOverlayYPx's
+        // assumptions.
         val windowFlags = if (prefsManager.focusableOverlay) {
             WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                 showWhenLockedFlag
         } else {
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                 showWhenLockedFlag
         }
 

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -252,6 +252,48 @@ class OverlayManagerRobolectricTest {
         )
     }
 
+    // ── Issue #229: overlay positioned relative to the true screen origin ───
+
+    /**
+     * Regression guard for Issue #229: the overlay window's [WindowManager.LayoutParams] must
+     * include `FLAG_LAYOUT_IN_SCREEN` (in addition to `FLAG_LAYOUT_NO_LIMITS`) so that
+     * `Gravity.TOP or Gravity.START` with `x`/`y` set by [calculateOverlayXPx] /
+     * [calculateOverlayYPx] positions the overlay relative to the physical-screen origin
+     * (0, 0), not below the status bar.
+     *
+     * Without this flag, the E2E visual test observed the overlay rendered ~128 px lower
+     * than its configured `yPercent` (BLUE centroid at y=1784 instead of the expected
+     * y=1656 for yPercent=69% on a 2400 px-tall display).
+     */
+    @Test
+    fun `overlay window uses FLAG_LAYOUT_IN_SCREEN so position is relative to screen origin`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager = mock {
+            on { galleryPackage } doReturn null
+            on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+            on { focusableOverlay } doReturn false
+        }
+
+        val overlayManager = OverlayManager(context, prefsManager)
+        overlayManager.show()
+
+        val windowManager = context.getSystemService(WindowManager::class.java)
+        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+        val overlayView = shadowWm.views[0]
+        val params = overlayView.layoutParams as WindowManager.LayoutParams
+
+        assertTrue(
+            "Overlay window must set FLAG_LAYOUT_IN_SCREEN so x/y are relative to the " +
+                "physical-screen origin, not below the status bar (Issue #229).",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN) != 0
+        )
+        assertTrue(
+            "Overlay window must retain FLAG_LAYOUT_NO_LIMITS so it can extend into the " +
+                "system-bar areas.",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0
+        )
+    }
+
     // ── Issue #81: loadThumbnailBitmap fallback ──────────────────────────────
 
     /**


### PR DESCRIPTION
Fixes #229.

## Root cause

`OverlayManager.createLayoutParams()` computes `xPx`/`yPx` via `calculateOverlayXPx`/`calculateOverlayYPx`, which treat `(0, 0)` as the top-left of the full physical screen (matching `displayWidth`/`displayHeight` from `currentWindowMetrics.bounds`).

However, the `TYPE_APPLICATION_OVERLAY` window was only setting `FLAG_LAYOUT_NO_LIMITS`, not `FLAG_LAYOUT_IN_SCREEN`. Without `FLAG_LAYOUT_IN_SCREEN`, a window's `Gravity.TOP or Gravity.START` origin for `x`/`y` is offset below the status bar rather than the true screen origin. The result: the overlay consistently rendered about 128 px lower than the configured `yPercent` on a 1080x2400 display.

This is the cause of the long-standing `test1a_overlayShowsBlueAtConfiguredPosition` E2E failure (issue #229), which has reported the exact same offset (`BLUE centroid at (216.0, 1784.0)` vs expected `(216.0, 1656.0)`, a 128 px gap) on every CI run since 2026-05-25.

## Fix

Add `FLAG_LAYOUT_IN_SCREEN` alongside `FLAG_LAYOUT_NO_LIMITS` in both branches of `createLayoutParams()` (focusable and non-focusable overlay), so the overlay's `x`/`y` are positioned relative to the true screen origin, matching the coordinates `calculateOverlayXPx`/`calculateOverlayYPx` compute and what `test1a_overlayShowsBlueAtConfiguredPosition` expects.

## Tests

- Added a Robolectric regression test (`overlay window uses FLAG_LAYOUT_IN_SCREEN so position is relative to screen origin`) asserting both `FLAG_LAYOUT_IN_SCREEN` and `FLAG_LAYOUT_NO_LIMITS` are set on the overlay's `WindowManager.LayoutParams`.
- All existing unit tests pass (`./gradlew :app:testDebugUnitTest`).
- The E2E suite (including `test1a_overlayShowsBlueAtConfiguredPosition`) runs as part of CI's `build-and-test` job.
