### PR TITLE
Document gh_api None return; confirm response_body rename landed in #457

### DIFF
--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -52,6 +52,8 @@ MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
 def gh_api(path: str, token: str, method: str = "GET", body: object = None) -> object:
     """Make a GitHub API request and return the parsed JSON response.
 
+    Returns ``None`` for responses with an empty body (e.g. 204 No Content).
+
     Raises ``urllib.error.HTTPError`` or ``urllib.error.URLError`` on
     failure so callers can handle errors explicitly.
     """


### PR DESCRIPTION
Fixes #461

The `body`-shadowing nit noted in PR #457's second review was addressed on the PR branch before merge: the inner response-reading variable was renamed from `body` to `response_body` (line 70) so it no longer shadows the `body` parameter.
Issue #461 was filed as a follow-on tracker, but the rename was already present in the merged code.

This PR adds one related improvement: the `gh_api` docstring previously only described the happy-path JSON return.
The function can also return `None` when the response body is empty (204 No Content from a label DELETE), so a "Returns None for empty-body responses" line is added to make the contract match the implementation.
