### PR TITLE
Replace -- placeholder with single-column label-transition tables

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -155,9 +155,9 @@ Routing on the Verification Agent's signal:
   Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
   Apply this transition to the PR only if needed. The `verification needed` label is probably already applied:
 
-  | Remove label | Add label |
-  |---|---|
-  | -- | `verification needed` |
+  | Add label |
+  |---|
+  | `verification needed` |
 
 ## Assigning a Programmer
 
@@ -189,15 +189,15 @@ Monitor output lines are relayed to the user verbatim; this is user-facing statu
 
 When the Reviewer returns, apply this transition to the PR:
 
-| Remove label | Add label |
-|---|---|
-| `changes done` | -- |
+| Remove label |
+|---|
+| `changes done` |
 
 If the Reviewer requested changes, additionally apply this transition to the PR:
 
-| Remove label | Add label |
-|---|---|
-| -- | `changes requested` |
+| Add label |
+|---|
+| `changes requested` |
 
 ```text
   if Reviewer requested changes → goto newAuthor
@@ -223,15 +223,15 @@ If the Reviewer requested changes, additionally apply this transition to the PR:
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
       In that case, apply this transition to **both the issue and the PR**:
 
-      | Remove label | Add label |
-      |---|---|
-      | -- | `verified` |
+      | Add label |
+      |---|
+      | `verified` |
 
       Otherwise, relay the planner's reported before-merging list to the user verbatim, and apply this transition to the PR:
 
-      | Remove label | Add label |
-      |---|---|
-      | -- | `verification needed` |
+      | Add label |
+      |---|
+      | `verification needed` |
 
       Then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items.
       The Verification Agent automates each item where possible and reports results on the tracking issues and PR; it does not consult the user.
@@ -337,6 +337,6 @@ Stop the automated cycle and escalate to the User in these cases:
 
 When you conclude orchestration of a PR (the cycle is complete or you are escalating and stepping out of the Orchestrator role for this PR), apply this transition to **both the issue and the PR**:
 
-| Remove label | Add label |
-|---|---|
-| `orchestrating` | -- |
+| Remove label |
+|---|
+| `orchestrating` |


### PR DESCRIPTION
Fixes #481

Six label-transition tables in `agents/dev_orchestration.md` used `--` in one column to indicate "no action on this side."
Per the owner's comment on the issue, tables with only one action are now reduced to a single-column table showing just that action.

Tables affected:

- "Verification incomplete" -- was `| -- | \`verification needed\` |`, now `| Add label |`
- "Reviewer returns" -- was `| \`changes done\` | -- |`, now `| Remove label |`
- "Reviewer requested changes" -- was `| -- | \`changes requested\` |`, now `| Add label |`
- "Planner empty" -- was `| -- | \`verified\` |`, now `| Add label |`
- "Planner non-empty" -- was `| -- | \`verification needed\` |`, now `| Add label |`
- "Concluding PR orchestration" -- was `| \`orchestrating\` | -- |`, now `| Remove label |`

Two-column tables where both columns have real values are unchanged.
