### PR TITLE
Wire the Verification Agent into AGENTS.md and the orchestration flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@
 - If creating a PR, read `./agents/pr_creation.md`.
 - If editing code, read `./agents/code_edit.md`.
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
+- If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
 - If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -98,6 +98,7 @@ Role assignment statements (copy the applicable line exactly):
 - Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR. If it does *not* exist, create the PR before you exit."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
+- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
 
 ## Decision-signal templates
 
@@ -177,7 +178,9 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
       Dispatch a Verification Planner sub-agent using the dispatch template.
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
-      Otherwise, relay the planner's reported before-merging list to the user verbatim.
+      Otherwise, relay the planner's reported before-merging list to the user verbatim, then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items.
+      The Verification Agent automates each item where possible and reports results on the tracking issues and PR; it does not consult the user.
+      Route on the Verification Agent's terminal signal per "Routing on the Verification Agent's signal" above.
       → PR may be merged once every issue the planner filed for its before-merging list is resolved.
 
 undiagnosedTerminal:


### PR DESCRIPTION
Fixes #465

PR #453 added `agents/pr_verify.md` (the Verification Agent role) but explicitly deferred wiring `AGENTS.md` to route tasks to it. Now that those instructions exist, this PR completes the wiring.

## Changes

- **`AGENTS.md`**: Add a routing line so an agent acting as a Verification Agent is directed to read `./agents/pr_verify.md`, mirroring the existing routing entries.
- **`agents/dev_orchestration.md`**: Close two related gaps that left the Verification Agent unreachable:
  - The dispatch template had role-assignment statements for Programmer, Reviewer, and Verification Planner, but none for the Verification Agent. Added a Verification Agent statement.
  - The Monitor loop dispatched the Verification Planner (which files before-merging tracking issues) but never dispatched a Verification Agent to carry those items out, so the doc's existing "Routing on the Verification Agent's signal" section was orphaned. The loop now dispatches a Verification Agent after the Planner produces a non-empty before-merging list, and routes on its terminal signal.

## Notes

This change is documentation-only (agent-instruction Markdown). There is no automated test coverage for prose routing entries, and the pre-commit hooks (including markdownlint) pass.