### PR TITLE
Fix stale label spellings in automation scripts and workflow

### DIFF
--- a/.github/workflows/block-merge-on-blocking-labels.yml
+++ b/.github/workflows/block-merge-on-blocking-labels.yml
@@ -5,8 +5,8 @@ name: Block merge when a blocking label is present
 #
 # Blocking labels:
 #   - verification needed
-#   - change requested
-#   - change done
+#   - changes requested
+#   - changes done
 #   - orchestrating
 #
 # Triggers on the full set of PR events so the check always reflects the
@@ -30,7 +30,7 @@ jobs:
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          BLOCKING_LABELS='["verification needed","change requested","change done","orchestrating"]'
+          BLOCKING_LABELS='["verification needed","changes requested","changes done","orchestrating"]'
           PRESENT=$(echo "$LABELS" | jq --argjson blocking "$BLOCKING_LABELS" \
             '[.[] | ascii_downcase] as $pr | $blocking | map(. as $b | $pr | any(. == $b)) | any')
           if [ "$PRESENT" = "true" ]; then

--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -7,8 +7,8 @@ member of each set is present at any time.
 
 Mutually exclusive sets (fixed):
     [p1, p2, p3]
-    [needs verification, verified]
-    [change requested, change done]
+    [verification needed, verified]
+    [changes requested, changes done]
     [for ai to do, orchestrating]
 
 Mutually exclusive prefix groups (any label sharing a prefix is exclusive):
@@ -42,8 +42,8 @@ import urllib.request
 
 MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
     frozenset({"p1", "p2", "p3"}),
-    frozenset({"needs verification", "verified"}),
-    frozenset({"change requested", "change done"}),
+    frozenset({"verification needed", "verified"}),
+    frozenset({"changes requested", "changes done"}),
     frozenset({"for ai to do", "orchestrating"}),
 ]
 

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -63,26 +63,26 @@ class TestFindConflictingSet(unittest.TestCase):
         self.assertIsNotNone(emxl.find_conflicting_set("P3"))
 
     def test_verification_labels_found(self):
-        result = emxl.find_conflicting_set("needs verification")
+        result = emxl.find_conflicting_set("verification needed")
         self.assertIsNotNone(result)
-        self.assertIn("needs verification", result)
+        self.assertIn("verification needed", result)
         self.assertIn("verified", result)
 
     def test_verified_label_found(self):
         result = emxl.find_conflicting_set("verified")
         self.assertIsNotNone(result)
-        self.assertIn("needs verification", result)
+        self.assertIn("verification needed", result)
 
-    def test_change_requested_found(self):
-        result = emxl.find_conflicting_set("change requested")
+    def test_changes_requested_found(self):
+        result = emxl.find_conflicting_set("changes requested")
         self.assertIsNotNone(result)
-        self.assertIn("change requested", result)
-        self.assertIn("change done", result)
+        self.assertIn("changes requested", result)
+        self.assertIn("changes done", result)
 
-    def test_change_done_found(self):
-        result = emxl.find_conflicting_set("change done")
+    def test_changes_done_found(self):
+        result = emxl.find_conflicting_set("changes done")
         self.assertIsNotNone(result)
-        self.assertIn("change requested", result)
+        self.assertIn("changes requested", result)
 
     def test_for_ai_to_do_found(self):
         result = emxl.find_conflicting_set("for ai to do")
@@ -234,13 +234,13 @@ class TestLabelsToRemove(unittest.TestCase):
         self.assertEqual(result, ["P2"])
 
     def test_non_set_labels_are_not_returned(self):
-        verification_set = frozenset({"needs verification", "verified"})
+        verification_set = frozenset({"verification needed", "verified"})
         result = emxl.labels_to_remove(
             "verified",
-            ["needs verification", "ci", "p1", "bug"],
+            ["verification needed", "ci", "p1", "bug"],
             verification_set,
         )
-        self.assertEqual(result, ["needs verification"])
+        self.assertEqual(result, ["verification needed"])
 
 
 # ---------------------------------------------------------------------------
@@ -311,9 +311,9 @@ class TestRemoveLabels(unittest.TestCase):
             call_paths.append(path)
 
         with patch.object(emxl, "gh_api", side_effect=fake_api):
-            emxl.remove_labels(5, ["needs verification"], "owner/repo", "tok")
+            emxl.remove_labels(5, ["verification needed"], "owner/repo", "tok")
 
-        self.assertTrue(any("needs%20verification" in p for p in call_paths))
+        self.assertTrue(any("verification%20needed" in p for p in call_paths))
 
 
 # ---------------------------------------------------------------------------
@@ -409,23 +409,23 @@ class TestMain(unittest.TestCase):
                 emxl,
                 "gh_api",
                 side_effect=[
-                    self._make_issue_response(["needs verification", "ci"]),
-                    None,  # DELETE needs verification
+                    self._make_issue_response(["verification needed", "ci"]),
+                    None,  # DELETE verification needed
                 ],
             ) as mock_api:
                 result = emxl.main()
 
         self.assertEqual(result, 0)
         delete_call = mock_api.call_args_list[1]
-        self.assertIn("needs%20verification", delete_call[0][0])
+        self.assertIn("verification%20needed", delete_call[0][0])
 
     def test_removes_for_change_set(self):
-        with patch.dict(os.environ, {"ADDED_LABEL": "change done", "ISSUE_NUMBER": "7"}):
+        with patch.dict(os.environ, {"ADDED_LABEL": "changes done", "ISSUE_NUMBER": "7"}):
             with patch.object(
                 emxl,
                 "gh_api",
                 side_effect=[
-                    self._make_issue_response(["change requested", "bug"]),
+                    self._make_issue_response(["changes requested", "bug"]),
                     None,
                 ],
             ) as mock_api:
@@ -433,7 +433,7 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(result, 0)
         delete_call = mock_api.call_args_list[1]
-        self.assertIn("change%20requested", delete_call[0][0])
+        self.assertIn("changes%20requested", delete_call[0][0])
 
     def test_removes_for_ai_workflow_set(self):
         with patch.dict(os.environ, {"ADDED_LABEL": "orchestrating", "ISSUE_NUMBER": "3"}):


### PR DESCRIPTION
Fixes #477

Two automation files drifted from the canonical label spellings established in `agents/dev_orchestration.md`.

## Changes

**`scripts/enforce_mutually_exclusive_labels.py`** and **`.github/workflows/block-merge-on-blocking-labels.yml`** now use the correct label names:

- `needs verification` -> `verification needed`
- `change requested` -> `changes requested`
- `change done` -> `changes done`

**`scripts/test_enforce_mutually_exclusive_labels.py`** updated to match the corrected labels throughout.

All 64 unit tests pass.
