### PR TITLE
Remove verified label automatically on new PR push

### DIFF
--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   remove-verified-label:

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -10,7 +10,8 @@ on:
     types: [synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  issues: write
+  pull-requests: read
 
 jobs:
   remove-verified-label:
@@ -28,7 +29,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" \
             | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
-          if echo "$LABELS" | grep -qw "verified"; then
+          if echo "$LABELS" | tr ' ' '\n' | grep -qx "verified"; then
             echo "Removing 'verified' label from PR #$PR_NUMBER"
             curl -sf -X DELETE \
               -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -1,0 +1,39 @@
+name: Remove verified label on new push
+
+# When a new commit is pushed to a PR (synchronize) or the PR is reopened,
+# the `verified` label applied by the Verification Planner becomes stale.
+# This workflow removes it so the label only reflects the most recent
+# verification pass.
+
+on:
+  pull_request:
+    types: [synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-verified-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove verified label if present
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Check if the verified label is on the PR.
+          LABELS=$(curl -sf \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" \
+            | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
+          if echo "$LABELS" | grep -qw "verified"; then
+            echo "Removing 'verified' label from PR #$PR_NUMBER"
+            curl -sf -X DELETE \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/verified"
+          else
+            echo "'verified' label not present on PR #$PR_NUMBER -- nothing to do"
+          fi


### PR DESCRIPTION
The `verified` label applied by the Verification Planner becomes stale as soon as a new commit is pushed to a PR. This adds a GitHub Actions workflow that removes it on `synchronize` and `reopened` events so the label only ever reflects the most recent verification pass.

Fixes #431

## How it works

The new `.github/workflows/remove-verified-on-push.yml` workflow triggers on `pull_request` types `synchronize` and `reopened`. It calls the GitHub Labels REST API to check whether `verified` is present on the PR and, if so, issues a `DELETE` to remove it. When the label is absent the step logs that and exits cleanly.

## Test plan

- [ ] Push a commit to a PR that carries the `verified` label and confirm the workflow run removes the label.
- [ ] Push a commit to a PR that does not carry the `verified` label and confirm the workflow run completes without error.
