### PR TITLE
Add workflow to block merge when "verification needed" label is present

### DIFF
--- a/.github/workflows/block-merge-verification-needed.yml
+++ b/.github/workflows/block-merge-verification-needed.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          if echo "$LABELS" | grep -qi '"verification needed"'; then
+          if echo "$LABELS" | jq -e '[.[] | ascii_downcase] | contains(["verification needed"])' > /dev/null; then
             echo "ERROR: This PR has a 'verification needed' label."
             echo "Remove the label after all before-merging requirements are resolved."
             exit 1

--- a/.github/workflows/block-merge-verification-needed.yml
+++ b/.github/workflows/block-merge-verification-needed.yml
@@ -1,0 +1,32 @@
+name: Block merge when "verification needed" label is present
+
+# Fails the required status check whenever the PR carries a "verification
+# needed" label, preventing merge until the label is removed.
+#
+# Triggers on the full set of PR events so the check always reflects the
+# current label state:
+#   - opened / reopened / synchronize: ensure fresh PRs are blocked from the start.
+#   - labeled / unlabeled: re-evaluate immediately when the label changes.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  check-verification-needed:
+    name: No "verification needed" label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "verification needed" label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -qi '"verification needed"'; then
+            echo "ERROR: This PR has a 'verification needed' label."
+            echo "Remove the label after all before-merging requirements are resolved."
+            exit 1
+          fi
+          echo "OK: 'verification needed' label is not present."


### PR DESCRIPTION
Fixes #432

Adds `.github/workflows/block-merge-verification-needed.yml`, a required-status-check workflow that fails whenever the PR carries a `verification needed` label.
This replaces the process relying on human discipline to check before merging with an automated gate.

The check re-evaluates on `labeled` and `unlabeled` events so the status updates immediately when the label is added or removed.
It also runs on `opened`, `reopened`, and `synchronize` so fresh PRs are covered from the start.

Once the label is removed, the check passes and merge is unblocked.
