### PR TITLE
Stop allowing test2a_emptyGalleryNoGreenAfterTap to fail (depends on #388)

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -21,6 +21,5 @@
 # removed from this list as it is fixed.
 
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
-com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen    # issue #232

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -349,9 +349,10 @@ class E2EFixture(
      *
      * Issue #229 established that the overlay's rendered position does not match the
      * coordinates computed from [PrefsManager.getOverlayPosition]: the overlay renders about
-     * 128px lower than [calculateOverlayYPx] predicts. Tapping the *computed* position
-     * therefore misses the overlay's clickable view entirely--the tap lands on empty camera-app
-     * space above the icon and silently fails to launch the gallery (issues #230, #231, #232).
+     * 128px lower than `OverlayManager.calculateOverlayYPx` predicts. Tapping the *computed*
+     * position therefore misses the overlay's clickable view entirely--the tap lands on empty
+     * camera-app space above the icon and silently fails to launch the gallery (issues #230,
+     * #231, #232).
      *
      * To tap reliably regardless of that rendering discrepancy, this locates the overlay by its
      * actual on-screen pixels: it takes a fresh screenshot and taps the centroid of the

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -345,24 +345,40 @@ class E2EFixture(
     }
 
     /**
-     * Taps the overlay button at its configured screen position.
+     * Taps the overlay button at its actual rendered position.
      *
-     * Reads the active [com.gb4pc.data.OverlayPosition] from [PrefsManager], computes pixel
-     * coordinates from [android.view.WindowMetrics] (API 30+) or [android.util.DisplayMetrics]
-     * (API 26–29), then dispatches a tap via [UiDevice].
+     * Issue #229 established that the overlay's rendered position does not match the
+     * coordinates computed from [PrefsManager.getOverlayPosition]: the overlay renders about
+     * 128px lower than [calculateOverlayYPx] predicts. Tapping the *computed* position
+     * therefore misses the overlay's clickable view entirely--the tap lands on empty camera-app
+     * space above the icon and silently fails to launch the gallery (issues #230, #231, #232).
      *
-     * If the overlay is not rendered (e.g. blocked in secure-camera mode) this call taps empty
-     * screen space and has no visible effect — the plan requires this silent behaviour for
-     * Tests 4a/5a's baseline-failure scenario.
+     * To tap reliably regardless of that rendering discrepancy, this locates the overlay by its
+     * actual on-screen pixels: it takes a fresh screenshot and taps the centroid of the
+     * YELLOW union BLUE mask (the gallery icon's background and foreground colors, as used by
+     * test1c_overlayOuterIsSquircle).
+     *
+     * If the overlay is not rendered (e.g. blocked in secure-camera mode), the mask is empty and
+     * this falls back to the position computed from [PrefsManager.getOverlayPosition], tapping
+     * empty screen space and having no visible effect, which Tests 4a/5a's baseline-failure
+     * scenario requires.
      */
     fun tapOverlay() {
         val (displayWidth, displayHeight) = displaySize()
 
-        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
-        val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
+        val screen = Screenshot.captureScreen()
+        val iconMask = ColorMatch.union(
+            ColorMatch.mask(screen, Rgb.BLUE),
+            ColorMatch.mask(screen, Rgb.YELLOW)
+        )
 
-        val x = (pos.xPercent / 100f * displayWidth).toInt()
-        val y = (pos.yPercent / 100f * displayHeight).toInt()
+        val (x, y) = if (iconMask.pixelCount > 0) {
+            iconMask.centroid.x.toInt() to iconMask.centroid.y.toInt()
+        } else {
+            val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+            val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
+            (pos.xPercent / 100f * displayWidth).toInt() to (pos.yPercent / 100f * displayHeight).toInt()
+        }
 
         UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).click(x, y)
     }

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -345,41 +345,28 @@ class E2EFixture(
     }
 
     /**
-     * Taps the overlay button at its actual rendered position.
+     * Taps the overlay button at its configured screen position.
      *
-     * Issue #229 established that the overlay's rendered position does not match the
-     * coordinates computed from [PrefsManager.getOverlayPosition]: the overlay renders about
-     * 128px lower than `OverlayManager.calculateOverlayYPx` predicts. Tapping the *computed*
-     * position therefore misses the overlay's clickable view entirely--the tap lands on empty
-     * camera-app space above the icon and silently fails to launch the gallery (issues #230,
-     * #231, #232).
+     * Reads the active [com.gb4pc.data.OverlayPosition] from [PrefsManager], computes pixel
+     * coordinates from [android.view.WindowMetrics] (API 30+) or [android.util.DisplayMetrics]
+     * (API 26-29), then dispatches a tap via [UiDevice].
      *
-     * To tap reliably regardless of that rendering discrepancy, this locates the overlay by its
-     * actual on-screen pixels: it takes a fresh screenshot and taps the centroid of the
-     * YELLOW union BLUE mask (the gallery icon's background and foreground colors, as used by
-     * test1c_overlayOuterIsSquircle).
+     * This relies on the overlay rendering at the position [PrefsManager.getOverlayPosition]
+     * reports (issue #229: `OverlayManager.createLayoutParams()` must set
+     * `FLAG_LAYOUT_IN_SCREEN` so the rendered position matches this computation).
      *
-     * If the overlay is not rendered (e.g. blocked in secure-camera mode), the mask is empty and
-     * this falls back to the position computed from [PrefsManager.getOverlayPosition], tapping
-     * empty screen space and having no visible effect, which Tests 4a/5a's baseline-failure
-     * scenario requires.
+     * If the overlay is not rendered (e.g. blocked in secure-camera mode) this call taps empty
+     * screen space and has no visible effect--the plan requires this silent behaviour for
+     * Tests 4a/5a's baseline-failure scenario.
      */
     fun tapOverlay() {
         val (displayWidth, displayHeight) = displaySize()
 
-        val screen = Screenshot.captureScreen()
-        val iconMask = ColorMatch.union(
-            ColorMatch.mask(screen, Rgb.BLUE),
-            ColorMatch.mask(screen, Rgb.YELLOW)
-        )
+        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+        val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
 
-        val (x, y) = if (iconMask.pixelCount > 0) {
-            iconMask.centroid.x.toInt() to iconMask.centroid.y.toInt()
-        } else {
-            val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
-            val pos = PrefsManager(context).getOverlayPosition(aspectRatio)
-            (pos.xPercent / 100f * displayWidth).toInt() to (pos.yPercent / 100f * displayHeight).toInt()
-        }
+        val x = (pos.xPercent / 100f * displayWidth).toInt()
+        val y = (pos.yPercent / 100f * displayHeight).toInt()
 
         UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).click(x, y)
     }


### PR DESCRIPTION
## Problem

`GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap` has been failing consistently, reporting GREEN coverage of about 87% after tapping the overlay, when it should drop below 10% once the gallery opens over the empty roll.

CI screenshots from a recent run show the before-tap and after-tap screenshots are identical: the green MockCameraActivity screen with the overlay icon unchanged. The gallery never opens, meaning the tap had no effect.

## Root cause

Issue #229 established that the overlay's actual rendered position is about 128px lower than the position computed from `PrefsManager.getOverlayPosition()` (via `calculateOverlayYPx`). `E2EFixture.tapOverlay()` taps the *computed* position, so its tap lands on empty camera-app space above the icon and never hits the overlay's clickable view. The gallery is never launched, so the green camera feed stays on screen (issue #230, and likely the same cause behind #231 and #232).

## Fix

PR #388 fixes that root cause directly: it adds `FLAG_LAYOUT_IN_SCREEN` to the overlay's window flags, so the overlay's *rendered* position matches the *computed* position that `tapOverlay()` already uses. Once #388 merges, `tapOverlay()`'s existing computed-position tap lands on the overlay correctly, and `test2a_emptyGalleryNoGreenAfterTap` should pass without any change to `tapOverlay()` itself.

This PR therefore:

1. Removes `test2a_emptyGalleryNoGreenAfterTap` from `.github/allowed-test-failures.txt` now that #388 fixes the underlying cause.
2. Documents `tapOverlay()`'s dependency on #229/#388's fix in its KDoc, so a future regression in the overlay's window flags is easier to connect back to this assumption.

An earlier version of this PR independently reworked `tapOverlay()` to locate the overlay by screenshotting the screen and tapping the centroid of its icon's color mask, as a way to sidestep the computed/rendered position mismatch without depending on #388. Per review discussion, that added meaningful complexity on top of a fix (#388) that closes the gap at its source, so it has been reverted in favor of this smaller, #388-dependent change.

Doesn't Fix (but really tried) #230

## Test plan

- [x] `./gradlew :app:compileDebugAndroidTestKotlin -q` succeeds.
- [x] `./gradlew :app:testDebugUnitTest -q` passes.
- [x] `python3 -m unittest scripts.test_check_allowed_failures -v` passes after the allowlist edit.
- [ ] This PR should merge after #388. CI instrumented E2E run confirms `test2a_emptyGalleryNoGreenAfterTap` now passes once #388's fix is present.
