### PR TITLE
Record label-management transitions inline in the Orchestrator FSM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
+- If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
 - If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -73,6 +73,33 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 - See `inaugurate.md` for the full protocol when starting fresh work.
 
+## Label management
+
+The Orchestrator keeps the labels on the issue and its PR in step with the development cycle.
+At each transition below, a small Markdown table records the label move so the FSM is easy to spot when reviewing this file.
+Read each table as: remove the label in the left column, add the label in the right column.
+
+Unless a table says otherwise, the move applies **only to the PR**.
+Tables that act on the issue say *issue* explicitly.
+
+The transition tables appear inline at the point in the sequence where each transition occurs (see the sections below).
+This section lists them together for reference:
+
+- Starting to orchestrate a PR (see "Starting to orchestrate a PR")
+- Author returns (see "Assigning a Programmer")
+- Reviewer returns (see "CI checking after a Reviewer exits")
+- Verification Planner returns (see "CI checking after a Reviewer exits", Clear-line block)
+- Verifier returns (see "Decision-signal templates", Verification Agent routing)
+- Concluding PR orchestration (see "Concluding PR orchestration")
+
+## Starting to orchestrate a PR
+
+When you begin orchestrating a PR (the first thing you do once you have entered the Orchestrator role for a given issue and its PR), apply this transition to **both the issue and the PR**:
+
+| Remove label | Add label |
+|---|---|
+| `for ai to do` | `orchestrating` |
+
 ## Model selection
 
 For each sub-agent role, use the first rule that applies:
@@ -133,6 +160,14 @@ Routing on the Verification Agent's signal:
   Do not treat the PR as cleared and do not start a new Author round.
   Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
 
+When the Verifier returns, apply the transition matching its signal to the PR:
+
+| Signal | Remove label | Add label |
+|---|---|---|
+| `Verification passed` | `needs verification` | `verified` |
+| `Verification revealed an error` | `needs verification` | `change requested` |
+| `Verification incomplete` | -- | -- (leave `needs verification` applied) |
+
 ## Assigning a Programmer
 
 - Create a sub-agent at the Author model (see Model selection above)
@@ -140,6 +175,12 @@ Routing on the Verification Agent's signal:
   Branch names should follow the pattern `fix/issue-N-short-description` for bug fixes or `feature/issue-N-short-description` for new features.
   Never direct two Programmers for unrelated issues to the same branch.
 - Dispatch using the dispatch template above, with the Programmer role assignment statement and the literal issue number and branch name tokens.
+
+When the Author returns, apply this transition to the PR:
+
+| Remove label | Add label |
+|---|---|
+| `change requested` | `change done` |
 
 ## Assigning a Reviewer
 
@@ -154,6 +195,12 @@ If the Author disagrees with a review point, they should make their case in PR c
 
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
+
+When the Reviewer returns, apply this transition to the PR:
+
+| Remove label | Add label |
+|---|---|
+| `change done` | `change requested` (only if the Reviewer requested changes) |
 
 ```text
   if Reviewer requested changes → goto newAuthor
@@ -179,6 +226,14 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
       Otherwise, relay the planner's reported before-merging list to the user verbatim.
       → PR may be merged once every issue the planner filed for its before-merging list is resolved.
+
+      When the Verification Planner returns, apply this transition to the PR, depending on its answer:
+
+      | Remove label | Add label |
+      |---|---|
+      | -- | `verified` (if the before-merging list is empty) or `needs verification` (if it is not) |
+
+      (The Planner itself applies `verified` to both the PR and the issue when its before-merging list is empty; the Orchestrator adds `needs verification` to the PR when the list is not empty.)
 
 undiagnosedTerminal:
   // Issue #410 (Run G, issue #402): "drain poll found no new diagnostic
@@ -274,3 +329,11 @@ Stop the automated cycle and escalate to the User in these cases:
 
 - **After four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)
 - **If the Programmer gives up** or claims the issue cannot be solved as stated
+
+## Concluding PR orchestration
+
+When you conclude orchestration of a PR (the cycle is complete or you are escalating and stepping out of the Orchestrator role for this PR), apply this transition to **both the issue and the PR**:
+
+| Remove label | Add label |
+|---|---|
+| `orchestrating` | -- |

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -152,11 +152,11 @@ Routing on the Verification Agent's signal:
 - `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify.
   Do not treat the PR as cleared and do not start a new Author round.
   Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
-  Apply this transition to the PR (`verification needed` stays applied):
+  Apply this transition to the PR only if needed. The `verification needed` label is probably already applied:
 
   | Remove label | Add label |
   |---|---|
-  | -- | -- |
+  | -- | `verification needed` |
 
 ## Assigning a Programmer
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -93,7 +93,7 @@ This section lists them together for reference:
 - Starting to orchestrate a PR (see "Starting to orchestrate a PR")
 - Author returns (see "Assigning a Programmer")
 - Reviewer returns (see "CI checking after a Reviewer exits", both at the top and in the requested-changes branch)
-- Verification Planner returns (see "CI checking after a Reviewer exits", non-empty before-merging branch)
+- Verification Planner returns (see "CI checking after a Reviewer exits", both the empty and non-empty before-merging branches)
 - Verifier returns (see "Decision-signal templates", Verification Agent routing branches)
 - Concluding PR orchestration (see "Concluding PR orchestration")
 
@@ -245,7 +245,12 @@ If the Reviewer requested changes, apply this transition to the PR:
       Dispatch a Verification Planner sub-agent using the dispatch template.
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
-      (The Planner itself applies `verified` to both the PR and the issue in this case, so the Orchestrator has no label move to make.)
+      In that case, apply this transition to **both the issue and the PR**:
+
+      | Remove label | Add label |
+      |---|---|
+      | -- | `verified` |
+
       Otherwise, relay the planner's reported before-merging list to the user verbatim, and apply this transition to the PR:
 
       | Remove label | Add label |

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -73,30 +73,6 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 - See `inaugurate.md` for the full protocol when starting fresh work.
 
-## Label management
-
-The Orchestrator keeps the labels on the issue and its PR in step with the development cycle.
-At each transition below, a small Markdown table records the label move so the FSM is easy to spot when reviewing this file.
-Read each table as: remove the label in the "Remove label" column, add the label in the "Add label" column.
-A `--` cell means there is nothing to remove or add.
-
-Every table is unconditional: when control reaches the table, apply the whole table.
-There are no conditions or signals inside a table.
-Each table is placed at the exact point in the existing instruction sequence where that move applies, so the surrounding branch (not the table) already decides whether you are there.
-
-Unless a table says otherwise, the move applies **only to the PR**.
-Tables that act on the issue say *issue* explicitly.
-
-The transition tables appear inline at the point in the sequence where each transition occurs (see the sections below).
-This section lists them together for reference:
-
-- Starting to orchestrate a PR (see "Starting to orchestrate a PR")
-- Author returns (see "Assigning a Programmer")
-- Reviewer returns (see "CI checking after a Reviewer exits", both at the top and in the requested-changes branch)
-- Verification Planner returns (see "CI checking after a Reviewer exits", both the empty and non-empty before-merging branches)
-- Verifier returns (see "Decision-signal templates", Verification Agent routing branches)
-- Concluding PR orchestration (see "Concluding PR orchestration")
-
 ## Starting to orchestrate a PR
 
 When you begin orchestrating a PR (the first thing you do once you have entered the Orchestrator role for a given issue and its PR), apply this transition to **both the issue and the PR**:

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -77,7 +77,9 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 The Orchestrator keeps the labels on the issue and its PR in step with the development cycle.
 At each transition below, a small Markdown table records the label move so the FSM is easy to spot when reviewing this file.
-Read each table as: remove the label in the left column, add the label in the right column.
+Read each table as: remove the label in the "Remove label" column, add the label in the "Add label" column.
+The removal is unconditional unless the "Remove label" cell itself is qualified; a parenthetical in the "Add label" cell gates only the add.
+Some tables prepend a "Signal" column that selects which row applies (for example, the Verifier table); read the chosen row left-to-right as usual.
 
 Unless a table says otherwise, the move applies **only to the PR**.
 Tables that act on the issue say *issue* explicitly.
@@ -164,9 +166,9 @@ When the Verifier returns, apply the transition matching its signal to the PR:
 
 | Signal | Remove label | Add label |
 |---|---|---|
-| `Verification passed` | `needs verification` | `verified` |
-| `Verification revealed an error` | `needs verification` | `change requested` |
-| `Verification incomplete` | -- | -- (leave `needs verification` applied) |
+| `Verification passed` | `verification needed` | `verified` |
+| `Verification revealed an error` | `verification needed` | `changes requested` |
+| `Verification incomplete` | -- | -- (leave `verification needed` applied) |
 
 ## Assigning a Programmer
 
@@ -180,7 +182,7 @@ When the Author returns, apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|
-| `change requested` | `change done` |
+| `changes requested` | `changes done` |
 
 ## Assigning a Reviewer
 
@@ -200,7 +202,7 @@ When the Reviewer returns, apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|
-| `change done` | `change requested` (only if the Reviewer requested changes) |
+| `changes done` (always) | `changes requested` (only if the Reviewer requested changes) |
 
 ```text
   if Reviewer requested changes → goto newAuthor
@@ -231,9 +233,9 @@ When the Reviewer returns, apply this transition to the PR:
 
       | Remove label | Add label |
       |---|---|
-      | -- | `verified` (if the before-merging list is empty) or `needs verification` (if it is not) |
+      | -- | `verification needed` (only if the before-merging list is not empty) |
 
-      (The Planner itself applies `verified` to both the PR and the issue when its before-merging list is empty; the Orchestrator adds `needs verification` to the PR when the list is not empty.)
+      (When the before-merging list is empty, the Planner itself applies `verified` to both the PR and the issue, so the Orchestrator has nothing to add in that case. The Orchestrator's only added duty here is applying `verification needed` to the PR when the list is not empty.)
 
 undiagnosedTerminal:
   // Issue #410 (Run G, issue #402): "drain poll found no new diagnostic

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -210,13 +210,13 @@ If the Author disagrees with a review point, they should make their case in PR c
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
-When the Reviewer returns, apply this transition to the PR before branching on its decision:
+When the Reviewer returns, apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|
 | `changes done` | -- |
 
-Then if the Reviewer requested changes, apply this transition to the PR:
+If the Reviewer requested changes, additionally apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -216,8 +216,7 @@ When the Reviewer returns, apply this transition to the PR before branching on i
 |---|---|
 | `changes done` | -- |
 
-Then branch on the Reviewer's decision.
-If the Reviewer requested changes, apply this transition to the PR:
+Then if the Reviewer requested changes, apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -217,7 +217,7 @@ When the Reviewer returns, apply this transition to the PR before branching on i
 | `changes done` | -- |
 
 Then branch on the Reviewer's decision.
-In the `goto newAuthor` branch below (the Reviewer requested changes), also apply this transition to the PR:
+If the Reviewer requested changes, apply this transition to the PR:
 
 | Remove label | Add label |
 |---|---|

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -78,8 +78,11 @@ The Orchestrator is not a Reviewer or a Programmer.
 The Orchestrator keeps the labels on the issue and its PR in step with the development cycle.
 At each transition below, a small Markdown table records the label move so the FSM is easy to spot when reviewing this file.
 Read each table as: remove the label in the "Remove label" column, add the label in the "Add label" column.
-The removal is unconditional unless the "Remove label" cell itself is qualified; a parenthetical in the "Add label" cell gates only the add.
-Some tables prepend a "Signal" column that selects which row applies (for example, the Verifier table); read the chosen row left-to-right as usual.
+A `--` cell means there is nothing to remove or add.
+
+Every table is unconditional: when control reaches the table, apply the whole table.
+There are no conditions or signals inside a table.
+Each table is placed at the exact point in the existing instruction sequence where that move applies, so the surrounding branch (not the table) already decides whether you are there.
 
 Unless a table says otherwise, the move applies **only to the PR**.
 Tables that act on the issue say *issue* explicitly.
@@ -89,9 +92,9 @@ This section lists them together for reference:
 
 - Starting to orchestrate a PR (see "Starting to orchestrate a PR")
 - Author returns (see "Assigning a Programmer")
-- Reviewer returns (see "CI checking after a Reviewer exits")
-- Verification Planner returns (see "CI checking after a Reviewer exits", Clear-line block)
-- Verifier returns (see "Decision-signal templates", Verification Agent routing)
+- Reviewer returns (see "CI checking after a Reviewer exits", both at the top and in the requested-changes branch)
+- Verification Planner returns (see "CI checking after a Reviewer exits", non-empty before-merging branch)
+- Verifier returns (see "Decision-signal templates", Verification Agent routing branches)
 - Concluding PR orchestration (see "Concluding PR orchestration")
 
 ## Starting to orchestrate a PR
@@ -156,19 +159,28 @@ Verification Agent outcome vocabulary (a dispatched Verification Agent emits one
 Routing on the Verification Agent's signal:
 - `Verification passed`: every before-merging item was confirmed automatically.
   This *before-merging requirements* process is complete; the PR may be merged.
+  Apply this transition to the PR:
+
+  | Remove label | Add label |
+  |---|---|
+  | `verification needed` | `verified` |
+
 - `Verification revealed an error`: route the PR back to a new Author round (goto newAuthor).
   The Verification Agent leaves its diagnosis as a PR comment, which the Author reads from GitHub; the Orchestrator does not relay it.
+  Apply this transition to the PR:
+
+  | Remove label | Add label |
+  |---|---|
+  | `verification needed` | `changes requested` |
+
 - `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify.
   Do not treat the PR as cleared and do not start a new Author round.
   Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
+  Apply this transition to the PR (`verification needed` stays applied):
 
-When the Verifier returns, apply the transition matching its signal to the PR:
-
-| Signal | Remove label | Add label |
-|---|---|---|
-| `Verification passed` | `verification needed` | `verified` |
-| `Verification revealed an error` | `verification needed` | `changes requested` |
-| `Verification incomplete` | -- | -- (leave `verification needed` applied) |
+  | Remove label | Add label |
+  |---|---|
+  | -- | -- |
 
 ## Assigning a Programmer
 
@@ -198,11 +210,18 @@ If the Author disagrees with a review point, they should make their case in PR c
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
-When the Reviewer returns, apply this transition to the PR:
+When the Reviewer returns, apply this transition to the PR before branching on its decision:
 
 | Remove label | Add label |
 |---|---|
-| `changes done` (always) | `changes requested` (only if the Reviewer requested changes) |
+| `changes done` | -- |
+
+Then branch on the Reviewer's decision.
+In the `goto newAuthor` branch below (the Reviewer requested changes), also apply this transition to the PR:
+
+| Remove label | Add label |
+|---|---|
+| -- | `changes requested` |
 
 ```text
   if Reviewer requested changes → goto newAuthor
@@ -226,16 +245,14 @@ When the Reviewer returns, apply this transition to the PR:
       Dispatch a Verification Planner sub-agent using the dispatch template.
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
-      Otherwise, relay the planner's reported before-merging list to the user verbatim.
-      → PR may be merged once every issue the planner filed for its before-merging list is resolved.
-
-      When the Verification Planner returns, apply this transition to the PR, depending on its answer:
+      (The Planner itself applies `verified` to both the PR and the issue in this case, so the Orchestrator has no label move to make.)
+      Otherwise, relay the planner's reported before-merging list to the user verbatim, and apply this transition to the PR:
 
       | Remove label | Add label |
       |---|---|
-      | -- | `verification needed` (only if the before-merging list is not empty) |
+      | -- | `verification needed` |
 
-      (When the before-merging list is empty, the Planner itself applies `verified` to both the PR and the issue, so the Orchestrator has nothing to add in that case. The Orchestrator's only added duty here is applying `verification needed` to the PR when the list is not empty.)
+      → PR may be merged once every issue the planner filed for its before-merging list is resolved.
 
 undiagnosedTerminal:
   // Issue #410 (Run G, issue #402): "drain poll found no new diagnostic

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -98,6 +98,7 @@ Role assignment statements (copy the applicable line exactly):
 - Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR. If it does *not* exist, create the PR before you exit."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
+- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
 
 ## Decision-signal templates
 
@@ -177,7 +178,9 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       Dispatch a Verification Planner sub-agent using the dispatch template.
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
-      Otherwise, relay the planner's reported before-merging list to the user verbatim.
+      Otherwise, relay the planner's reported before-merging list to the user verbatim, then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items.
+      The Verification Agent automates each item where possible and reports results on the tracking issues and PR; it does not consult the user.
+      Route on the Verification Agent's terminal signal per "Routing on the Verification Agent's signal" above.
       → PR may be merged once every issue the planner filed for its before-merging list is resolved.
 
 undiagnosedTerminal:

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -32,8 +32,9 @@ Only the before-merging list controls the merge gate.
    Assemble two lists:
    - the *before merging* list, labeling each item as either an unautomated verification step or a change outside the repo, and noting for each item the URL of the specific PR comment that called for it; and
    - the *follow-on* list, noting for each item the URL of the source comment or description and a brief reason it is not a merge blocker (e.g., "explicitly deferred in PR comment," "out of scope for this PR").
-2. If the *before merging* list is empty, apply the `verified` label to both the PR and the issue it resolves, report this success to the Orchestrator (no unautomated steps or outside-the-repo requirements were identified; the PR may be merged) and exit.
-   A non-empty follow-on list does not prevent you from applying the `verified` label; apply it anyway and also report the follow-on list.
+2. If the *before merging* list is empty, report this success to the Orchestrator (no unautomated steps or outside-the-repo requirements were identified; the PR may be merged) and exit.
+   The Orchestrator owns all label moves, so do not apply any label yourself; it applies `verified` to the PR and the issue on your empty-list report.
+   A non-empty follow-on list does not change this report; report the follow-on list as well.
 3. **Before filing any issues**, check whether the PR already has a verification-plan comment from a prior run.
    Search the PR's comments for one that contains the exact HTML marker `<!-- gb4pc-verification-plan -->`.
    If such a comment exists, parse it to extract the list of already-filed issues (each line with a `- [ ]` or `- [x]` checkbox carries an issue number of the form `#{issue number}`).


### PR DESCRIPTION
Fixes #468

## What

Adds label-management instructions to `agents/dev_orchestration.md` so the Orchestrator keeps the labels on an issue and its PR in step with the development cycle.

## How

Rather than asking the Orchestrator to track a separate sequence, each label transition is specified inline at the point in the existing instruction sequence where that transition occurs. Each transition is recorded with a small Markdown table, which makes the FSM easy to spot when a human reviews this file (tables are otherwise rare in the agents markdown).

A new "Label management" section explains the table notation (remove the left-column label, add the right-column label; a dash means no change), states that transitions apply only to the PR unless the table says *issue* explicitly, and indexes where each inline table lives.

Transitions covered, placed at their sequence points:

- Starting to orchestrate a PR: remove `for ai to do`, add `orchestrating` (issue and PR).
- Author returns: remove `change requested`, add `change done`.
- Reviewer returns: remove `change done`; add `change requested` only if changes were requested.
- Verification Planner returns: add `verified` (empty before-merging list) or `needs verification` (non-empty). Notes that `verification_planning.md` already applies `verified` itself, so the Orchestrator's added duty is applying `needs verification` to the PR.
- Verifier returns: passed -> remove `needs verification`, add `verified`; error -> remove `needs verification`, add `change requested`; incomplete -> leave `needs verification` applied.
- Concluding PR orchestration: remove `orchestrating` (issue and PR).

## Notes

Documentation-only change. Pre-commit hooks (including markdownlint) pass.

