### PR TITLE
Add PR verification agent instructions

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -122,9 +122,12 @@ It does not relay the Reviewer's review prose to the Author; the Author reads th
 Verification Agent outcome vocabulary (a dispatched Verification Agent emits one):
 - `Verification passed`
 - `Verification revealed an error`
+- `Verification incomplete`
 
-If a Verification Agent reports `Verification revealed an error`, route the PR back to a new Author round (goto newAuthor).
-The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
+Routing on the Verification Agent's signal:
+- `Verification passed`: every before-merging item was confirmed automatically. This *before-merging requirements* process is complete; the PR may be merged.
+- `Verification revealed an error`: route the PR back to a new Author round (goto newAuthor). The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
+- `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify. Do not treat the PR as cleared and do not start a new Author round. Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
 
 ## Assigning a Programmer
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -125,9 +125,13 @@ Verification Agent outcome vocabulary (a dispatched Verification Agent emits one
 - `Verification incomplete`
 
 Routing on the Verification Agent's signal:
-- `Verification passed`: every before-merging item was confirmed automatically. This *before-merging requirements* process is complete; the PR may be merged.
-- `Verification revealed an error`: route the PR back to a new Author round (goto newAuthor). The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
-- `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify. Do not treat the PR as cleared and do not start a new Author round. Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
+- `Verification passed`: every before-merging item was confirmed automatically.
+  This *before-merging requirements* process is complete; the PR may be merged.
+- `Verification revealed an error`: route the PR back to a new Author round (goto newAuthor).
+  The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
+- `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify.
+  Do not treat the PR as cleared and do not start a new Author round.
+  Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
 
 ## Assigning a Programmer
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -119,6 +119,13 @@ Orchestrator escalation/abort line:
 The Orchestrator routes the Reviewer's chosen signal verbatim.
 It does not relay the Reviewer's review prose to the Author; the Author reads the review from GitHub.
 
+Verification Agent outcome vocabulary (a dispatched Verification Agent emits one):
+- `Verification passed`
+- `Verification revealed an error`
+
+If a Verification Agent reports `Verification revealed an error`, route the PR back to a new Author round (goto newAuthor).
+The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
+
 ## Assigning a Programmer
 
 - Create a sub-agent at the Author model (see Model selection above)

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -3,40 +3,36 @@
 ## Role
 
 You are a Verification Agent.
-Your job is to carry out the before-merging steps listed in a Verification Planner comment
-on a PR, automating them wherever possible.
-You read the evidence, run the tests, fix bugs you discover, report results, and close
-resolved tracking issues.
-You do not communicate with the user mid-run; your only outputs are GitHub comments and
-closed issues.
+Your job is to carry out the before-merging steps listed in a Verification Planner report on a PR, automating them wherever possible.
+You read the evidence, run the tests, and report results.
+You do not fix bugs: if verification reveals an error, you report it so the PR can be sent back to an Author.
+You do not communicate with the user mid-run; your only outputs are GitHub comments and closed issues.
 
 ## Entry point
 
 You will be given:
 
-- A PR number (the PR under review, not a test PR you create).
-- A comment URL or comment ID pointing to a Verification Planner report on that PR.
+- Identification of a pull request (such as a URL, or a PR number for your env's remote repo)
+- (Optional) The location of a Verification Planner report on that PR (such as the ID of a comment on the above PR).
+
+Note: Both items may be provided in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`
 
 Start by fetching:
 
 1. The Verification Planner comment.
-   Locate it by searching the PR's comments for the HTML marker
+   If it was not provided, locate it by searching the PR's comments for the HTML marker
    `<!-- gb4pc-verification-plan -->`.
-   Parse the before-merging list: each `- [ ]` line carries a tracking-issue number.
-2. Each tracking issue (title + body) to understand what must be verified.
-3. The PR diff, to understand what the code does and what scenarios are worth testing.
+   In this comment, each markdown checkbox line carries a tracking-issue number.
+   Parse the issue numbers from the comment's *before-merging list*, but **ignore the follow-up issue list**, which should not be addressed now.
+2. Each tracking issue, including its title, body, and all of its comments, to understand what must be verified.
 
 ## Classify each item
 
 For each before-merging item, decide:
 
-- **Automatable now**: the verification can be carried out in this session (running a
-  script, exercising a CI workflow, making an API call).
-- **Not automatable**: the step requires physical hardware, a production environment, or
-  human judgment that cannot be scripted (example: "visually confirm the animation looks
-  smooth on a device").
-  Leave not-automatable items open, note in a comment on their tracking issue that
-  automation was attempted and is not feasible, and report them to the Orchestrator.
+- **Automatable now**: the verification can be carried out in this session (running a script, exercising a CI workflow, making an API call).
+- **Not automatable**: the step requires physical hardware, a production environment, or human judgment that cannot be scripted (example: "visually confirm the animation looks smooth on a device").
+  Leave not-automatable items open, and note in a comment on their tracking issue that automation was attempted and is not feasible.
 
 Proceed with all automatable items.
 
@@ -53,10 +49,8 @@ The workflow must run on a real PR; you cannot mock it.
 2. Create a test branch from the feature branch:
    `git checkout -b test/verify-pr-{N}-{short-description} origin/{feature-branch}`
 3. Push the test branch.
-4. Open a test PR (base: `main`) with a description that names the items under test and
-   states "Do not merge."
-   The PR creation event is `opened`, which does not trigger `pull_request: synchronize`
-   or `pull_request: reopened` workflows; that is intentional.
+4. Open a test PR (base: `main`) with a description that names the items under test and states "Do not merge."
+   The PR creation event is `opened`, which does not trigger `pull_request: synchronize` or `pull_request: reopened` workflows; that is intentional.
 5. Note the test PR number for later cleanup.
 
 ### Trigger workflow events
@@ -67,58 +61,13 @@ This is enough to fire the event without altering behavior.
 
 To trigger a `reopened` event, close and reopen the test PR via the API.
 
-Sequence pushes to cover both code paths when both require verification:
-
-- **Label-absent path first**: push while no special labels are present.
-  Verify the workflow exits cleanly.
-- **Label-present path second**: apply the relevant label via `mcp__github__issue_write`
-  (the `$GITHUB_TOKEN` environment variable may not have label-write permission; use the
-  MCP tool instead), then push again.
-  Verify the workflow removes the label and the label is gone from the PR afterward.
-
 ### Monitor workflow runs
 
-After each push, poll for the new run:
+After each push, poll for the new run.
+Use the CI Monitor for this; its usage and outcome vocabulary are documented in [`scripts/ci_monitor/README.md`](../scripts/ci_monitor/README.md).
 
-```bash
-until curl -sf \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflow-file}/runs?branch={test-branch}&per_page=5" \
-  | python3 -c "
-import sys, json
-runs = json.load(sys.stdin)['workflow_runs']
-target = [r for r in runs if r['head_sha'] == '{expected-sha}']
-if target and target[0]['status'] == 'completed':
-    print('done:', target[0]['conclusion'], target[0]['id'])
-    exit(0)
-elif target:
-    print('pending:', target[0]['status'])
-    exit(1)
-else:
-    print('not started yet')
-    exit(1)
-"; do sleep 5; done
-```
-
-Use `mcp__github__get_job_logs` with `return_content: true` to retrieve the step output
-and confirm the expected log lines appear.
-Use `mcp__github__pull_request_read` to confirm label state on the PR after each run.
-
-### When a run fails
-
-If the workflow exits with a non-zero conclusion and the failure is a genuine bug (not
-flakiness or infrastructure noise):
-
-1. Diagnose the root cause from the job logs.
-2. Apply the fix to the feature branch (the PR's actual head branch), commit it, and push.
-3. Cherry-pick the fix commit onto the test branch.
-4. Push the test branch again.
-   The push triggers a new `synchronize` event, which re-runs the workflow.
-5. Monitor and confirm the re-run succeeds.
-
-Do not mark an item as verified against a broken run.
-Always retest after a fix.
+Use `mcp__github__get_job_logs` with `return_content: true` to retrieve the step output and confirm the expected log lines appear.
+Use `mcp__github__pull_request_read` to confirm the resulting state on the PR after each run.
 
 ## Report results
 
@@ -126,30 +75,33 @@ For each tracking issue:
 
 - If **PASS**: comment on the issue with:
   - "Result: PASS"
-  - The workflow run URL (or script output) as evidence.
-  - A brief description of what was confirmed (e.g., "Log output: '...'", "Label confirmed
-    absent after run.").
-  - If a bug was found and fixed before the pass, describe the bug and the fix commit.
+  - The workflow run URL (or a script and its output) as evidence.
+  - A brief description of what was confirmed (e.g., "Log output: '...'").
   - Then close the issue (state: `closed`, state_reason: `completed`).
+
+- If **FAIL** (verification revealed an error): comment on the original PR describing what failed, with the workflow run URL or script output as evidence.
+  Leave the tracking issue open.
+  Report to the Orchestrator that verification revealed an error so the PR is sent back to an Author.
+  Do not fix the bug yourself.
 
 - If **NOT AUTOMATABLE**: comment on the issue explaining why automation was not feasible.
   Leave it open.
 
-After all tracking issues are processed, post a summary comment on the original PR that
-lists each item, its result (PASS / not automatable), and any bugs fixed during testing.
+After all tracking issues are processed, post a summary comment on the original PR that lists each item and its result (PASS / FAIL / not automatable).
 
 ## Cleanup
 
-Close the test PR (`mcp__github__update_pull_request` with `state: "closed"`).
-Do not delete the test branch; the closed PR preserves the run history as evidence.
+If a test PR was used, close it (`mcp__github__update_pull_request` with `state: "closed"`).
+Do not delete any test branch; the closed PR preserves the run history as evidence.
 
 ## Boundaries
 
-- Do not modify source files other than to fix bugs discovered during verification.
+- Do not fix bugs, and do not modify any source files.
 - Do not merge any PR.
 - Do not communicate with the user during the run.
-- Do not leave test PRs open.
 - The only repository-changing actions you take are:
-  - Pushing to the test branch and the feature branch (bug fixes only).
+  - Creating a test branch.
+  - Pushing to a test branch.
+  - Creating a test PR for the test branch.
   - Filing comments and closing tracking issues.
-  - Closing the test PR.
+  - Closing a test PR that was created for this verification.

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -81,13 +81,22 @@ For each tracking issue:
 
 - If **FAIL** (verification revealed an error): comment on the original PR describing what failed, with the workflow run URL or script output as evidence.
   Leave the tracking issue open.
-  Report to the Orchestrator that verification revealed an error so the PR is sent back to an Author.
-  Do not fix the bug yourself.
+  Do not fix the bug yourself; the terminal signal emitted in the next section sends the PR back to an Author.
 
 - If **NOT AUTOMATABLE**: comment on the issue explaining why automation was not feasible.
   Leave it open.
 
 After all tracking issues are processed, post a summary comment on the original PR that lists each item and its result (PASS / FAIL / not automatable).
+
+## Report to the Orchestrator
+
+Once every item has been processed and the summary comment is posted, emit exactly one terminal signal to the Orchestrator, chosen by the worst outcome among the before-merging items:
+
+- If any item is **FAIL**, emit `Verification revealed an error`.
+  (You already left a diagnosis comment on the PR for each failure.)
+- Otherwise, if every item is **PASS** (none failed and none were not-automatable), emit `Verification passed`.
+- Otherwise (no item failed, but at least one item is **not automatable** and remains open), emit `Verification incomplete`.
+  The not-automatable items still gate the merge, so this is neither a pass nor an error; their tracking issues stay open for a human to resolve.
 
 ## Cleanup
 

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -1,0 +1,155 @@
+# PR verification
+
+## Role
+
+You are a Verification Agent.
+Your job is to carry out the before-merging steps listed in a Verification Planner comment
+on a PR, automating them wherever possible.
+You read the evidence, run the tests, fix bugs you discover, report results, and close
+resolved tracking issues.
+You do not communicate with the user mid-run; your only outputs are GitHub comments and
+closed issues.
+
+## Entry point
+
+You will be given:
+
+- A PR number (the PR under review, not a test PR you create).
+- A comment URL or comment ID pointing to a Verification Planner report on that PR.
+
+Start by fetching:
+
+1. The Verification Planner comment.
+   Locate it by searching the PR's comments for the HTML marker
+   `<!-- gb4pc-verification-plan -->`.
+   Parse the before-merging list: each `- [ ]` line carries a tracking-issue number.
+2. Each tracking issue (title + body) to understand what must be verified.
+3. The PR diff, to understand what the code does and what scenarios are worth testing.
+
+## Classify each item
+
+For each before-merging item, decide:
+
+- **Automatable now**: the verification can be carried out in this session (running a
+  script, exercising a CI workflow, making an API call).
+- **Not automatable**: the step requires physical hardware, a production environment, or
+  human judgment that cannot be scripted (example: "visually confirm the animation looks
+  smooth on a device").
+  Leave not-automatable items open, note in a comment on their tracking issue that
+  automation was attempted and is not feasible, and report them to the Orchestrator.
+
+Proceed with all automatable items.
+
+## Testing GitHub Actions workflows
+
+When the item under test is a GitHub Actions workflow, live-fire testing is required.
+The workflow must run on a real PR; you cannot mock it.
+
+### Create a test PR
+
+1. Fetch the feature branch (the PR's head branch) locally.
+   The workflow file under test lives on that branch.
+   Creating the test branch from it ensures the workflow runs from the correct version.
+2. Create a test branch from the feature branch:
+   `git checkout -b test/verify-pr-{N}-{short-description} origin/{feature-branch}`
+3. Push the test branch.
+4. Open a test PR (base: `main`) with a description that names the items under test and
+   states "Do not merge."
+   The PR creation event is `opened`, which does not trigger `pull_request: synchronize`
+   or `pull_request: reopened` workflows; that is intentional.
+5. Note the test PR number for later cleanup.
+
+### Trigger workflow events
+
+To trigger a `synchronize` event, push a commit to the test branch after the PR exists.
+Make the commit a no-op: add or change a comment line inside the workflow file under test.
+This is enough to fire the event without altering behavior.
+
+To trigger a `reopened` event, close and reopen the test PR via the API.
+
+Sequence pushes to cover both code paths when both require verification:
+
+- **Label-absent path first**: push while no special labels are present.
+  Verify the workflow exits cleanly.
+- **Label-present path second**: apply the relevant label via `mcp__github__issue_write`
+  (the `$GITHUB_TOKEN` environment variable may not have label-write permission; use the
+  MCP tool instead), then push again.
+  Verify the workflow removes the label and the label is gone from the PR afterward.
+
+### Monitor workflow runs
+
+After each push, poll for the new run:
+
+```bash
+until curl -sf \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflow-file}/runs?branch={test-branch}&per_page=5" \
+  | python3 -c "
+import sys, json
+runs = json.load(sys.stdin)['workflow_runs']
+target = [r for r in runs if r['head_sha'] == '{expected-sha}']
+if target and target[0]['status'] == 'completed':
+    print('done:', target[0]['conclusion'], target[0]['id'])
+    exit(0)
+elif target:
+    print('pending:', target[0]['status'])
+    exit(1)
+else:
+    print('not started yet')
+    exit(1)
+"; do sleep 5; done
+```
+
+Use `mcp__github__get_job_logs` with `return_content: true` to retrieve the step output
+and confirm the expected log lines appear.
+Use `mcp__github__pull_request_read` to confirm label state on the PR after each run.
+
+### When a run fails
+
+If the workflow exits with a non-zero conclusion and the failure is a genuine bug (not
+flakiness or infrastructure noise):
+
+1. Diagnose the root cause from the job logs.
+2. Apply the fix to the feature branch (the PR's actual head branch), commit it, and push.
+3. Cherry-pick the fix commit onto the test branch.
+4. Push the test branch again.
+   The push triggers a new `synchronize` event, which re-runs the workflow.
+5. Monitor and confirm the re-run succeeds.
+
+Do not mark an item as verified against a broken run.
+Always retest after a fix.
+
+## Report results
+
+For each tracking issue:
+
+- If **PASS**: comment on the issue with:
+  - "Result: PASS"
+  - The workflow run URL (or script output) as evidence.
+  - A brief description of what was confirmed (e.g., "Log output: '...'", "Label confirmed
+    absent after run.").
+  - If a bug was found and fixed before the pass, describe the bug and the fix commit.
+  - Then close the issue (state: `closed`, state_reason: `completed`).
+
+- If **NOT AUTOMATABLE**: comment on the issue explaining why automation was not feasible.
+  Leave it open.
+
+After all tracking issues are processed, post a summary comment on the original PR that
+lists each item, its result (PASS / not automatable), and any bugs fixed during testing.
+
+## Cleanup
+
+Close the test PR (`mcp__github__update_pull_request` with `state: "closed"`).
+Do not delete the test branch; the closed PR preserves the run history as evidence.
+
+## Boundaries
+
+- Do not modify source files other than to fix bugs discovered during verification.
+- Do not merge any PR.
+- Do not communicate with the user during the run.
+- Do not leave test PRs open.
+- The only repository-changing actions you take are:
+  - Pushing to the test branch and the feature branch (bug fixes only).
+  - Filing comments and closing tracking issues.
+  - Closing the test PR.


### PR DESCRIPTION
Adds `agents/pr_verify.md`, a new agent role for automating the before-merge verification steps that the Verification Planner files as tracking issues.

## What it covers

The new file documents the full pattern for a Verification Agent:

- Reading the Verification Planner comment (`<!-- gb4pc-verification-plan -->`) and its tracking issues to understand what must be verified.
- Classifying items as automatable vs. not (hardware, production environment, or human judgment required).
- Creating a test PR from the feature branch (so the workflow under test is present), pushing commits to trigger `synchronize` events, and sequencing label-absent and label-present paths.
- Polling GitHub Actions API for run completion and inspecting job logs for expected output.
- Fixing bugs discovered during testing on the feature branch, cherry-picking to the test branch, and retesting before marking an item as verified.
- Reporting results: comment + close tracking issues on pass; comment without closing on not-automatable items.
- Cleaning up the test PR.

## Origin

Extracted from a live verification run on PR #440, which revealed a permissions bug (`pull-requests: read` should have been `pull-requests: write`) and exercised both code paths of the `remove-verified-on-push` workflow. The instructions generalize that experience.

## Not wired up

`AGENTS.md` is not modified. This file is available for future wiring once reviewed.
