### PR TITLE
Allow an Author to decline opening a PR and request review on the issue

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -99,10 +99,21 @@ Role assignment statements (copy the applicable line exactly):
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 
+The Programmer statement's "create the PR before you exit" is the default.
+It does not override the Author's right to decline to open a PR in the three circumstances described under "Declining to open a PR" in `pr_participation.md`.
+An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `Review the issue comment` (see the Author review-target vocabulary below) instead of creating a PR.
+
 ## Decision-signal templates
 
 When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
+
+Author-to-Orchestrator review-target vocabulary (the Programmer emits one when it finishes a round):
+- `Review the PR` -- a PR exists; review it.
+- `Review the issue comment` -- the Author opened no PR and is requesting a review on its explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+
+When the Author emits `Review the issue comment`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
+The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
 - `LGTM`
@@ -145,15 +156,32 @@ Routing on the Verification Agent's signal:
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
 - Dispatch using the dispatch template above, with the Reviewer role assignment statement and the literal issue number token.
+- If the Author emitted `Review the issue comment` (no PR was opened), the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
+  The dispatch template's issue token already points the Reviewer there; the Reviewer follows "Reviewing an Author who declined to open a PR" in `pr_participation.md`.
 
 ## Author disagreement
 
 If the Author disagrees with a review point, they should make their case in PR comments rather than acquiescing.
+When the round is running on the no-PR path (the Author declined to open a PR), the Author makes its case in **issue** comments instead, since that is where the review lives.
 
 ## CI checking after a Reviewer exits (Monitor loop)
 
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
+
+There are two shapes the round can take, decided by the Author's review-target signal from the prior round:
+
+- **No PR (the Author emitted `Review the issue comment`).**
+  There is no diff, no branch to merge, and no CI to run.
+    if Reviewer requested changes → goto newAuthor
+    if Reviewer gave LGTM:
+      The issue is resolved without a code change, and the Reviewer agreed.
+      Do NOT launch the CI Monitor and do NOT dispatch a Verification Planner; both presuppose a PR.
+      Inform the user that the Author and Reviewer agreed the issue needs no PR, and that the loop is complete.
+      The issue may now be closed by the user (the Orchestrator does not close it).
+      stop
+- **PR (the Author emitted `Review the PR`).**
+  Proceed with the Monitor loop below.
 
 ```text
   if Reviewer requested changes → goto newAuthor

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -102,18 +102,18 @@ Role assignment statements (copy the applicable line exactly):
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
-An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `Review the issue comment` (see the Author review-target vocabulary below) instead of creating a PR.
+An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.
 
 ## Decision-signal templates
 
 When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
-Author-to-Orchestrator review-target vocabulary (the Programmer emits one when it finishes a round):
-- `Review the PR` -- the Author opened a PR.
-- `Review the issue comment` -- the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+Author-to-Orchestrator status vocabulary (the Programmer emits one when it finishes a round, reporting only what it did):
+- `PR opened` -- the Author opened a PR.
+- `No PR; position posted on the issue` -- the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
 
-When the Author emits `Review the issue comment`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
+When the Author emits `No PR; position posted on the issue`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
@@ -157,7 +157,7 @@ Routing on the Verification Agent's signal:
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
 - Dispatch using the dispatch template above, with the Reviewer role assignment statement and the literal issue number token.
-- If the Author emitted `Review the issue comment` (no PR was opened), the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
+- If the Author emitted `No PR; position posted on the issue` (no PR was opened), the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
   The dispatch template's issue token already points the Reviewer there; the Reviewer follows "Reviewing an Author who declined to open a PR" in `pr_participation.md`.
 
 ## Author disagreement
@@ -170,8 +170,8 @@ When the round is running on the no-PR path (the Author declined to open a PR), 
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
-The Author's review-target signal from the prior round decides which fence applies.
-If the Author emitted `Review the issue comment`, there is no diff or CI to run, so follow the no-PR routing fence; if it emitted `Review the PR`, follow the Monitor loop fence.
+The Author's status signal from the prior round decides which fence applies.
+If the Author emitted `No PR; position posted on the issue`, there is no diff or CI to run, so follow the no-PR routing fence; if it emitted `PR opened`, follow the Monitor loop fence.
 
 No-PR routing:
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -110,8 +110,8 @@ When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
 Author-to-Orchestrator status vocabulary (the Programmer emits one when it finishes a round, reporting only what it did):
-- `PR opened` -- the Author opened a PR.
-- `No PR; position posted on the issue` -- the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+- `PR opened`: the Author opened a PR.
+- `No PR; position posted on the issue`: the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
 
 When the Author emits `No PR; position posted on the issue`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -95,7 +95,9 @@ Git branch: {branch name or "None"}
 
 Role assignment statements (copy the applicable line exactly):
 
-- Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR. If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
+- Programmer: "You are a Programmer resolving the linked issue.
+  You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR.
+  If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 
@@ -108,8 +110,8 @@ When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
 Author-to-Orchestrator review-target vocabulary (the Programmer emits one when it finishes a round):
-- `Review the PR` -- a PR exists; review it.
-- `Review the issue comment` -- the Author opened no PR and is requesting a review on its explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+- `Review the PR` -- the Author opened a PR.
+- `Review the issue comment` -- the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
 
 When the Author emits `Review the issue comment`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
@@ -168,13 +170,8 @@ When the round is running on the no-PR path (the Author declined to open a PR), 
 After the Reviewer exits and delivers its decision, the Orchestrator acts as follows.
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
-There are two shapes the round can take, decided by the Author's review-target signal from the prior round:
-
-- **No PR (the Author emitted `Review the issue comment`).**
-  There is no diff, no branch to merge, and no CI to run.
-  Follow the no-PR routing in the first fence below; the Monitor loop in the second fence does not apply.
-- **PR (the Author emitted `Review the PR`).**
-  Skip the no-PR fence and proceed with the Monitor loop in the second fence below.
+The Author's review-target signal from the prior round decides which fence applies.
+If the Author emitted `Review the issue comment`, there is no diff or CI to run, so follow the no-PR routing fence; if it emitted `Review the PR`, follow the Monitor loop fence.
 
 No-PR routing:
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -95,12 +95,11 @@ Git branch: {branch name or "None"}
 
 Role assignment statements (copy the applicable line exactly):
 
-- Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR. If it does *not* exist, create the PR before you exit."
+- Programmer: "You are a Programmer resolving the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and, if it exists, on the PR. If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 
-The Programmer statement's "create the PR before you exit" is the default.
-It does not override the Author's right to decline to open a PR in the three circumstances described under "Declining to open a PR" in `pr_participation.md`.
+The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
 An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `Review the issue comment` (see the Author review-target vocabulary below) instead of creating a PR.
 
 ## Decision-signal templates
@@ -173,15 +172,23 @@ There are two shapes the round can take, decided by the Author's review-target s
 
 - **No PR (the Author emitted `Review the issue comment`).**
   There is no diff, no branch to merge, and no CI to run.
-    if Reviewer requested changes → goto newAuthor
-    if Reviewer gave LGTM:
-      The issue is resolved without a code change, and the Reviewer agreed.
-      Do NOT launch the CI Monitor and do NOT dispatch a Verification Planner; both presuppose a PR.
-      Inform the user that the Author and Reviewer agreed the issue needs no PR, and that the loop is complete.
-      The issue may now be closed by the user (the Orchestrator does not close it).
-      stop
+  Follow the no-PR routing in the first fence below; the Monitor loop in the second fence does not apply.
 - **PR (the Author emitted `Review the PR`).**
-  Proceed with the Monitor loop below.
+  Skip the no-PR fence and proceed with the Monitor loop in the second fence below.
+
+No-PR routing:
+
+```text
+  if Reviewer requested changes → goto newAuthor
+  if Reviewer gave LGTM:
+    The issue is resolved without a code change, and the Reviewer agreed.
+    Do NOT launch the CI Monitor and do NOT dispatch a Verification Planner; both presuppose a PR.
+    Inform the user that the Author and Reviewer agreed the issue needs no PR, and that the loop is complete.
+    The issue may now be closed by the user (the Orchestrator does not close it).
+    stop
+```
+
+PR routing (Monitor loop):
 
 ```text
   if Reviewer requested changes → goto newAuthor

--- a/agents/pr_creation.md
+++ b/agents/pr_creation.md
@@ -1,5 +1,12 @@
 # PR creation
 
+## A PR is not always required
+
+Before creating a PR, confirm one is warranted.
+An Author may legitimately decline to open a PR when addressing the issue needs no code change, when it cannot fix the issue, or when the issue is flawed or should not be acted upon.
+In those cases, follow "Declining to open a PR" in `pr_participation.md` instead of creating a PR.
+The rest of this document applies only once you have decided a PR is the right artifact.
+
 ## One topic per PR
 
 Do not combine unrelated work in a single PR. You may resolve multiple issues with one PR, but *only* if they're both symptoms of the same technical issue.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -19,7 +19,9 @@
   The Orchestrator runs the CI Monitor script after you exit; you do not need to poll.
 - **Do not return before posting your review.** Posting your review is the only valid exit condition. After forming your verdict, call the review-submission tool before stopping.
 
-  Review pattern (this is the PR-path mechanism; when the Author opened no PR, post on the issue instead, per "Reviewing an Author who declined to open a PR" below):
+  Review pattern:
+
+  (This is the PR-path mechanism. If the Author opened no PR, see "Reviewing an Author who declined to open a PR" below.)
 
   ``` no
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
@@ -36,7 +38,7 @@
 
 ### Reviewing an Author who declined to open a PR
 
-Sometimes the Author opens no PR and instead requests a review on an **issue comment** (see "Declining to open a PR" in the Author section).
+Sometimes the Author opens no PR and instead posts its position as an **issue comment** (see "Declining to open a PR" in the Author section).
 The artifact under review is then that issue comment and the Author's stated position, not a diff.
 The Orchestrator will point you at the issue rather than a PR.
 
@@ -46,10 +48,10 @@ Choose among three stances and map each to a verdict:
 
 - **Agree and approve.** You are convinced the Author is right that no PR is warranted (the issue needs no code change, cannot be fixed, or should not be acted upon).
   Say so plainly and emit `LGTM`.
-  An `LGTM` here means the issue is resolved without a code change; there is nothing to merge, and the Orchestrator closes the loop (see `dev_orchestration.md`).
+  An `LGTM` here means the issue is resolved without a code change; there is nothing to merge.
 - **Point out a blocking flaw.** You accept the Author's general direction but find a flaw in its reasoning or in the out-of-repo action it proposed (for example, the suggested setting is wrong, or the answer it gave is incomplete).
   Explain the flaw fully and emit `Changes requested` so the Author revises its issue comment or its proposed action.
-- **Fundamentally disagree.** You believe the Author is wrong and that a code change *is* required (or that the issue is valid and must be acted upon).
+- **Fundamentally disagree.** You believe the Author is wrong, the issue is valid, and a change is required and possible.
   Make the case that code is needed, citing what behavior is missing or broken, and emit `Changes requested`.
   This sends the Author back to either rebut your case in the issue comments or, if convinced, open a PR with the needed code.
 
@@ -70,14 +72,15 @@ In any of the following three circumstances, the Author should *not* open a PR:
 
 1. Addressing the issue does not require a code change.
 2. The Author believes it cannot fix the issue.
-3. The Author believes the issue is flawed, invalid, or otherwise should not be acted upon.
+3. The issue is flawed, invalid, or otherwise should not be acted upon.
 
 When declining to open a PR, the Author must:
 
 - Post a comment on the **issue** (not on a PR, since none exists) that explains its position.
   Begin the comment with the `🤖 Author` attribution line, then state which of the three circumstances applies and the reasoning behind it.
-  If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, a question the issue was really asking), describe that action or give that answer in the comment.
-- Inform the Orchestrator that it is requesting a review on the **issue comment** instead of on a PR, so the Orchestrator dispatches a Reviewer pointed at the issue (see the decision-signal vocabulary in `dev_orchestration.md`).
+  If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, the issue is really asking a question), describe that action or give that answer in the comment.
+- Tell the Orchestrator that it opened no PR and posted its position as an **issue comment** instead, using the review-target vocabulary in `dev_orchestration.md`.
+  The Orchestrator then points a Reviewer at the issue.
 
 This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.
 The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Reviewer section), and the Author still defends its position or revises it across rounds.
@@ -86,9 +89,9 @@ The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Rev
 
 An Author may change its position between rounds, in either direction:
 
-- An Author that opened a PR may, on reflection or after a review, conclude that no code change is warranted (circumstance 1) or that the issue should not be acted upon (circumstance 3).
+- An Author that opened a PR may, after a review, conclude that no code change is warranted or that the issue should not be acted upon.
   In that case it should close its PR and switch to the declining-to-open-a-PR path above, explaining the change on the issue.
-- An Author that declined to open a PR may, after a Reviewer points out a blocking flaw or insists that code is needed, become convinced and switch to authoring a PR.
+- An Author that declined to open a PR may later become convinced and switch to authoring a PR.
   It opens the PR as usual (see `pr_creation.md`), and the review then proceeds against the PR.
 
 Because each round begins by re-reading the issue, the PR (if any), and all comments, an Author is free to adopt whichever position the evidence supports; it is not bound by a position it took in an earlier round.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -19,7 +19,7 @@
   The Orchestrator runs the CI Monitor script after you exit; you do not need to poll.
 - **Do not return before posting your review.** Posting your review is the only valid exit condition. After forming your verdict, call the review-submission tool before stopping.
 
-  Review pattern:
+  Review pattern (this is the PR-path mechanism; when the Author opened no PR, post on the issue instead, per "Reviewing an Author who declined to open a PR" below):
 
   ``` no
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -79,7 +79,7 @@ When declining to open a PR, the Author must:
 - Post a comment on the **issue** (not on a PR, since none exists) that explains its position.
   Begin the comment with the `🤖 Author` attribution line, then state which of the three circumstances applies and the reasoning behind it.
   If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, the issue is really asking a question), describe that action or give that answer in the comment.
-- Tell the Orchestrator that it opened no PR and posted its position as an **issue comment** instead, using the review-target vocabulary in `dev_orchestration.md`.
+- Tell the Orchestrator that it opened no PR and posted its position as an **issue comment** instead, using the status vocabulary in `dev_orchestration.md`.
   The Orchestrator then points a Reviewer at the issue.
 
 This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -34,6 +34,27 @@
   There is no middle option.
   If you want any change made before merge, request changes so the full review cycle continues.
 
+### Reviewing an Author who declined to open a PR
+
+Sometimes the Author opens no PR and instead requests a review on an **issue comment** (see "Declining to open a PR" in the Author section).
+The artifact under review is then that issue comment and the Author's stated position, not a diff.
+The Orchestrator will point you at the issue rather than a PR.
+
+Because there is no PR, post your review as an ordinary comment on the **issue** (begin it with the `🤖 Reviewer` line), not via the PR review tool.
+Your verdict vocabulary is unchanged: `LGTM` or `Changes requested`.
+Choose among three stances and map each to a verdict:
+
+- **Agree and approve.** You are convinced the Author is right that no PR is warranted (the issue needs no code change, cannot be fixed, or should not be acted upon).
+  Say so plainly and emit `LGTM`.
+  An `LGTM` here means the issue is resolved without a code change; there is nothing to merge, and the Orchestrator closes the loop (see `dev_orchestration.md`).
+- **Point out a blocking flaw.** You accept the Author's general direction but find a flaw in its reasoning or in the out-of-repo action it proposed (for example, the suggested setting is wrong, or the answer it gave is incomplete).
+  Explain the flaw fully and emit `Changes requested` so the Author revises its issue comment or its proposed action.
+- **Fundamentally disagree.** You believe the Author is wrong and that a code change *is* required (or that the issue is valid and must be acted upon).
+  Make the case that code is needed, citing what behavior is missing or broken, and emit `Changes requested`.
+  This sends the Author back to either rebut your case in the issue comments or, if convinced, open a PR with the needed code.
+
+As always, do not hold back, and do not make the change yourself; convince the Author.
+
 ## Author / Programmer
 
 Terminology: In most cases, the *Author* is also referred to as *Programmer*. In this document, we use the term *Author* to allow for PRs that don't involve code changes.
@@ -41,6 +62,37 @@ Terminology: In most cases, the *Author* is also referred to as *Programmer*. In
 - An *Author* should consider review comments with a degree of skepticism, and should not instantly or automatically accede to a Reviewer's opinion. If the Author becomes convinced of the need to change the PR, then it should do so. Otherwise, it should enter a debate with the Reviewer.
 - The Author should reply to Reviewer comments to provide justification for refusing a Reviewer's requested changes.
 - When a Reviewer requests a change that is out of scope for the current PR, the Author should decline to make it here, file a new issue to track it, and cite the issue number in their reply to the Reviewer.
+
+### Declining to open a PR
+
+An Author is not obligated to open a PR.
+In any of the following three circumstances, the Author should *not* open a PR:
+
+1. Addressing the issue does not require a code change.
+2. The Author believes it cannot fix the issue.
+3. The Author believes the issue is flawed, invalid, or otherwise should not be acted upon.
+
+When declining to open a PR, the Author must:
+
+- Post a comment on the **issue** (not on a PR, since none exists) that explains its position.
+  Begin the comment with the `🤖 Author` attribution line, then state which of the three circumstances applies and the reasoning behind it.
+  If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, a question the issue was really asking), describe that action or give that answer in the comment.
+- Inform the Orchestrator that it is requesting a review on the **issue comment** instead of on a PR, so the Orchestrator dispatches a Reviewer pointed at the issue (see the decision-signal vocabulary in `dev_orchestration.md`).
+
+This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.
+The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Reviewer section), and the Author still defends its position or revises it across rounds.
+
+### Changing position
+
+An Author may change its position between rounds, in either direction:
+
+- An Author that opened a PR may, on reflection or after a review, conclude that no code change is warranted (circumstance 1) or that the issue should not be acted upon (circumstance 3).
+  In that case it should close its PR and switch to the declining-to-open-a-PR path above, explaining the change on the issue.
+- An Author that declined to open a PR may, after a Reviewer points out a blocking flaw or insists that code is needed, become convinced and switch to authoring a PR.
+  It opens the PR as usual (see `pr_creation.md`), and the review then proceeds against the PR.
+
+Because each round begins by re-reading the issue, the PR (if any), and all comments, an Author is free to adopt whichever position the evidence supports; it is not bound by a position it took in an earlier round.
+The Author should not flip-flop merely to appease the Reviewer: change position only when genuinely convinced (see the skepticism guidance above).
 
 ## Code review cycles should be overseen by an Orchestrator.
 


### PR DESCRIPTION
Fixes #469.

## What changed

The agent process docs now let an Author decline to open a PR and instead request a review on a comment it posts to the issue. The review cycle is otherwise unchanged: a Reviewer still renders `LGTM` or `Changes requested`, and the Orchestrator still routes that verdict.

- `agents/pr_participation.md`
  - Author "Declining to open a PR": the three circumstances, the requirement to explain the position in an issue comment (with the `🤖 Author` attribution line), and the instruction to tell the Orchestrator it is requesting a review on the issue comment.
  - Author "Changing position": an Author may move into or out of the no-PR stance between rounds.
  - Reviewer "Reviewing an Author who declined to open a PR": review the issue comment (not a diff), post the verdict as an ordinary issue comment, and the three Reviewer stances mapped to verdicts.
- `agents/pr_creation.md`: a short note that a PR is not always required, pointing to the decline path.
- `agents/dev_orchestration.md`
  - Author review-target vocabulary: `Review the PR` / `Review the issue comment`.
  - Reviewer assignment pointed at the issue when no PR was opened.
  - A no-PR branch in the post-review loop that, on `LGTM`, skips the CI Monitor and Verification Planner (both presuppose a PR) and closes the loop.
  - A note that the Programmer role statement's "create the PR before you exit" is the default, not an override of the decline path.

## Reasoning and answers to the planning prompts

**What changes to the orchestration steps are needed?**
The orchestration loop was keyed entirely on a PR: Reviewer reviews the PR, then on `LGTM` the Orchestrator runs the CI Monitor and dispatches the Verification Planner. Two things had to change. First, the Orchestrator needs to know which artifact the Reviewer should examine, so I added an Author review-target signal (`Review the PR` / `Review the issue comment`) that the Programmer emits when it finishes a round. Second, the post-review loop needed a no-PR branch: when there is no PR, an `LGTM` means the issue is resolved without code, so the Orchestrator skips CI and verification (there is nothing to merge or verify) and stops, leaving the issue for the user to close. `Changes requested` still routes to a new Author round in both shapes.

**What information should and should not be communicated among the parties?**
I kept the Orchestrator's say-nothing discipline intact. The new Author signal is a fixed control token, like the existing Reviewer vocabulary, so the Orchestrator routes it without reading or judging the Author's explanation. The Author's reasoning lives in the issue comment, which the Reviewer reads directly from GitHub, the same way the Reviewer reads a PR today. The Orchestrator only learns which artifact to point the Reviewer at, not the substance of the Author's position.

**Can an Author change its mind, to or from any of the positions?**
Yes, in either direction, and the existing design already supports it because every round begins by re-reading the issue, the PR (if any), and all comments. An Author that opened a PR may conclude no code is warranted, close the PR, and switch to the no-PR path. An Author that declined may be convinced by a Reviewer that code is needed and open a PR. I added explicit guidance plus a caution against flip-flopping merely to appease the Reviewer, consistent with the existing skepticism guidance.

**For each circumstance, what does each Reviewer action look like?**
The three circumstances (no code needed / cannot fix / issue invalid) all reduce to the same review surface: the Author's stated position in an issue comment. So I defined the Reviewer's three actions once, mapped to the binary verdict:
- Agree and approve: the Reviewer is convinced the Author is right; emits `LGTM`; the issue is resolved without a code change and the loop closes.
- Point out a blocking flaw: the Reviewer accepts the direction but finds a flaw in the reasoning or in the proposed out-of-repo action; emits `Changes requested` so the Author revises the comment or the action.
- Fundamentally disagree (insist code is needed): the Reviewer argues a code change is required, citing the missing or broken behavior; emits `Changes requested`, sending the Author back to either rebut in issue comments or open a PR.

There is deliberately no third verdict: keeping the verdict binary preserves the existing routing and the "slightly competitive between at least two parties" review property.

## Test plan

Documentation-only change to `agents/` markdown; no automated test suite covers these process docs. markdownlint ran clean via the pre-commit hook.

