### PR TITLE
Add c-a-* and c-r-* prefix groups to the mutually exclusive label enforcer

### DIFF
--- a/.github/workflows/enforce-mutually-exclusive-labels.yml
+++ b/.github/workflows/enforce-mutually-exclusive-labels.yml
@@ -4,11 +4,15 @@ name: Enforce mutually exclusive labels
 # pull request, automatically removes any other labels from the same set so
 # that at most one member of each set is present at any time.
 #
-# Mutually exclusive sets:
+# Mutually exclusive sets (fixed):
 #   [p1, p2, p3]
 #   [needs verification, verified]
 #   [change requested, change done]
 #   [for ai to do, orchestrating]
+#
+# Mutually exclusive prefix groups:
+#   c-a-*   (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
+#   c-r-*   (reviewer model, e.g. c-r-haiku, c-r-sonnet, c-r-opus)
 
 on:
   issues:

--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -5,11 +5,15 @@ When a label that belongs to a mutually exclusive set is added to an issue or
 pull request, remove all other labels in the same set so that at most one
 member of each set is present at any time.
 
-Mutually exclusive sets:
+Mutually exclusive sets (fixed):
     [p1, p2, p3]
     [needs verification, verified]
     [change requested, change done]
     [for ai to do, orchestrating]
+
+Mutually exclusive prefix groups (any label sharing a prefix is exclusive):
+    c-a-*   (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
+    c-r-*   (reviewer model, e.g. c-r-haiku, c-r-sonnet, c-r-opus)
 
 Usage:
     python3 scripts/enforce_mutually_exclusive_labels.py
@@ -41,6 +45,13 @@ MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
     frozenset({"needs verification", "verified"}),
     frozenset({"change requested", "change done"}),
     frozenset({"for ai to do", "orchestrating"}),
+]
+
+# Prefix-based exclusive groups: any two labels sharing a prefix are exclusive.
+# Matching is case-insensitive.
+MUTUALLY_EXCLUSIVE_PREFIXES: list[str] = [
+    "c-a-",
+    "c-r-",
 ]
 
 
@@ -85,18 +96,45 @@ def find_conflicting_set(added_label: str) -> frozenset[str] | None:
     return None
 
 
+def find_conflicting_prefix(added_label: str) -> str | None:
+    """Return the exclusive prefix that *added_label* matches, or None."""
+    lower = added_label.lower()
+    for prefix in MUTUALLY_EXCLUSIVE_PREFIXES:
+        if lower.startswith(prefix):
+            return prefix
+    return None
+
+
 def labels_to_remove(
     added_label: str,
     current_labels: list[str],
     label_set: frozenset[str],
 ) -> list[str]:
-    """Return the current labels that conflict with *added_label*.
+    """Return the current labels that conflict with *added_label* (fixed-set groups).
 
     Conflicts are labels in *label_set* other than *added_label* itself.
     """
     added_lower = added_label.lower()
     return [
         lbl for lbl in current_labels if lbl.lower() in label_set and lbl.lower() != added_lower
+    ]
+
+
+def labels_to_remove_by_prefix(
+    added_label: str,
+    current_labels: list[str],
+    prefix: str,
+) -> list[str]:
+    """Return the current labels that conflict with *added_label* (prefix groups).
+
+    Conflicts are labels that share *prefix* (case-insensitive) but differ from
+    *added_label* itself.
+    """
+    added_lower = added_label.lower()
+    return [
+        lbl
+        for lbl in current_labels
+        if lbl.lower().startswith(prefix) and lbl.lower() != added_lower
     ]
 
 
@@ -168,7 +206,9 @@ def main() -> int:
         return 0
 
     label_set = find_conflicting_set(added_label)
-    if label_set is None:
+    conflicting_prefix = find_conflicting_prefix(added_label)
+
+    if label_set is None and conflicting_prefix is None:
         print(f"Label '{added_label}' is not in any mutually exclusive set -- nothing to do.")
         return 0
 
@@ -186,7 +226,14 @@ def main() -> int:
         return 0
 
     current_labels = [lbl["name"] for lbl in issue.get("labels", [])]
-    to_remove = labels_to_remove(added_label, current_labels, label_set)
+
+    to_remove: list[str] = []
+    if label_set is not None:
+        to_remove.extend(labels_to_remove(added_label, current_labels, label_set))
+    if conflicting_prefix is not None:
+        to_remove.extend(
+            labels_to_remove_by_prefix(added_label, current_labels, conflicting_prefix)
+        )
 
     if not to_remove:
         print(

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -105,6 +105,92 @@ class TestFindConflictingSet(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# find_conflicting_prefix tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindConflictingPrefix(unittest.TestCase):
+    def test_c_a_label_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("c-a-sonnet"), "c-a-")
+
+    def test_c_a_opus_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("c-a-opus"), "c-a-")
+
+    def test_c_r_label_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("c-r-haiku"), "c-r-")
+
+    def test_c_r_opus_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("c-r-opus"), "c-r-")
+
+    def test_case_insensitive_c_a(self):
+        self.assertEqual(emxl.find_conflicting_prefix("C-A-Opus"), "c-a-")
+
+    def test_case_insensitive_c_r(self):
+        self.assertEqual(emxl.find_conflicting_prefix("C-R-Haiku"), "c-r-")
+
+    def test_unrelated_label_returns_none(self):
+        self.assertIsNone(emxl.find_conflicting_prefix("ci"))
+        self.assertIsNone(emxl.find_conflicting_prefix("p1"))
+        self.assertIsNone(emxl.find_conflicting_prefix("bug"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(emxl.find_conflicting_prefix(""))
+
+    def test_partial_prefix_not_matched(self):
+        # "c-a" without trailing dash should not match "c-a-"
+        self.assertIsNone(emxl.find_conflicting_prefix("c-a"))
+        self.assertIsNone(emxl.find_conflicting_prefix("c-r"))
+
+
+# ---------------------------------------------------------------------------
+# labels_to_remove_by_prefix tests
+# ---------------------------------------------------------------------------
+
+
+class TestLabelsByPrefix(unittest.TestCase):
+    def test_removes_conflicting_c_a_label(self):
+        result = emxl.labels_to_remove_by_prefix("c-a-opus", ["c-a-sonnet", "ci"], "c-a-")
+        self.assertEqual(result, ["c-a-sonnet"])
+
+    def test_does_not_remove_added_label_itself(self):
+        result = emxl.labels_to_remove_by_prefix("c-a-opus", ["c-a-opus", "c-a-sonnet"], "c-a-")
+        self.assertNotIn("c-a-opus", result)
+        self.assertIn("c-a-sonnet", result)
+
+    def test_removes_conflicting_c_r_label(self):
+        result = emxl.labels_to_remove_by_prefix("c-r-haiku", ["c-r-opus", "bug"], "c-r-")
+        self.assertEqual(result, ["c-r-opus"])
+
+    def test_returns_empty_when_no_prefix_conflicts(self):
+        result = emxl.labels_to_remove_by_prefix("c-a-sonnet", ["ci", "p1", "c-r-haiku"], "c-a-")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_current_labels_empty(self):
+        result = emxl.labels_to_remove_by_prefix("c-a-sonnet", [], "c-a-")
+        self.assertEqual(result, [])
+
+    def test_case_insensitive_added_label(self):
+        """C-A-Opus should be treated as c-a-opus and not remove itself."""
+        result = emxl.labels_to_remove_by_prefix("C-A-Opus", ["c-a-opus", "c-a-sonnet"], "c-a-")
+        self.assertNotIn("c-a-opus", result)
+        self.assertIn("c-a-sonnet", result)
+
+    def test_case_insensitive_current_label(self):
+        """Current label C-A-Sonnet should be matched and returned."""
+        result = emxl.labels_to_remove_by_prefix("c-a-opus", ["C-A-Sonnet", "ci"], "c-a-")
+        self.assertEqual(result, ["C-A-Sonnet"])
+
+    def test_does_not_remove_labels_from_other_prefix(self):
+        """c-r-* labels must not be removed when enforcing c-a-*."""
+        result = emxl.labels_to_remove_by_prefix(
+            "c-a-sonnet", ["c-a-haiku", "c-r-opus", "ci"], "c-a-"
+        )
+        self.assertIn("c-a-haiku", result)
+        self.assertNotIn("c-r-opus", result)
+        self.assertNotIn("ci", result)
+
+
+# ---------------------------------------------------------------------------
 # labels_to_remove tests
 # ---------------------------------------------------------------------------
 
@@ -378,6 +464,108 @@ class TestMain(unittest.TestCase):
         self.assertEqual(result, 0)
         # Only the GET was attempted; no DELETE follows a bad response.
         self.assertEqual(mock_api.call_count, 1)
+
+    # ------------------------------------------------------------------
+    # Prefix group tests
+    # ------------------------------------------------------------------
+
+    def test_c_a_opus_removes_c_a_sonnet(self):
+        """Adding c-a-opus when c-a-sonnet is present removes c-a-sonnet."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "c-a-opus"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["c-a-sonnet", "ci"]),
+                    None,  # DELETE c-a-sonnet
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("c-a-sonnet", delete_call[0][0])
+        self.assertEqual(delete_call[1]["method"], "DELETE")
+
+    def test_c_r_haiku_removes_c_r_opus(self):
+        """Adding c-r-haiku when c-r-opus is present removes c-r-opus."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "c-r-haiku"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["c-r-opus", "bug"]),
+                    None,  # DELETE c-r-opus
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("c-r-opus", delete_call[0][0])
+        self.assertEqual(delete_call[1]["method"], "DELETE")
+
+    def test_c_a_sonnet_no_conflict_does_nothing(self):
+        """Adding c-a-sonnet when no other c-a-* label is present does nothing."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "c-a-sonnet"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[self._make_issue_response(["ci", "c-r-haiku"])],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        # Only the GET should have been called.
+        self.assertEqual(mock_api.call_count, 1)
+
+    def test_unrelated_label_unaffected_by_prefix_groups(self):
+        """Adding 'ci' should not trigger any prefix-group enforcement."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "ci"}):
+            with patch.object(emxl, "gh_api") as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+
+    def test_c_a_prefix_case_insensitive(self):
+        """C-A-Opus is treated as c-a-opus and removes c-a-sonnet."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "C-A-Opus"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["c-a-sonnet", "ci"]),
+                    None,  # DELETE c-a-sonnet
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("c-a-sonnet", delete_call[0][0])
+
+    def test_c_r_prefix_does_not_remove_c_a_labels(self):
+        """Enforcing c-r-* must not touch c-a-* labels."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "c-r-sonnet"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["c-r-haiku", "c-a-opus", "ci"]),
+                    None,  # DELETE c-r-haiku only
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        # Exactly two calls: one GET, one DELETE (for c-r-haiku only)
+        self.assertEqual(mock_api.call_count, 2)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("c-r-haiku", delete_call[0][0])
+        # c-a-opus must not appear in any DELETE call
+        delete_paths = [c[0][0] for c in mock_api.call_args_list[1:]]
+        self.assertFalse(any("c-a-opus" in p for p in delete_paths))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #466

## What changed

Extended `scripts/enforce_mutually_exclusive_labels.py` with prefix-based exclusive groups alongside the existing fixed sets.

**Script (`scripts/enforce_mutually_exclusive_labels.py`)**
- Added `MUTUALLY_EXCLUSIVE_PREFIXES` list containing `c-a-` and `c-r-`.
- Added `find_conflicting_prefix(added_label)` -- mirrors `find_conflicting_set` but matches by prefix instead of set membership. Matching is case-insensitive.
- Added `labels_to_remove_by_prefix(added_label, current_labels, prefix)` -- returns labels sharing the prefix that differ from the newly added label.
- Updated `main()` to check both fixed sets and prefix groups; both kinds of conflicts are collected and removed in a single pass.
- Updated the module docstring to document the two new prefix groups.

**Workflow (`.github/workflows/enforce-mutually-exclusive-labels.yml`)**
- Updated the header comment to list `c-a-*` and `c-r-*` alongside the four existing fixed sets.

**Tests (`scripts/test_enforce_mutually_exclusive_labels.py`)**
- Added `TestFindConflictingPrefix` (9 cases): prefix match for `c-a-*` and `c-r-*`, case-insensitivity, no match for unrelated labels and partial prefixes.
- Added `TestLabelsByPrefix` (8 cases): conflict detection, self-exclusion, case-insensitivity on both sides, cross-prefix isolation.
- Added 6 new `TestMain` integration cases: adding `c-a-opus` removes `c-a-sonnet`; adding `c-r-haiku` removes `c-r-opus`; no conflict does nothing; unrelated label `ci` is unaffected; case-insensitive matching; `c-r-*` enforcement does not touch `c-a-*` labels.

All 64 tests pass (47 pre-existing + 17 new).
