### PR TITLE
Align overlay touchable input region with its surface via setFitInsetsTypes(0)

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,6 +20,5 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-com.gb4pc.e2e.GalleryButtonVisualE2ETest#test2a_emptyGalleryNoGreenAfterTap                     # issue #230
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test3a_populatedGalleryShowsGreenAfterTap              # issue #231
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen    # issue #232

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -13,7 +13,6 @@ import android.os.Build
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.WindowManager
-import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -75,23 +74,6 @@ class OverlayManager(
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-
-    /**
-     * The full-screen host window actually added to the [WindowManager]. The gallery icon is a
-     * positioned child of this host (see [createOverlayHost]).
-     *
-     * The window spans the whole display so its input/touchable region coincides with its
-     * rendered surface. A small positioned [TYPE_APPLICATION_OVERLAY] window's touchable region
-     * is derived from the decor-inset-fitted frame, which diverges from the surface after
-     * [WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN] shifts the surface to the physical
-     * origin (Issue #229's fix). That divergence left taps on the rendered icon landing outside
-     * the window's touchable region, so the tap never reached [handleTap] (Issue #230). With a
-     * full-screen window there is no inset to subtract, so a tap on the icon's pixels hits the
-     * icon child and fires its click listener.
-     */
-    private var hostView: FrameLayout? = null
-
-    /** The gallery icon child view. Holds the icon/thumbnail drawable and the tap listener. */
     private var overlayView: ImageView? = null
     private var isShowing = false
 
@@ -100,13 +82,12 @@ class OverlayManager(
             return
         }
 
-        val (host, icon) = createOverlayHost()
+        val view = createOverlayView()
         val params = createLayoutParams()
 
         try {
-            windowManager.addView(host, params)
-            hostView = host
-            overlayView = icon
+            windowManager.addView(view, params)
+            overlayView = view
             isShowing = true
             DebugLog.log("Overlay shown")
         } catch (e: Exception) {
@@ -115,28 +96,23 @@ class OverlayManager(
     }
 
     fun hide() {
-        hostView?.let { view ->
+        overlayView?.let { view ->
             try {
                 windowManager.removeView(view)
             } catch (_: Exception) {
                 // View may already be removed
             }
         }
-        hostView = null
         overlayView = null
         isShowing = false
         DebugLog.log("Overlay hidden")
     }
 
     fun updatePosition() {
-        val icon = overlayView ?: return
-        val host = hostView ?: return
-        if (!isShowing) return
-        // The window is full-screen; only the icon child's offset/size changes when the
-        // configured position changes. Re-apply the child's layout params in place.
-        icon.layoutParams = iconLayoutParams()
+        if (!isShowing || overlayView == null) return
+        val params = createLayoutParams()
         try {
-            host.requestLayout()
+            windowManager.updateViewLayout(overlayView, params)
         } catch (_: Exception) {}
     }
 
@@ -200,22 +176,10 @@ class OverlayManager(
         }
     }
 
-    /**
-     * Builds the full-screen host [FrameLayout] and its gallery-icon [ImageView] child.
-     *
-     * The host fills the window (which spans the whole display) and is NOT clickable, so touches
-     * outside the icon are not consumed by the view hierarchy and -- together with
-     * [WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL] on the window -- pass through to the
-     * camera app below. Only the icon child is clickable, so a tap on the icon fires [handleTap]
-     * while taps elsewhere reach the camera (Issue #230).
-     *
-     * The key and focus overrides that used to live on the icon view now live on the host, since
-     * the host is the attached root that receives window-level key and focus events.
-     */
-    private fun createOverlayHost(): Pair<FrameLayout, ImageView> {
+    private fun createOverlayView(): ImageView {
         // When focusable overlay is enabled we need a custom subclass to handle key and focus
-        // events on the root (host) view.
-        val host = object : FrameLayout(context) {
+        // events on the root view.
+        val imageView = object : ImageView(context) {
             /**
              * Do not consume key events — pass them through to the camera app.
              *
@@ -242,41 +206,10 @@ class OverlayManager(
                 }
             }
         }
-        // The host itself must not be clickable, so touches outside the icon are not consumed and
-        // pass through to the camera app.
-        host.isClickable = false
-
-        val imageView = ImageView(context)
         imageView.scaleType = ImageView.ScaleType.FIT_CENTER
         updateIconDrawable(imageView)
         imageView.setOnClickListener { handleTap() }
-
-        host.addView(imageView, iconLayoutParams())
-        return host to imageView
-    }
-
-    /**
-     * Computes the icon child's [FrameLayout.LayoutParams]: its size and its top/left offset
-     * within the full-screen host, derived from the configured overlay position via the same
-     * pure functions used for the previous per-window x/y ([calculateOverlaySizePx],
-     * [calculateOverlayXPx], [calculateOverlayYPx]). Keeping these functions unchanged means the
-     * icon renders at the same pixel position as before, so the position assertion in
-     * test1a_overlayShowsBlueAtConfiguredPosition still holds.
-     */
-    private fun iconLayoutParams(): FrameLayout.LayoutParams {
-        val (displayWidth, displayHeight) = displayBounds()
-        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
-        val position = prefsManager.getOverlayPosition(aspectRatio)
-
-        val sizePx = calculateOverlaySizePx(position.sizePercent, displayWidth, displayHeight)
-        val xPx = calculateOverlayXPx(position.xPercent, displayWidth, sizePx)
-        val yPx = calculateOverlayYPx(position.yPercent, displayHeight, sizePx)
-
-        return FrameLayout.LayoutParams(sizePx, sizePx).apply {
-            gravity = Gravity.TOP or Gravity.START
-            leftMargin = xPx
-            topMargin = yPx
-        }
+        return imageView
     }
 
     /**
@@ -413,50 +346,43 @@ class OverlayManager(
         DebugLog.log("Launched secure viewer")
     }
 
-    /**
-     * The full display bounds in pixels.
-     *
-     * M8: On API 30+ use currentWindowMetrics for correct bounds in split-screen; fall back to
-     * displayMetrics on older API. The same bounds drive the full-screen window size and the icon
-     * child's offset, so the icon lands at the configured percent of the real display.
-     */
-    private fun displayBounds(): Pair<Int, Int> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    private fun createLayoutParams(): WindowManager.LayoutParams {
+        @Suppress("DEPRECATION")
+        val showWhenLockedFlag = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+
+        // M8: On API 30+ use currentWindowMetrics for correct bounds in split-screen;
+        // fall back to displayMetrics on older API.
+        val (displayWidth, displayHeight) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val bounds = windowManager.currentWindowMetrics.bounds
             bounds.width() to bounds.height()
         } else {
             @Suppress("DEPRECATION")
             val dm = android.util.DisplayMetrics()
-            @Suppress("DEPRECATION")
             windowManager.defaultDisplay.getMetrics(dm)
             dm.widthPixels to dm.heightPixels
         }
-    }
 
-    private fun createLayoutParams(): WindowManager.LayoutParams {
-        @Suppress("DEPRECATION")
-        val showWhenLockedFlag = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+        val position = prefsManager.getOverlayPosition(aspectRatio)
 
-        // The overlay window spans the whole display. A full-screen window's input/touchable
-        // region matches its rendered surface (no decor-inset subtraction), so a tap on the
-        // icon's pixels reaches the icon child (Issue #230). The icon is positioned within this
-        // window by iconLayoutParams(), not by the window's own x/y.
+        val sizePx = calculateOverlaySizePx(position.sizePercent, displayWidth, displayHeight)
+        val xPx = calculateOverlayXPx(position.xPercent, displayWidth, sizePx)
+        val yPx = calculateOverlayYPx(position.yPercent, displayHeight, sizePx)
+
+        // FLAG_NOT_FOCUSABLE: safe default — overlay never steals input focus.
+        // Experimental focusable path: omit FLAG_NOT_FOCUSABLE so the window can receive focus
+        // events, enabling onWindowFocusChanged(false) as a task-switcher signal.
+        // FLAG_NOT_TOUCH_MODAL is also set to keep touch events outside the overlay's bounds
+        // passing through to the camera app. Trade-off: the focusable window may steal
+        // volume/power key events from the camera app even when dispatchKeyEvent returns false.
         //
-        // FLAG_NOT_TOUCH_MODAL is REQUIRED on this full-screen window: without it the window is
-        // touch-modal and would swallow every touch on screen, blocking the camera app. With it,
-        // only the icon child (the sole clickable view) is touchable; touches elsewhere pass
-        // through to the camera below.
-        //
-        // FLAG_NOT_FOCUSABLE (non-focusable default): the overlay never steals input focus.
-        // Focusable path: omit FLAG_NOT_FOCUSABLE so the window can receive focus events,
-        // enabling onWindowFocusChanged(false) as a task-switcher signal. Trade-off: the
-        // focusable window may steal volume/power key events from the camera app even when
-        // dispatchKeyEvent returns false.
-        //
-        // FLAG_LAYOUT_IN_SCREEN + FLAG_LAYOUT_NO_LIMITS keep the full-screen window anchored at
-        // the true physical-screen origin (0, 0) and allowed to extend into the system-bar areas,
-        // so the icon child's (leftMargin, topMargin) are relative to the real display origin,
-        // matching calculateOverlayXPx/calculateOverlayYPx's assumptions (Issue #229).
+        // FLAG_LAYOUT_IN_SCREEN: without this flag, a TYPE_APPLICATION_OVERLAY window's
+        // Gravity.TOP|START origin is offset below the system status bar, so x/y (computed
+        // above relative to the full display size) land the overlay too far down the screen
+        // (Issue #229 — the overlay rendered ~128 px lower than the configured yPercent).
+        // Combined with FLAG_LAYOUT_NO_LIMITS, this makes (x, y) relative to the true
+        // physical-screen origin (0, 0), matching calculateOverlayXPx/calculateOverlayYPx's
+        // assumptions.
         val windowFlags = if (prefsManager.focusableOverlay) {
             WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
@@ -464,22 +390,21 @@ class OverlayManager(
                 showWhenLockedFlag
         } else {
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                 showWhenLockedFlag
         }
 
         return WindowManager.LayoutParams(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            WindowManager.LayoutParams.MATCH_PARENT,
+            sizePx,
+            sizePx,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
             windowFlags,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START
-            x = 0
-            y = 0
+            x = xPx
+            y = yPx
         }
     }
 }

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -405,6 +405,25 @@ class OverlayManager(
             gravity = Gravity.TOP or Gravity.START
             x = xPx
             y = yPx
+
+            // Issue #230: align the window's touchable input region with its rendered surface.
+            //
+            // FLAG_LAYOUT_IN_SCREEN (above) shifts the rendered surface up to the physical-screen
+            // origin so the icon draws at the configured (x, y) (Issue #229, verified by
+            // test1a_overlayShowsBlueAtConfiguredPosition). But on API 30+ a window's frame -- and
+            // therefore the touchable input region derived from it -- is by default fitted to the
+            // system-bar insets, which FLAG_LAYOUT_IN_SCREEN does not move. The surface and the
+            // input region then diverged by the status-bar height: a tap at the rendered icon
+            // centre (where UiDevice.click lands) fell below the touchable region and passed
+            // through to the camera, so handleTap() never fired and the gallery never opened.
+            //
+            // setFitInsetsTypes(0) stops the frame from being inset-fitted, so the input region
+            // coincides with the FLAG_LAYOUT_IN_SCREEN-placed surface at (x, y). The window stays
+            // small (sizePx x sizePx), so touches outside the icon still pass through to the
+            // camera (FLAG_NOT_FOCUSABLE / FLAG_NOT_TOUCH_MODAL forward out-of-bounds events).
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                fitInsetsTypes = 0
+            }
         }
     }
 }

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.WindowManager
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -74,6 +75,23 @@ class OverlayManager(
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+    /**
+     * The full-screen host window actually added to the [WindowManager]. The gallery icon is a
+     * positioned child of this host (see [createOverlayHost]).
+     *
+     * The window spans the whole display so its input/touchable region coincides with its
+     * rendered surface. A small positioned [TYPE_APPLICATION_OVERLAY] window's touchable region
+     * is derived from the decor-inset-fitted frame, which diverges from the surface after
+     * [WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN] shifts the surface to the physical
+     * origin (Issue #229's fix). That divergence left taps on the rendered icon landing outside
+     * the window's touchable region, so the tap never reached [handleTap] (Issue #230). With a
+     * full-screen window there is no inset to subtract, so a tap on the icon's pixels hits the
+     * icon child and fires its click listener.
+     */
+    private var hostView: FrameLayout? = null
+
+    /** The gallery icon child view. Holds the icon/thumbnail drawable and the tap listener. */
     private var overlayView: ImageView? = null
     private var isShowing = false
 
@@ -82,12 +100,13 @@ class OverlayManager(
             return
         }
 
-        val view = createOverlayView()
+        val (host, icon) = createOverlayHost()
         val params = createLayoutParams()
 
         try {
-            windowManager.addView(view, params)
-            overlayView = view
+            windowManager.addView(host, params)
+            hostView = host
+            overlayView = icon
             isShowing = true
             DebugLog.log("Overlay shown")
         } catch (e: Exception) {
@@ -96,23 +115,28 @@ class OverlayManager(
     }
 
     fun hide() {
-        overlayView?.let { view ->
+        hostView?.let { view ->
             try {
                 windowManager.removeView(view)
             } catch (_: Exception) {
                 // View may already be removed
             }
         }
+        hostView = null
         overlayView = null
         isShowing = false
         DebugLog.log("Overlay hidden")
     }
 
     fun updatePosition() {
-        if (!isShowing || overlayView == null) return
-        val params = createLayoutParams()
+        val icon = overlayView ?: return
+        val host = hostView ?: return
+        if (!isShowing) return
+        // The window is full-screen; only the icon child's offset/size changes when the
+        // configured position changes. Re-apply the child's layout params in place.
+        icon.layoutParams = iconLayoutParams()
         try {
-            windowManager.updateViewLayout(overlayView, params)
+            host.requestLayout()
         } catch (_: Exception) {}
     }
 
@@ -176,10 +200,22 @@ class OverlayManager(
         }
     }
 
-    private fun createOverlayView(): ImageView {
+    /**
+     * Builds the full-screen host [FrameLayout] and its gallery-icon [ImageView] child.
+     *
+     * The host fills the window (which spans the whole display) and is NOT clickable, so touches
+     * outside the icon are not consumed by the view hierarchy and -- together with
+     * [WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL] on the window -- pass through to the
+     * camera app below. Only the icon child is clickable, so a tap on the icon fires [handleTap]
+     * while taps elsewhere reach the camera (Issue #230).
+     *
+     * The key and focus overrides that used to live on the icon view now live on the host, since
+     * the host is the attached root that receives window-level key and focus events.
+     */
+    private fun createOverlayHost(): Pair<FrameLayout, ImageView> {
         // When focusable overlay is enabled we need a custom subclass to handle key and focus
-        // events on the root view.
-        val imageView = object : ImageView(context) {
+        // events on the root (host) view.
+        val host = object : FrameLayout(context) {
             /**
              * Do not consume key events — pass them through to the camera app.
              *
@@ -206,10 +242,41 @@ class OverlayManager(
                 }
             }
         }
+        // The host itself must not be clickable, so touches outside the icon are not consumed and
+        // pass through to the camera app.
+        host.isClickable = false
+
+        val imageView = ImageView(context)
         imageView.scaleType = ImageView.ScaleType.FIT_CENTER
         updateIconDrawable(imageView)
         imageView.setOnClickListener { handleTap() }
-        return imageView
+
+        host.addView(imageView, iconLayoutParams())
+        return host to imageView
+    }
+
+    /**
+     * Computes the icon child's [FrameLayout.LayoutParams]: its size and its top/left offset
+     * within the full-screen host, derived from the configured overlay position via the same
+     * pure functions used for the previous per-window x/y ([calculateOverlaySizePx],
+     * [calculateOverlayXPx], [calculateOverlayYPx]). Keeping these functions unchanged means the
+     * icon renders at the same pixel position as before, so the position assertion in
+     * test1a_overlayShowsBlueAtConfiguredPosition still holds.
+     */
+    private fun iconLayoutParams(): FrameLayout.LayoutParams {
+        val (displayWidth, displayHeight) = displayBounds()
+        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
+        val position = prefsManager.getOverlayPosition(aspectRatio)
+
+        val sizePx = calculateOverlaySizePx(position.sizePercent, displayWidth, displayHeight)
+        val xPx = calculateOverlayXPx(position.xPercent, displayWidth, sizePx)
+        val yPx = calculateOverlayYPx(position.yPercent, displayHeight, sizePx)
+
+        return FrameLayout.LayoutParams(sizePx, sizePx).apply {
+            gravity = Gravity.TOP or Gravity.START
+            leftMargin = xPx
+            topMargin = yPx
+        }
     }
 
     /**
@@ -346,43 +413,50 @@ class OverlayManager(
         DebugLog.log("Launched secure viewer")
     }
 
-    private fun createLayoutParams(): WindowManager.LayoutParams {
-        @Suppress("DEPRECATION")
-        val showWhenLockedFlag = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-
-        // M8: On API 30+ use currentWindowMetrics for correct bounds in split-screen;
-        // fall back to displayMetrics on older API.
-        val (displayWidth, displayHeight) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    /**
+     * The full display bounds in pixels.
+     *
+     * M8: On API 30+ use currentWindowMetrics for correct bounds in split-screen; fall back to
+     * displayMetrics on older API. The same bounds drive the full-screen window size and the icon
+     * child's offset, so the icon lands at the configured percent of the real display.
+     */
+    private fun displayBounds(): Pair<Int, Int> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val bounds = windowManager.currentWindowMetrics.bounds
             bounds.width() to bounds.height()
         } else {
             @Suppress("DEPRECATION")
             val dm = android.util.DisplayMetrics()
+            @Suppress("DEPRECATION")
             windowManager.defaultDisplay.getMetrics(dm)
             dm.widthPixels to dm.heightPixels
         }
+    }
 
-        val aspectRatio = AspectRatioUtil.quantize(displayWidth, displayHeight)
-        val position = prefsManager.getOverlayPosition(aspectRatio)
+    private fun createLayoutParams(): WindowManager.LayoutParams {
+        @Suppress("DEPRECATION")
+        val showWhenLockedFlag = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
 
-        val sizePx = calculateOverlaySizePx(position.sizePercent, displayWidth, displayHeight)
-        val xPx = calculateOverlayXPx(position.xPercent, displayWidth, sizePx)
-        val yPx = calculateOverlayYPx(position.yPercent, displayHeight, sizePx)
-
-        // FLAG_NOT_FOCUSABLE: safe default — overlay never steals input focus.
-        // Experimental focusable path: omit FLAG_NOT_FOCUSABLE so the window can receive focus
-        // events, enabling onWindowFocusChanged(false) as a task-switcher signal.
-        // FLAG_NOT_TOUCH_MODAL is also set to keep touch events outside the overlay's bounds
-        // passing through to the camera app. Trade-off: the focusable window may steal
-        // volume/power key events from the camera app even when dispatchKeyEvent returns false.
+        // The overlay window spans the whole display. A full-screen window's input/touchable
+        // region matches its rendered surface (no decor-inset subtraction), so a tap on the
+        // icon's pixels reaches the icon child (Issue #230). The icon is positioned within this
+        // window by iconLayoutParams(), not by the window's own x/y.
         //
-        // FLAG_LAYOUT_IN_SCREEN: without this flag, a TYPE_APPLICATION_OVERLAY window's
-        // Gravity.TOP|START origin is offset below the system status bar, so x/y (computed
-        // above relative to the full display size) land the overlay too far down the screen
-        // (Issue #229 — the overlay rendered ~128 px lower than the configured yPercent).
-        // Combined with FLAG_LAYOUT_NO_LIMITS, this makes (x, y) relative to the true
-        // physical-screen origin (0, 0), matching calculateOverlayXPx/calculateOverlayYPx's
-        // assumptions.
+        // FLAG_NOT_TOUCH_MODAL is REQUIRED on this full-screen window: without it the window is
+        // touch-modal and would swallow every touch on screen, blocking the camera app. With it,
+        // only the icon child (the sole clickable view) is touchable; touches elsewhere pass
+        // through to the camera below.
+        //
+        // FLAG_NOT_FOCUSABLE (non-focusable default): the overlay never steals input focus.
+        // Focusable path: omit FLAG_NOT_FOCUSABLE so the window can receive focus events,
+        // enabling onWindowFocusChanged(false) as a task-switcher signal. Trade-off: the
+        // focusable window may steal volume/power key events from the camera app even when
+        // dispatchKeyEvent returns false.
+        //
+        // FLAG_LAYOUT_IN_SCREEN + FLAG_LAYOUT_NO_LIMITS keep the full-screen window anchored at
+        // the true physical-screen origin (0, 0) and allowed to extend into the system-bar areas,
+        // so the icon child's (leftMargin, topMargin) are relative to the real display origin,
+        // matching calculateOverlayXPx/calculateOverlayYPx's assumptions (Issue #229).
         val windowFlags = if (prefsManager.focusableOverlay) {
             WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
@@ -390,21 +464,22 @@ class OverlayManager(
                 showWhenLockedFlag
         } else {
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                 showWhenLockedFlag
         }
 
         return WindowManager.LayoutParams(
-            sizePx,
-            sizePx,
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
             windowFlags,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START
-            x = xPx
-            y = yPx
+            x = 0
+            y = 0
         }
     }
 }

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -4,7 +4,10 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.BitmapDrawable
+import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import com.gb4pc.data.OverlayPosition
@@ -37,6 +40,15 @@ import org.robolectric.shadows.ShadowWindowManagerImpl
  */
 @RunWith(RobolectricTestRunner::class)
 class OverlayManagerRobolectricTest {
+
+    /**
+     * The view added to the WindowManager is now the full-screen host (Issue #230); the gallery
+     * icon is its single child. Returns that child [ImageView].
+     */
+    private fun iconViewOf(hostView: View): ImageView {
+        val host = hostView as ViewGroup
+        return host.getChildAt(0) as ImageView
+    }
 
     /**
      * Regression guard for Issue #66: when focusableOverlay is false (the default),
@@ -113,7 +125,7 @@ class OverlayManagerRobolectricTest {
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
         val views = shadowWm.views
         assertEquals("Expected exactly one view added to WindowManager after show()", 1, views.size)
-        val overlayView = views[0] as ImageView
+        val overlayView = iconViewOf(views[0])
 
         // Step 2: simulate showLatestPhotoThumbnail() successfully loading a bitmap.
         val testBitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
@@ -160,7 +172,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = shadowWm.views[0] as ImageView
+        val overlayView = iconViewOf(shadowWm.views[0])
 
         assertTrue(
             "Issue #188: overlay drawable must be a SquircleDrawable so the squircle shape " +
@@ -190,7 +202,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = shadowWm.views[0] as ImageView
+        val overlayView = iconViewOf(shadowWm.views[0])
 
         // Exercise the public API to trigger a thumbnail load attempt.
         overlayManager.showLatestPhotoThumbnail("content://com.gb4pc.test/images/1")
@@ -233,7 +245,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = shadowWm.views[0] as ImageView
+        val overlayView = iconViewOf(shadowWm.views[0])
 
         // The drawable must be a SquircleDrawable (outer squircle clip is guaranteed regardless
         // of the launcher mask), wrapping a raw AdaptiveIconDrawable (not a pre-masked bitmap).
@@ -252,21 +264,27 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issue #229: overlay positioned relative to the true screen origin ───
+    // ── Issues #229 / #230: full-screen overlay window, icon positioned as a child ───
 
     /**
-     * Regression guard for Issue #229: the overlay window's [WindowManager.LayoutParams] must
-     * include `FLAG_LAYOUT_IN_SCREEN` (in addition to `FLAG_LAYOUT_NO_LIMITS`) so that
-     * `Gravity.TOP or Gravity.START` with `x`/`y` set by [calculateOverlayXPx] /
-     * [calculateOverlayYPx] positions the overlay relative to the physical-screen origin
-     * (0, 0), not below the status bar.
+     * Regression guard for Issues #229 and #230: the overlay window must be a full-screen
+     * (MATCH_PARENT x MATCH_PARENT) window, anchored at the physical-screen origin via
+     * `FLAG_LAYOUT_IN_SCREEN` + `FLAG_LAYOUT_NO_LIMITS`, with `FLAG_NOT_TOUCH_MODAL` set so it
+     * does not swallow touches meant for the camera app below.
      *
-     * Without this flag, the E2E visual test observed the overlay rendered ~128 px lower
-     * than its configured `yPercent` (BLUE centroid at y=1784 instead of the expected
-     * y=1656 for yPercent=69% on a 2400 px-tall display).
+     * Issue #229: the overlay used to be a small window positioned with `Gravity.TOP|START` and
+     * an explicit x/y. `FLAG_LAYOUT_IN_SCREEN` shifted the *rendered surface* to the physical
+     * origin (the overlay had rendered ~128 px lower, BLUE centroid at y=1784 instead of the
+     * expected y=1656 for yPercent=69% on a 2400 px-tall display).
+     *
+     * Issue #230: a small window's *touchable* region is derived from the decor-inset-fitted
+     * frame, which diverged from the shifted surface, so taps on the rendered icon missed the
+     * window's touchable region and never reached the click listener. Making the window
+     * full-screen keeps the input region aligned with the surface, and the icon is positioned
+     * by [calculateOverlayXPx] / [calculateOverlayYPx] as the child's `leftMargin` / `topMargin`.
      */
     @Test
-    fun `overlay window uses FLAG_LAYOUT_IN_SCREEN so position is relative to screen origin`() {
+    fun `overlay window is full-screen and not touch modal with the icon positioned as a child`() {
         val context: Application = ApplicationProvider.getApplicationContext()
         val prefsManager: PrefsManager = mock {
             on { galleryPackage } doReturn null
@@ -279,11 +297,28 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = shadowWm.views[0]
-        val params = overlayView.layoutParams as WindowManager.LayoutParams
+        val hostView = shadowWm.views[0] as ViewGroup
+        val params = hostView.layoutParams as WindowManager.LayoutParams
 
+        assertEquals(
+            "Overlay window must be full-screen width so its input region matches the rendered " +
+                "surface (Issue #230).",
+            WindowManager.LayoutParams.MATCH_PARENT,
+            params.width
+        )
+        assertEquals(
+            "Overlay window must be full-screen height so its input region matches the rendered " +
+                "surface (Issue #230).",
+            WindowManager.LayoutParams.MATCH_PARENT,
+            params.height
+        )
         assertTrue(
-            "Overlay window must set FLAG_LAYOUT_IN_SCREEN so x/y are relative to the " +
+            "Full-screen overlay window must set FLAG_NOT_TOUCH_MODAL so touches outside the " +
+                "icon pass through to the camera app (Issue #230).",
+            (params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL) != 0
+        )
+        assertTrue(
+            "Overlay window must set FLAG_LAYOUT_IN_SCREEN so it is anchored at the " +
                 "physical-screen origin, not below the status bar (Issue #229).",
             (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN) != 0
         )
@@ -291,6 +326,25 @@ class OverlayManagerRobolectricTest {
             "Overlay window must retain FLAG_LAYOUT_NO_LIMITS so it can extend into the " +
                 "system-bar areas.",
             (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0
+        )
+
+        // The icon is a positioned child of the full-screen host, offset by the pure position
+        // functions so it still renders at the configured percent of the display (Issue #229).
+        val icon = iconViewOf(hostView)
+        val iconParams = icon.layoutParams as FrameLayout.LayoutParams
+        val displayWidth = context.resources.displayMetrics.widthPixels
+        val displayHeight = context.resources.displayMetrics.heightPixels
+        val pos = OverlayPosition.default()
+        val sizePx = calculateOverlaySizePx(pos.sizePercent, displayWidth, displayHeight)
+        assertEquals(
+            "Icon child leftMargin must equal calculateOverlayXPx for the configured position.",
+            calculateOverlayXPx(pos.xPercent, displayWidth, sizePx),
+            iconParams.leftMargin
+        )
+        assertEquals(
+            "Icon child topMargin must equal calculateOverlayYPx for the configured position.",
+            calculateOverlayYPx(pos.yPercent, displayHeight, sizePx),
+            iconParams.topMargin
         )
     }
 

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -252,21 +252,30 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issue #229: overlay positioned relative to the true screen origin ───
+    // ── Issues #229 / #230: small window placed and made touchable at the screen origin ──
 
     /**
-     * Regression guard for Issue #229: the overlay window's [WindowManager.LayoutParams] must
-     * include `FLAG_LAYOUT_IN_SCREEN` (in addition to `FLAG_LAYOUT_NO_LIMITS`) so that
-     * `Gravity.TOP or Gravity.START` with `x`/`y` set by [calculateOverlayXPx] /
-     * [calculateOverlayYPx] positions the overlay relative to the physical-screen origin
-     * (0, 0), not below the status bar.
+     * Regression guard for Issues #229 and #230: the overlay window must be a SMALL
+     * (icon-sized) [WindowManager.LayoutParams] window, positioned with `Gravity.TOP or
+     * Gravity.START` and `x`/`y` from [calculateOverlayXPx] / [calculateOverlayYPx], anchored
+     * to the physical-screen origin via `FLAG_LAYOUT_IN_SCREEN` + `FLAG_LAYOUT_NO_LIMITS`, AND
+     * with its touchable input region aligned to that surface via `setFitInsetsTypes(0)`.
      *
-     * Without this flag, the E2E visual test observed the overlay rendered ~128 px lower
-     * than its configured `yPercent` (BLUE centroid at y=1784 instead of the expected
-     * y=1656 for yPercent=69% on a 2400 px-tall display).
+     * Issue #229: without `FLAG_LAYOUT_IN_SCREEN` the rendered surface sat ~128 px below the
+     * configured `yPercent` (BLUE centroid at y=1784 instead of y=1656 for yPercent=69% on a
+     * 2400 px-tall display).
+     *
+     * Issue #230: `FLAG_LAYOUT_IN_SCREEN` moved the surface but not the inset-fitted frame the
+     * touchable input region is derived from, so a tap at the rendered icon centre fell outside
+     * the touchable region and never reached the click listener. `setFitInsetsTypes(0)` stops
+     * the frame from being inset-fitted, so the input region coincides with the surface.
+     *
+     * The window must stay SMALL (icon-sized, NOT full-screen): a full-screen window would
+     * swallow every on-screen touch except the icon and block the camera app. The explicit
+     * width/height assertions guard against re-introducing that regression.
      */
     @Test
-    fun `overlay window uses FLAG_LAYOUT_IN_SCREEN so position is relative to screen origin`() {
+    fun `overlay window is small, screen-anchored, and has input region aligned to its surface`() {
         val context: Application = ApplicationProvider.getApplicationContext()
         val prefsManager: PrefsManager = mock {
             on { galleryPackage } doReturn null
@@ -282,6 +291,32 @@ class OverlayManagerRobolectricTest {
         val overlayView = shadowWm.views[0]
         val params = overlayView.layoutParams as WindowManager.LayoutParams
 
+        // The window must be small (icon-sized), NOT full-screen (Issue #230 regression guard).
+        val displayWidth = context.resources.displayMetrics.widthPixels
+        val displayHeight = context.resources.displayMetrics.heightPixels
+        val pos = OverlayPosition.default()
+        val sizePx = calculateOverlaySizePx(pos.sizePercent, displayWidth, displayHeight)
+        assertEquals(
+            "Overlay window width must be the icon size, not full-screen (Issue #230).",
+            sizePx,
+            params.width
+        )
+        assertEquals(
+            "Overlay window height must be the icon size, not full-screen (Issue #230).",
+            sizePx,
+            params.height
+        )
+        assertEquals(
+            "Overlay window x must equal calculateOverlayXPx for the configured position.",
+            calculateOverlayXPx(pos.xPercent, displayWidth, sizePx),
+            params.x
+        )
+        assertEquals(
+            "Overlay window y must equal calculateOverlayYPx for the configured position.",
+            calculateOverlayYPx(pos.yPercent, displayHeight, sizePx),
+            params.y
+        )
+
         assertTrue(
             "Overlay window must set FLAG_LAYOUT_IN_SCREEN so x/y are relative to the " +
                 "physical-screen origin, not below the status bar (Issue #229).",
@@ -291,6 +326,12 @@ class OverlayManagerRobolectricTest {
             "Overlay window must retain FLAG_LAYOUT_NO_LIMITS so it can extend into the " +
                 "system-bar areas.",
             (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0
+        )
+        assertEquals(
+            "Overlay window must set fitInsetsTypes = 0 so its touchable input region aligns " +
+                "with the FLAG_LAYOUT_IN_SCREEN-placed surface (Issue #230).",
+            0,
+            params.fitInsetsTypes
         )
     }
 

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -4,10 +4,7 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.BitmapDrawable
-import android.view.View
-import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import com.gb4pc.data.OverlayPosition
@@ -40,15 +37,6 @@ import org.robolectric.shadows.ShadowWindowManagerImpl
  */
 @RunWith(RobolectricTestRunner::class)
 class OverlayManagerRobolectricTest {
-
-    /**
-     * The view added to the WindowManager is now the full-screen host (Issue #230); the gallery
-     * icon is its single child. Returns that child [ImageView].
-     */
-    private fun iconViewOf(hostView: View): ImageView {
-        val host = hostView as ViewGroup
-        return host.getChildAt(0) as ImageView
-    }
 
     /**
      * Regression guard for Issue #66: when focusableOverlay is false (the default),
@@ -125,7 +113,7 @@ class OverlayManagerRobolectricTest {
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
         val views = shadowWm.views
         assertEquals("Expected exactly one view added to WindowManager after show()", 1, views.size)
-        val overlayView = iconViewOf(views[0])
+        val overlayView = views[0] as ImageView
 
         // Step 2: simulate showLatestPhotoThumbnail() successfully loading a bitmap.
         val testBitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
@@ -172,7 +160,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = iconViewOf(shadowWm.views[0])
+        val overlayView = shadowWm.views[0] as ImageView
 
         assertTrue(
             "Issue #188: overlay drawable must be a SquircleDrawable so the squircle shape " +
@@ -202,7 +190,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = iconViewOf(shadowWm.views[0])
+        val overlayView = shadowWm.views[0] as ImageView
 
         // Exercise the public API to trigger a thumbnail load attempt.
         overlayManager.showLatestPhotoThumbnail("content://com.gb4pc.test/images/1")
@@ -245,7 +233,7 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = iconViewOf(shadowWm.views[0])
+        val overlayView = shadowWm.views[0] as ImageView
 
         // The drawable must be a SquircleDrawable (outer squircle clip is guaranteed regardless
         // of the launcher mask), wrapping a raw AdaptiveIconDrawable (not a pre-masked bitmap).
@@ -264,27 +252,21 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issues #229 / #230: full-screen overlay window, icon positioned as a child ───
+    // ── Issue #229: overlay positioned relative to the true screen origin ───
 
     /**
-     * Regression guard for Issues #229 and #230: the overlay window must be a full-screen
-     * (MATCH_PARENT x MATCH_PARENT) window, anchored at the physical-screen origin via
-     * `FLAG_LAYOUT_IN_SCREEN` + `FLAG_LAYOUT_NO_LIMITS`, with `FLAG_NOT_TOUCH_MODAL` set so it
-     * does not swallow touches meant for the camera app below.
+     * Regression guard for Issue #229: the overlay window's [WindowManager.LayoutParams] must
+     * include `FLAG_LAYOUT_IN_SCREEN` (in addition to `FLAG_LAYOUT_NO_LIMITS`) so that
+     * `Gravity.TOP or Gravity.START` with `x`/`y` set by [calculateOverlayXPx] /
+     * [calculateOverlayYPx] positions the overlay relative to the physical-screen origin
+     * (0, 0), not below the status bar.
      *
-     * Issue #229: the overlay used to be a small window positioned with `Gravity.TOP|START` and
-     * an explicit x/y. `FLAG_LAYOUT_IN_SCREEN` shifted the *rendered surface* to the physical
-     * origin (the overlay had rendered ~128 px lower, BLUE centroid at y=1784 instead of the
-     * expected y=1656 for yPercent=69% on a 2400 px-tall display).
-     *
-     * Issue #230: a small window's *touchable* region is derived from the decor-inset-fitted
-     * frame, which diverged from the shifted surface, so taps on the rendered icon missed the
-     * window's touchable region and never reached the click listener. Making the window
-     * full-screen keeps the input region aligned with the surface, and the icon is positioned
-     * by [calculateOverlayXPx] / [calculateOverlayYPx] as the child's `leftMargin` / `topMargin`.
+     * Without this flag, the E2E visual test observed the overlay rendered ~128 px lower
+     * than its configured `yPercent` (BLUE centroid at y=1784 instead of the expected
+     * y=1656 for yPercent=69% on a 2400 px-tall display).
      */
     @Test
-    fun `overlay window is full-screen and not touch modal with the icon positioned as a child`() {
+    fun `overlay window uses FLAG_LAYOUT_IN_SCREEN so position is relative to screen origin`() {
         val context: Application = ApplicationProvider.getApplicationContext()
         val prefsManager: PrefsManager = mock {
             on { galleryPackage } doReturn null
@@ -297,28 +279,11 @@ class OverlayManagerRobolectricTest {
 
         val windowManager = context.getSystemService(WindowManager::class.java)
         val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val hostView = shadowWm.views[0] as ViewGroup
-        val params = hostView.layoutParams as WindowManager.LayoutParams
+        val overlayView = shadowWm.views[0]
+        val params = overlayView.layoutParams as WindowManager.LayoutParams
 
-        assertEquals(
-            "Overlay window must be full-screen width so its input region matches the rendered " +
-                "surface (Issue #230).",
-            WindowManager.LayoutParams.MATCH_PARENT,
-            params.width
-        )
-        assertEquals(
-            "Overlay window must be full-screen height so its input region matches the rendered " +
-                "surface (Issue #230).",
-            WindowManager.LayoutParams.MATCH_PARENT,
-            params.height
-        )
         assertTrue(
-            "Full-screen overlay window must set FLAG_NOT_TOUCH_MODAL so touches outside the " +
-                "icon pass through to the camera app (Issue #230).",
-            (params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL) != 0
-        )
-        assertTrue(
-            "Overlay window must set FLAG_LAYOUT_IN_SCREEN so it is anchored at the " +
+            "Overlay window must set FLAG_LAYOUT_IN_SCREEN so x/y are relative to the " +
                 "physical-screen origin, not below the status bar (Issue #229).",
             (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN) != 0
         )
@@ -326,25 +291,6 @@ class OverlayManagerRobolectricTest {
             "Overlay window must retain FLAG_LAYOUT_NO_LIMITS so it can extend into the " +
                 "system-bar areas.",
             (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0
-        )
-
-        // The icon is a positioned child of the full-screen host, offset by the pure position
-        // functions so it still renders at the configured percent of the display (Issue #229).
-        val icon = iconViewOf(hostView)
-        val iconParams = icon.layoutParams as FrameLayout.LayoutParams
-        val displayWidth = context.resources.displayMetrics.widthPixels
-        val displayHeight = context.resources.displayMetrics.heightPixels
-        val pos = OverlayPosition.default()
-        val sizePx = calculateOverlaySizePx(pos.sizePercent, displayWidth, displayHeight)
-        assertEquals(
-            "Icon child leftMargin must equal calculateOverlayXPx for the configured position.",
-            calculateOverlayXPx(pos.xPercent, displayWidth, sizePx),
-            iconParams.leftMargin
-        )
-        assertEquals(
-            "Icon child topMargin must equal calculateOverlayYPx for the configured position.",
-            calculateOverlayYPx(pos.yPercent, displayHeight, sizePx),
-            iconParams.topMargin
         )
     }
 


### PR DESCRIPTION
Fixes #230.

## Root cause

This is the second, independent cause of #230, distinct from the position mismatch (#229) that #388 already fixed.

`FLAG_LAYOUT_IN_SCREEN` (added in #388) shifts the overlay's rendered **surface** up to the physical-screen origin, so the icon draws at the configured position (`test1a_overlayShowsBlueAtConfiguredPosition` passes). But on API 30+ a window's frame -- and therefore the touchable **input region** derived from it -- is by default fitted to the system-bar insets, which `FLAG_LAYOUT_IN_SCREEN` does not move. The surface and the input region diverged by the status-bar height, so a tap at the rendered icon centre (where `UiDevice.click(x, y)` lands) fell below the window's touchable region and passed through to the camera. `setOnClickListener { handleTap() }` never fired, the gallery never opened, and the green camera feed stayed on screen -- exactly what PR #389's final CI run observed.

## The fix

Keep the overlay window **small** (icon-sized, positioned with `Gravity.TOP|START` + explicit `x`/`y`) and call `setFitInsetsTypes(0)` on its `LayoutParams` (guarded `>= Build.VERSION_CODES.R`).

- With no inset types fitted, the window frame -- and thus the default touchable input region -- is no longer pushed below the status bar, so it coincides with the `FLAG_LAYOUT_IN_SCREEN`-placed surface at `(x, y)`. A tap on the rendered icon now hits the window and fires the click listener.
- The window stays `sizePx x sizePx`, so there is a genuine region outside the window and camera touches outside the icon still pass through to the camera below (via `FLAG_NOT_FOCUSABLE` / `FLAG_NOT_TOUCH_MODAL`), preserving camera interaction.

### Why not the earlier full-screen approach

An earlier revision of this PR made the window full-screen with `FLAG_NOT_TOUCH_MODAL`. That was abandoned: `FLAG_NOT_TOUCH_MODAL` only forwards pointer events *outside* the window's bounds, and a full-screen window has no outside region, so it would have swallowed every on-screen touch except the icon and left the camera untappable. The first commit here reverts that approach back to the proven small-window structure; the second commit applies the targeted `setFitInsetsTypes(0)` fix.

## Tests

- Updated the #229/#230 `OverlayManagerRobolectricTest` flag-contract test to assert the new contract: the window is icon-sized (explicit `width`/`height` guards against re-introducing the full-screen regression), `x`/`y` come from the unchanged pure position functions, `FLAG_LAYOUT_IN_SCREEN` + `FLAG_LAYOUT_NO_LIMITS` are retained, and `fitInsetsTypes == 0`.
- `test2a_emptyGalleryNoGreenAfterTap` stays removed from `.github/allowed-test-failures.txt`, so CI gates on it again. It is the decisive validator: it taps the rendered icon centre and asserts the empty gallery opens (GREEN < 10%). `test1a` continues to guard that the surface did not move.
- `./gradlew :app:compileDebugAndroidTestKotlin :app:testDebugUnitTest` passes locally. The instrumented `test2a` runs only in CI (no emulator locally).

Note: `test3a_populatedGalleryShowsGreenAfterTap` (#231) shares this tap-routing root cause and may now pass as a side effect, but its allowlist entry is left in place since fixing #231 is out of scope here; CI will reveal whether it goes green.

Before-merging: `setFitInsetsTypes(0)` on a `TYPE_APPLICATION_OVERLAY` window is exercised only by the emulator CI; real-device behaviour across OEM skins warrants manual verification before merge.