### PR TITLE
Stop tolerating test1a_overlayShowsBlueAtConfiguredPosition now that it passes

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,7 +20,6 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-com.gb4pc.e2e.GalleryButtonVisualE2ETest#test1a_overlayShowsBlueAtConfiguredPosition            # issue #229
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen    # issue #232


### PR DESCRIPTION
Fixes #391

PR #388 fixed the root cause of issue #229 (the overlay was rendering ~128px below its configured position because the overlay window was missing `FLAG_LAYOUT_IN_SCREEN`), but left `test1a_overlayShowsBlueAtConfiguredPosition` in `.github/allowed-test-failures.txt`.

The CI run on `main` after PR #388 merged ([run 27490562611](https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/27490562611)) confirms the E2E suite now passes for this test (and the related shape tests):

```
{"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1a_overlayShowsBlueAtConfiguredPosition","outcome":"PASS",...}
{"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1b_overlayBlueIsSquare","outcome":"PASS",...}
{"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1c_overlayOuterIsSquircle","outcome":"PASS",...}
```

This removes the `test1a_overlayShowsBlueAtConfiguredPosition # issue #229` entry from `.github/allowed-test-failures.txt`, so CI starts enforcing this test again, per the request in [PR #388's review comments](https://github.com/aunger/gallery-button-for-pixel-camera/pull/388#issuecomment-4700858375).

## Test plan

- [x] CI E2E run on `main` after PR #388 already confirms `test1a_overlayShowsBlueAtConfiguredPosition` (and `test1b`/`test1c`) pass — no further manual verification needed.

