### PR TITLE
Test PR: verify remove-verified-on-push workflow (closes #441, #442)

### DIFF
--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -4,6 +4,7 @@ name: Remove verified label on new push
 # the `verified` label applied by the Verification Planner becomes stale.
 # This workflow removes it so the label only reflects the most recent
 # verification pass.
+# Test trigger 1: label-absent path (re issue #442)
 
 on:
   pull_request:

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -10,7 +10,8 @@ on:
     types: [synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  issues: write
+  pull-requests: read
 
 jobs:
   remove-verified-label:
@@ -28,7 +29,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" \
             | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
-          if echo "$LABELS" | grep -qw "verified"; then
+          if echo "$LABELS" | tr ' ' '\n' | grep -qx "verified"; then
             echo "Removing 'verified' label from PR #$PR_NUMBER"
             curl -sf -X DELETE \
               -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -4,7 +4,7 @@ name: Remove verified label on new push
 # the `verified` label applied by the Verification Planner becomes stale.
 # This workflow removes it so the label only reflects the most recent
 # verification pass.
-# Test trigger 1: label-absent path (re issue #442)
+# Test trigger 2: label-present path (re issue #441)
 
 on:
   pull_request:

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -1,0 +1,39 @@
+name: Remove verified label on new push
+
+# When a new commit is pushed to a PR (synchronize) or the PR is reopened,
+# the `verified` label applied by the Verification Planner becomes stale.
+# This workflow removes it so the label only reflects the most recent
+# verification pass.
+
+on:
+  pull_request:
+    types: [synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-verified-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove verified label if present
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Check if the verified label is on the PR.
+          LABELS=$(curl -sf \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" \
+            | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
+          if echo "$LABELS" | grep -qw "verified"; then
+            echo "Removing 'verified' label from PR #$PR_NUMBER"
+            curl -sf -X DELETE \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/verified"
+          else
+            echo "'verified' label not present on PR #$PR_NUMBER -- nothing to do"
+          fi

--- a/.github/workflows/remove-verified-on-push.yml
+++ b/.github/workflows/remove-verified-on-push.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   remove-verified-label:


### PR DESCRIPTION
Temporary test PR used to verify the two before-merging requirements for PR #440.

**Issue #442** (label absent path): a push to this PR without the `verified` label must cause the workflow to exit cleanly.

**Issue #441** (label present path): a push to this PR with the `verified` label applied must cause the workflow to remove it.

This PR will be closed once both checks pass.

Do not merge.
