### PR TITLE
Clear cross-package MediaStore rows in clearCameraRoll() via shell content delete

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.media.MediaScannerConnection
 import android.os.Build
 import android.os.Environment
+import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
@@ -255,42 +256,56 @@ class E2EFixture(
     }
 
     /**
-     * Deletes all images owned by this package from the external MediaStore and asserts
-     * none remain.
+     * Empties the external-images MediaStore of every row, regardless of which package owns
+     * it, and asserts none remain.
      *
-     * Uses [ContentResolver.delete] with a null predicate to remove every row from
-     * [MediaStore.Images.Media.EXTERNAL_CONTENT_URI]. [ContentResolver.delete] only ever
-     * removes rows owned by the calling package (`com.gb4pc`); rows inserted by other
-     * packages (e.g. the mock camera's captured photos, owned by
-     * `com.google.android.GoogleCamera`) are left in place and are not this method's concern.
+     * Two deletion passes run, because no single API caller can remove every row:
      *
-     * After deletion, the post-condition is checked by querying with
-     * `OWNER_PACKAGE_NAME = com.gb4pc` rather than an unfiltered query: since `com.gb4pc`
-     * holds `READ_MEDIA_IMAGES` (see `app/src/debug/AndroidManifest.xml`), an unfiltered
-     * query also returns other packages' rows, which this method cannot and should not
-     * delete. Asserting on the unfiltered count would fail whenever a cross-package row
-     * (such as a previously captured mock photo) is still present, even though this
-     * method did exactly what it could: clear every row `com.gb4pc` owns.
+     *  1. [ContentResolver.delete] from this process (`com.gb4pc`). Under scoped storage
+     *     (API 29+) this only removes rows `com.gb4pc` itself owns; rows inserted by other
+     *     packages (e.g. the mock camera's captured photos, owned by
+     *     `com.google.android.GoogleCamera`) are silently skipped, because an app cannot
+     *     delete another app's MediaStore rows without a user-confirmed
+     *     `createDeleteRequest` consent dialog, which is unavailable in an unattended test.
+     *
+     *  2. A `content delete` shell command via [runShellCommand]. `uiAutomation`-issued shell
+     *     commands run under the `shell` UID, which holds broad MediaStore access and deletes
+     *     rows owned by *any* package without a consent dialog. This is the cross-package
+     *     cleanup tracked by issue #406: it removes the mock camera's leftover GREEN capture
+     *     (owned by `com.google.android.GoogleCamera`) that pass 1 cannot touch, so a later
+     *     test (e.g. `test4a`) genuinely starts from an empty roll rather than inheriting
+     *     `test3a`'s photo.
+     *
+     * Pass 1 is kept rather than relying solely on pass 2 so the common case (clearing
+     * `com.gb4pc`'s own rows) still works directly through the ContentResolver, and the shell
+     * pass is purely additive for the cross-package rows.
+     *
+     * The post-condition is now an *unfiltered* count: after both passes the entire external
+     * camera roll must be empty. Asserting the unfiltered count (rather than only the rows
+     * `com.gb4pc` owns) is what makes the "empty gallery" assumption in `test2a`/`test4a`
+     * actually true.
      */
     fun clearCameraRoll() {
+        // Pass 1: delete this package's own rows via the ContentResolver.
         context.contentResolver.delete(
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             null,
             null,
         )
-        val cursor =
-            context.contentResolver.query(
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                arrayOf(MediaStore.Images.Media._ID),
-                "${MediaStore.Images.Media.OWNER_PACKAGE_NAME} = ?",
-                arrayOf(context.packageName),
-                null,
+
+        // Pass 2: delete cross-package rows via the shell UID, which is not bound by the
+        // scoped-storage ownership restriction that limits pass 1 (issue #406).
+        val deleteOutput =
+            runShellCommand(
+                "content delete --uri ${MediaStore.Images.Media.EXTERNAL_CONTENT_URI}",
             )
-        val count = cursor?.count ?: 0
-        cursor?.close()
+        Log.i(TAG, "clearCameraRoll: shell content delete output: $deleteOutput")
+
+        // Post-condition: the entire external camera roll must now be empty, across all owners.
+        val count = countMediaStoreImages()
         assertEquals(
-            "MediaStore should contain no rows owned by ${context.packageName} " +
-                "after clearCameraRoll()",
+            "MediaStore external images should be empty after clearCameraRoll() " +
+                "(both the com.gb4pc ContentResolver pass and the cross-package shell pass)",
             0,
             count,
         )
@@ -555,6 +570,21 @@ class E2EFixture(
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Runs [command] via [UiAutomation.executeShellCommand] under the `shell` UID and returns
+     * its combined stdout/stderr as a trimmed string.
+     *
+     * Unlike the fire-and-forget `executeShellCommand(...).close()` pattern used elsewhere in
+     * this fixture, this helper drains the command's output so callers can log or inspect it.
+     * The `shell` UID has broader MediaStore privileges than this test's own UID (`com.gb4pc`),
+     * which is why it is used for the cross-package `content delete` in [clearCameraRoll]
+     * (issue #406).
+     */
+    private fun runShellCommand(command: String): String =
+        ParcelFileDescriptor.AutoCloseInputStream(uiAutomation.executeShellCommand(command)).use {
+            it.readBytes().toString(Charsets.UTF_8).trim()
+        }
 
     private fun countMediaStoreImages(): Int {
         val cursor =

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -306,22 +306,17 @@ class GalleryButtonVisualE2ETest {
      * it fails when the regression is present and MockCameraActivity is green, and passes when
      * the overlay works and the empty gallery is shown. Do not change the assertion.
      *
-     * **Caveat introduced by PR #400 (issues #231/#232) — re-check when fixing #156.**
+     * **Cross-package roll cleanup (issue #406 — resolves the PR #400 caveat).**
      *
-     * [E2EFixture.clearCameraRoll] can only delete MediaStore rows owned by `com.gb4pc`.
      * `test3a` (which runs alphabetically before this test) captures a GREEN photo owned by
-     * `com.google.android.GoogleCamera` (the mock camera), which `clearCameraRoll()` cannot
-     * remove and which therefore remains in the camera roll for every test that runs after
-     * `test3a`, including this one. Today that is harmless: this test fails for the #156 reason
-     * (overlay blocked, tap is a no-op) regardless of the camera roll's contents.
-     *
-     * But once #156 is fixed and `tapOverlay()` starts succeeding here, the gallery will no
-     * longer be empty -- it will show `test3a`'s leftover GREEN photo -- so GREEN coverage will
-     * be >= 10% and this assertion will fail for a reason unrelated to #156. If this test is
-     * still failing after #156 lands, check for that leftover row before assuming the
-     * secure-camera fix is incomplete. Fixing this will require a way to clear cross-package
-     * MediaStore rows the test suite itself created (e.g. `pm clear` / shell `content delete`
-     * as root between tests), which is out of scope for #231/#232.
+     * `com.google.android.GoogleCamera` (the mock camera). Earlier, [E2EFixture.clearCameraRoll]
+     * could only delete rows owned by `com.gb4pc`, so that cross-package photo survived into
+     * this test and would have made the "empty gallery" assumption false once #156 was fixed.
+     * [E2EFixture.clearCameraRoll] now also runs a `content delete` shell command under the
+     * `shell` UID, which removes rows owned by *any* package, so this test's `clearCameraRoll()`
+     * genuinely empties the roll before the tap. The empty-gallery assumption therefore holds
+     * independently of `test3a`, and a failure here after #156 lands reflects the secure-camera
+     * path itself, not a leftover MediaStore row.
      *
      * Tracking issue: #156 — same as test5a. Do NOT skip, ignore, or quarantine this test.
      */


### PR DESCRIPTION
Fixes #406.

## Problem

PR #400 granted `com.gb4pc` `READ_MEDIA_IMAGES` so E2E MediaStore queries can see rows written by the mock camera, but it left a caveat: `E2EFixture.clearCameraRoll()` deletes only rows owned by `com.gb4pc`.
Under scoped storage (API 29+), `ContentResolver.delete()` cannot remove another package's MediaStore rows without a user-confirmed `createDeleteRequest` consent dialog, which is unavailable in an unattended instrumented test.

As a result, `test3a`'s GREEN capture, owned by `com.google.android.GoogleCamera` (the mock camera), survived `clearCameraRoll()` and persisted into later tests (`test4a`, `test5a`).
Today that is harmless because those tests fail for the unrelated #156 reason regardless.
But once #156 (secure-camera overlay regression) is fixed, that leftover row would make `test4a`'s "empty gallery" assumption false, causing a confusing failure unrelated to #156.

## Design

The chosen mechanism is a `content delete` shell command issued through `UiAutomation.executeShellCommand()`.
The fixture already issues many shell commands this way (`am start`, `am force-stop`, `input keyevent`).
Those commands run under the `shell` UID, which holds broad MediaStore access and can delete rows owned by *any* package without a consent dialog.

This was preferred over the alternatives floated in the issue:
- No root is required (`uiAutomation` shell access already runs at the `shell` UID, which is sufficient for `content delete`), so it works in CI as-is with no workflow or device-image changes.
- It is scoped to the external-images collection, not a blanket `pm clear` of whole packages (which would also wipe app data/permissions and is heavier than needed).

## Changes

- `E2EFixture.clearCameraRoll()` now runs two deletion passes: the existing `ContentResolver.delete()` for `com.gb4pc`'s own rows, then a `content delete --uri <EXTERNAL_CONTENT_URI>` shell pass for cross-package rows. The post-condition is now an unfiltered count: the entire external roll must be empty.
- Add a private `runShellCommand()` helper that drains a shell command's combined output (for logging the `content delete` result), versus the existing fire-and-forget `executeShellCommand(...).close()` pattern.
- Update `test4a`'s caveat doc to describe the now-implemented cross-package cleanup instead of warning about the leftover row.

## Verification

- `./gradlew :app:compileDebugAndroidTestKotlin` compiles clean.
- `./gradlew :app:testDebugUnitTest` passes.
- `ktlint` passes on both changed files.

The E2E suite itself requires an emulator with the mock APKs installed and is run via `./gradlew connectedE2EAndroidTest` in CI; that is where the cross-package delete is exercised end-to-end.
🦀

