### PR TITLE
Add delegation rules so Authors wait for foreground sub-agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,4 @@
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
-- If delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.
+- If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
+- If delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -19,6 +19,23 @@
   - For example, *Modified test `pocket_square_is_a_square` to allow circles in addition to squares, because they are more round.*
 - Existing tests must not be deleted or silently disabled to make a change compile.
 
+## Delegating to nested sub-agents
+
+When you dispatch a nested sub-agent via the Agent tool, follow these rules:
+
+- **Use foreground (the default) when you need the results in the same turn.**
+  Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.
+  The Agent tool blocks until the sub-agent completes, so the results are available immediately.
+- **Do not exit before a foreground sub-agent completes.**
+  A foreground sub-agent runs to completion during the same tool call; you receive its result as the return value.
+  If the call returns, the sub-agent is done--you do not need to wait further.
+  Exit only after you have consumed or recorded the result.
+- **Use `run_in_background: true` only for fire-and-forget work** whose results are not needed in the current turn.
+  If you are unsure whether you will need the results, use foreground.
+- **Never rely on a background sub-agent's output in the same turn.**
+  Background sub-agents surface as task-notification events after you exit.
+  Their results are not available to you during the current turn.
+
 ## Finish well
 
 - If you are a sub-agent and were given a branch or branch name, commit your changes before you return.

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -26,11 +26,10 @@ When you dispatch a nested sub-agent via the Agent tool, follow these rules:
 - **Use foreground (the default) when you need the results in the same turn.**
   Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.
   The Agent tool blocks until the sub-agent completes, so the results are available immediately.
-- **Do not exit before a foreground sub-agent completes.**
-  A foreground sub-agent runs to completion during the same tool call; you receive its result as the return value.
-  If the call returns, the sub-agent is done--you do not need to wait further.
-  Exit only after you have consumed or recorded the result.
-- **Use `run_in_background: true` only for fire-and-forget work** whose results are not needed in the current turn.
+- **If you want to exit while a sub-agent is still running, that sub-agent was launched with `run_in_background: true` and should not have been.**
+  A foreground sub-agent blocks the Agent tool call; you cannot exit before it finishes.
+  The result is returned to you when the call returns--consume or record it, then exit.
+- **Use `run_in_background: true` only for fire-and-forget work whose results are not needed in the current turn.**
   If you are unsure whether you will need the results, use foreground.
 - **Never rely on a background sub-agent's output in the same turn.**
   Background sub-agents surface as task-notification events after you exit.

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -19,22 +19,6 @@
   - For example, *Modified test `pocket_square_is_a_square` to allow circles in addition to squares, because they are more round.*
 - Existing tests must not be deleted or silently disabled to make a change compile.
 
-## Delegating to nested sub-agents
-
-When you dispatch a nested sub-agent via the Agent tool, follow these rules:
-
-- **Use foreground (the default) when you need the results in the same turn.**
-  Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.
-  The Agent tool blocks until the sub-agent completes, so the results are available immediately.
-- **If you want to exit while a sub-agent is still running, that sub-agent was launched with `run_in_background: true` and should not have been.**
-  A foreground sub-agent blocks the Agent tool call; you cannot exit before it finishes.
-  The result is returned to you when the call returns--consume or record it, then exit.
-- **Use `run_in_background: true` only for fire-and-forget work whose results are not needed in the current turn.**
-  If you are unsure whether you will need the results, use foreground.
-- **Never rely on a background sub-agent's output in the same turn.**
-  Background sub-agents surface as task-notification events after you exit.
-  Their results are not available to you during the current turn.
-
 ## Finish well
 
 - If you are a sub-agent and were given a branch or branch name, commit your changes before you return.

--- a/agents/subagent_delegation.md
+++ b/agents/subagent_delegation.md
@@ -1,0 +1,15 @@
+# Delegating to nested sub-agents
+
+When you dispatch a nested sub-agent via the Agent tool, follow these rules:
+
+- **Use foreground (the default) when you need the results in the same turn.**
+  Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.
+  The Agent tool blocks until the sub-agent completes, so the results are available immediately.
+- **If you want to exit while a sub-agent is still running, that sub-agent was launched with `run_in_background: true` and should not have been.**
+  A foreground sub-agent blocks the Agent tool call; you cannot exit before it finishes.
+  The result is returned to you when the call returns--consume or record it, then exit.
+- **Use `run_in_background: true` only for fire-and-forget work whose results are not needed in the current turn.**
+  If you are unsure whether you will need the results, use foreground.
+- **Never rely on a background sub-agent's output in the same turn.**
+  Background sub-agents surface as task-notification events after you exit.
+  Their results are not available to you during the current turn.

--- a/agents/subagent_delegation.md
+++ b/agents/subagent_delegation.md
@@ -1,6 +1,6 @@
-# Delegating to nested sub-agents
+# Delegating to nested sub-agents, as a sub-agent
 
-When you dispatch a nested sub-agent via the Agent tool, follow these rules:
+If you are a sub-agent dispatching a nested sub-agent via the Agent tool, follow these rules:
 
 - **Use foreground (the default) when you need the results in the same turn.**
   Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.


### PR DESCRIPTION
Fixes #396

## What changed

Adds a "Delegating to nested sub-agents" section to `agents/code_edit.md` encoding four rules:

1. Use foreground (default) when the sub-agent's results are needed in the same turn.
2. Do not exit before a foreground sub-agent completes--wait for its return value.
3. Use `run_in_background: true` only for fire-and-forget work whose results are not needed in the current turn.
4. Never rely on a background sub-agent's output in the same turn.

## Why

Two separate Author rounds on issue #230 / PR #395 independently exhibited the same failure: the Author dispatched a nested research sub-agent and then exited before it completed.
The Orchestrator's communication-discipline rules prevent it from passing one sub-agent's findings to another, so the delegated work was lost.
Both rounds arrived at this pattern independently (fresh agent instances, separate worktrees), which suggests the failure is a documentation gap rather than a one-off mistake.

The new section makes the correct behavior explicit: foreground sub-agents block until completion and their result is the return value of the Agent tool call; an Author should consume that result and only then exit.
