### PR TITLE
Document drain poll diagnostic line in dev_orchestration.md

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -148,6 +148,7 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.
     Act only on the terminal lines Clear, Blocked, or Infra. Relay in_progress lines to the user as brief status updates (the script suppresses these unless no other output has been emitted for over 120 seconds).
     Relay `step "..." -> ...` and `FAIL [...] ...` lines to the user as informational test-result deltas; they do NOT end the loop or start a new Author round.
+    Relay a `PR#N: drain poll found no new diagnostic signals` line to the user the same way; it is informational, precedes the terminal line that follows it, and does NOT end the loop or start a new Author round on its own.
     if Monitor emits a Blocked line  → goto newAuthor
     if Monitor emits an Infra line   → escalate to user; stop
     if Monitor times out (30 min)    → escalate to user; stop


### PR DESCRIPTION
Fixes #409.

PR #408 added a new Monitor output line, `PR#N: drain poll found no new diagnostic signals`, printed immediately before a `Blocked`/`Infra` terminal line when every drain poll comes up empty. That PR documented the line in `scripts/ci_monitor/README.md`'s outcome vocabulary table, but `agents/dev_orchestration.md`'s Monitor-loop pseudocode (around lines 149-150) was not updated to match.

This PR adds a line to the Monitor-loop pseudocode documenting `PR#N: drain poll found no new diagnostic signals` as an informational line, relayed to the user the same way as `step`/`FAIL` lines: it precedes the terminal line that follows it and does not end the loop or start a new Author round on its own. This keeps `dev_orchestration.md` in sync with the README's outcome vocabulary table.

## Test plan

- [ ] None; this is a documentation-only change to agent instructions with no automated test coverage.
