### PR TITLE
Forward DebugLog to logcat under the GB4PC tag

### DIFF
--- a/app/src/main/java/com/gb4pc/util/DebugLog.kt
+++ b/app/src/main/java/com/gb4pc/util/DebugLog.kt
@@ -1,13 +1,20 @@
 package com.gb4pc.util
 
+import android.util.Log
 import com.gb4pc.Constants
 import java.util.LinkedList
 
 /**
  * In-memory circular buffer debug log (DA-03, UI-10).
  * Thread-safe. Entries are lost when the process is killed.
+ *
+ * Each call to [log] also forwards the message to [android.util.Log] under the tag [LOGCAT_TAG]
+ * so that all application log messages are visible in logcat and CI log captures (Issue #399).
  */
 object DebugLog {
+
+    /** logcat tag used for all forwarded messages. */
+    const val LOGCAT_TAG = "GB4PC"
 
     data class Entry(val timestamp: Long, val message: String)
 
@@ -18,6 +25,7 @@ object DebugLog {
     var listener: (() -> Unit)? = null
 
     fun log(message: String) {
+        Log.d(LOGCAT_TAG, message)
         val snapshot: (() -> Unit)?
         synchronized(lock) {
             buffer.addLast(Entry(System.currentTimeMillis(), message))

--- a/app/src/main/java/com/gb4pc/util/DebugLog.kt
+++ b/app/src/main/java/com/gb4pc/util/DebugLog.kt
@@ -25,9 +25,9 @@ object DebugLog {
     var listener: (() -> Unit)? = null
 
     fun log(message: String) {
-        Log.d(LOGCAT_TAG, message)
         val snapshot: (() -> Unit)?
         synchronized(lock) {
+            Log.d(LOGCAT_TAG, message)
             buffer.addLast(Entry(System.currentTimeMillis(), message))
             while (buffer.size > Constants.DEBUG_LOG_BUFFER_SIZE) buffer.removeFirst()
             snapshot = listener

--- a/app/src/test/java/com/gb4pc/util/DebugLogLogcatTest.kt
+++ b/app/src/test/java/com/gb4pc/util/DebugLogLogcatTest.kt
@@ -1,0 +1,70 @@
+package com.gb4pc.util
+
+import android.util.Log
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+
+/**
+ * Verifies that DebugLog.log() forwards each message to android.util.Log (Issue #399).
+ *
+ * Robolectric is required so ShadowLog captures Log.d() calls made by DebugLog.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DebugLogLogcatTest {
+
+    @Before
+    fun setUp() {
+        ShadowLog.reset()
+        DebugLog.clear()
+    }
+
+    @Test
+    fun `log forwards message to logcat under the GB4PC tag`() {
+        DebugLog.log("hello logcat")
+
+        val logged = ShadowLog.getLogsForTag(DebugLog.LOGCAT_TAG)
+        assertEquals("Expected exactly one logcat entry for tag GB4PC", 1, logged.size)
+        assertEquals("hello logcat", logged[0].msg)
+        assertEquals(Log.DEBUG, logged[0].type)
+    }
+
+    @Test
+    fun `log forwards every message to logcat in order`() {
+        DebugLog.log("first")
+        DebugLog.log("second")
+        DebugLog.log("third")
+
+        val logged = ShadowLog.getLogsForTag(DebugLog.LOGCAT_TAG)
+        assertEquals(3, logged.size)
+        assertEquals("first",  logged[0].msg)
+        assertEquals("second", logged[1].msg)
+        assertEquals("third",  logged[2].msg)
+    }
+
+    @Test
+    fun `logcat tag constant equals GB4PC`() {
+        assertEquals("GB4PC", DebugLog.LOGCAT_TAG)
+    }
+
+    @Test
+    fun `log forwards message to logcat even when buffer is at capacity`() {
+        // Fill the buffer to its limit so the next call will evict the oldest entry.
+        repeat(com.gb4pc.Constants.DEBUG_LOG_BUFFER_SIZE) { i ->
+            DebugLog.log("fill $i")
+        }
+        ShadowLog.reset()
+
+        DebugLog.log("overflow message")
+
+        val logged = ShadowLog.getLogsForTag(DebugLog.LOGCAT_TAG)
+        assertTrue(
+            "logcat must receive the overflow message even when the in-memory buffer evicts it",
+            logged.any { it.msg == "overflow message" }
+        )
+    }
+}


### PR DESCRIPTION
Fixes #399

## What changed

`DebugLog.log()` now calls `android.util.Log.d("GB4PC", message)` before writing to the in-memory buffer.
Every message logged through `DebugLog` -- across all 86+ call sites in production code -- is now visible in logcat, `adb logcat`, CI log captures, and device bug reports.

The in-memory circular buffer, the on-device viewer, and the `listener` callback are all unchanged.
This is Option 1 from the issue: always delegate, lowest risk, no call-site changes required.

## Why this approach

The issue noted that PR #398's debugging round was blocked because `DebugLog` messages were invisible in CI logcat.
Mirroring to logcat (rather than replacing the in-memory logger) keeps the on-device viewer's guarantees while closing the visibility gap.

## Tests

Added `DebugLogLogcatTest` (Robolectric) covering:
- Each `log()` call produces a `DEBUG` entry under the `GB4PC` tag in logcat.
- Multiple entries arrive in order.
- Forwarding still occurs when the in-memory buffer is at capacity (eviction does not suppress the logcat write).
- The `LOGCAT_TAG` constant equals `"GB4PC"`.

All existing `DebugLogTest` tests continue to pass without modification.
