### PR TITLE
Add PR and planner-comment tokens to the Orchestrator dispatch template

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -100,11 +100,11 @@ GitHub repository: {owner-slash-repo or URL}
 Issue: {#xxx or "None"}
 PR: {#xxx or "None"}
 Git branch: {branch name or "None"}
-Verification Planner comment: {#issuecomment-xxx, a comment URL, or "None"}
+Verification Planner comment: {numeric comment id, or "None"}
 ```
 
 Fill the `PR:` token with the PR number whenever a PR already exists for the work item; otherwise use "None".
-Fill the `Verification Planner comment:` token only when dispatching a Verification Agent and the planner's comment id (or URL) is known; otherwise use "None".
+Fill the `Verification Planner comment:` token only when dispatching a Verification Agent and the planner's numeric comment id is known; otherwise use "None".
 Both are literal tokens supplied by the Orchestrator (the PR number, and the comment id the Verification Planner reported); the Orchestrator does not read the PR or the comment to obtain them.
 
 Role assignment statements (copy the applicable line exactly):
@@ -114,7 +114,7 @@ Role assignment statements (copy the applicable line exactly):
   If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
-- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment named above (if none was named, locate it on the PR via its HTML marker) and each before-merging tracking issue it lists."
+- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment supplied in the `Verification Planner comment:` token (if none was supplied, locate it on the PR via its HTML marker) and each before-merging tracking issue it lists."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
 An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -103,10 +103,6 @@ Git branch: {branch name or "None"}
 Verification Planner comment: {numeric comment id, or "None"}
 ```
 
-Fill the `PR:` token with the PR number whenever a PR already exists for the work item; otherwise use "None".
-Fill the `Verification Planner comment:` token only when dispatching a Verification Agent and the planner's numeric comment id is known; otherwise use "None".
-Both are literal tokens supplied by the Orchestrator (the PR number, and the comment id the Verification Planner reported); the Orchestrator does not read the PR or the comment to obtain them.
-
 Role assignment statements (copy the applicable line exactly):
 
 - Programmer: "You are a Programmer resolving the linked issue.
@@ -114,7 +110,7 @@ Role assignment statements (copy the applicable line exactly):
   If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
-- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment supplied in the `Verification Planner comment:` token (if none was supplied, locate it on the PR via its HTML marker) and each before-merging tracking issue it lists."
+- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
 An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.
@@ -258,9 +254,8 @@ PR routing (Monitor loop):
       // Triggered after Reviewer approval AND CI clears (Monitor emits Clear).
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
-      Dispatch a Verification Planner sub-agent using the dispatch template, filling the `PR:` token with this PR's number (its `Verification Planner comment:` token is "None"; the planner posts that comment).
+      Dispatch a Verification Planner sub-agent using the dispatch template.
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
-      Record the id of the verification-plan comment the planner reports, for the Verification Agent dispatch below.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
       In that case, apply this transition to **both the issue and the PR**:
 
@@ -274,7 +269,7 @@ PR routing (Monitor loop):
       |---|
       | `verification needed` |
 
-      Then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items, filling the `PR:` token with this PR's number and the `Verification Planner comment:` token with the planner's reported comment id (so the agent goes straight to the right PR and plan without a discovery search).
+      Then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items.
       The Verification Agent automates each item where possible and reports results on the tracking issues and PR; it does not consult the user.
       Route on the Verification Agent's terminal signal per "Routing on the Verification Agent's signal" above.
       → PR may be merged once every issue the planner filed for its before-merging list is resolved.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -98,8 +98,14 @@ Fill only the tokens in braces; do not add any other words.
 **{Role assignment statement}**
 GitHub repository: {owner-slash-repo or URL}
 Issue: {#xxx or "None"}
+PR: {#xxx or "None"}
 Git branch: {branch name or "None"}
+Verification Planner comment: {#issuecomment-xxx, a comment URL, or "None"}
 ```
+
+Fill the `PR:` token with the PR number whenever a PR already exists for the work item; otherwise use "None".
+Fill the `Verification Planner comment:` token only when dispatching a Verification Agent and the planner's comment id (or URL) is known; otherwise use "None".
+Both are literal tokens supplied by the Orchestrator (the PR number, and the comment id the Verification Planner reported); the Orchestrator does not read the PR or the comment to obtain them.
 
 Role assignment statements (copy the applicable line exactly):
 
@@ -108,7 +114,7 @@ Role assignment statements (copy the applicable line exactly):
   If no PR exists, create one before you exit, unless the issue warrants declining to open a PR (see "Declining to open a PR" in `pr_participation.md`)."
 - Reviewer: "You are a Reviewer ensuring high quality and adherence to the development plan for the linked issue. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
 - Verification planner: "You are a Verification Planner: scan the linked issue and PR for outstanding before-merging requirements and file a tracking issue, linked to the PR, for each one. You *must* start your turn by re-fetching the description and all comments on the issue and on the PR."
-- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
+- Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment named above (if none was named, locate it on the PR via its HTML marker) and each before-merging tracking issue it lists."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
 An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.
@@ -252,8 +258,9 @@ PR routing (Monitor loop):
       // Triggered after Reviewer approval AND CI clears (Monitor emits Clear).
       // Dispatch the verification planner (see verification_planning.md).
       // The Orchestrator does not scan the issue or PR itself.
-      Dispatch a Verification Planner sub-agent using the dispatch template.
+      Dispatch a Verification Planner sub-agent using the dispatch template, filling the `PR:` token with this PR's number (its `Verification Planner comment:` token is "None"; the planner posts that comment).
       The planner assembles the before-merging list and, for each item, files a tracking issue linked to the PR (see verification_planning.md). It does not consult the user.
+      Record the id of the verification-plan comment the planner reports, for the Verification Agent dispatch below.
       If the Planner reports its before-merging list is empty, then this *before-merging requirements* process is complete, and the Orchestrator should exit this step.
       In that case, apply this transition to **both the issue and the PR**:
 
@@ -267,7 +274,7 @@ PR routing (Monitor loop):
       |---|
       | `verification needed` |
 
-      Then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items.
+      Then dispatch a Verification Agent (see pr_verify.md) using the dispatch template to carry out those before-merging items, filling the `PR:` token with this PR's number and the `Verification Planner comment:` token with the planner's reported comment id (so the agent goes straight to the right PR and plan without a discovery search).
       The Verification Agent automates each item where possible and reports results on the tracking issues and PR; it does not consult the user.
       Route on the Verification Agent's terminal signal per "Routing on the Verification Agent's signal" above.
       → PR may be merged once every issue the planner filed for its before-merging list is resolved.

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -12,10 +12,10 @@ You do not communicate with the user mid-run; your only outputs are GitHub comme
 
 You will be given:
 
-- Identification of a pull request (such as a URL, or a PR number for your env's remote repo), supplied as the dispatch template's `PR:` token.
-- (Optional) The location of a Verification Planner report on that PR, supplied as the dispatch template's `Verification Planner comment:` token. This is the bare numeric id of a comment on the above PR (the `{comment_id}` used by the GitHub comments API).
+- Identification of a pull request (such as a URL, or a PR number for your env's remote repo)
+- (Optional) The location of a Verification Planner report on that PR (such as the ID of a comment on the above PR).
 
-Legacy/alternative form: both items may instead arrive combined in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`. This is not the expected token-based form; if you receive it, parse the PR number and comment ID out of the URL rather than treating the whole string as either token.
+Note: Both items may be provided in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`
 
 Start by fetching:
 

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -12,8 +12,8 @@ You do not communicate with the user mid-run; your only outputs are GitHub comme
 
 You will be given:
 
-- Identification of a pull request (such as a URL, or a PR number for your env's remote repo)
-- (Optional) The location of a Verification Planner report on that PR (such as the ID of a comment on the above PR).
+- Identification of a pull request (such as a URL, or a PR number for your env's remote repo), supplied as the dispatch template's `PR:` token.
+- (Optional) The location of a Verification Planner report on that PR (such as the ID of a comment on the above PR), supplied as the dispatch template's `Verification Planner comment:` token.
 
 Note: Both items may be provided in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`
 

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -13,9 +13,9 @@ You do not communicate with the user mid-run; your only outputs are GitHub comme
 You will be given:
 
 - Identification of a pull request (such as a URL, or a PR number for your env's remote repo), supplied as the dispatch template's `PR:` token.
-- (Optional) The location of a Verification Planner report on that PR (such as the ID of a comment on the above PR), supplied as the dispatch template's `Verification Planner comment:` token.
+- (Optional) The location of a Verification Planner report on that PR, supplied as the dispatch template's `Verification Planner comment:` token. This is the bare numeric id of a comment on the above PR (the `{comment_id}` used by the GitHub comments API).
 
-Note: Both items may be provided in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`
+Legacy/alternative form: both items may instead arrive combined in a single URL of the form `https://github.com/{owner}/{repo name}/pull/{PR number}#{comment type}-{comment ID}`. This is not the expected token-based form; if you receive it, parse the PR number and comment ID out of the URL rather than treating the whole string as either token.
 
 Start by fetching:
 

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -96,8 +96,9 @@ Only the before-merging list controls the merge gate.
    To replace it, use the GitHub REST API to edit the existing comment body:
    `curl -sX PATCH -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id} -d '{"body": "..."}'`,
    where `{comment_id}` is the id of the existing verification-plan comment, and `{body}` is the markdown that will completely replace the existing body.
-7. Report both lists to the Orchestrator and exit.
-   When the *before merging* list is non-empty, also report the numeric id of the verification-plan comment you posted (or replaced) in step 6 (the bare numeric id used as `{comment_id}` in step 6, not a URL or `#issuecomment-` fragment), so the Orchestrator can hand it to the Verification Agent as a literal token rather than making the agent rediscover it.
+7. Report the following to the Orchestrator and exit:
+    a. the comment ID of the comment you just posted or updated
+    b. both lists
    The PR may be merged once every item on the *before merging* list is resolved.
    Follow-on issues do not gate the merge.
 

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -97,7 +97,7 @@ Only the before-merging list controls the merge gate.
    `curl -sX PATCH -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id} -d '{"body": "..."}'`,
    where `{comment_id}` is the id of the existing verification-plan comment, and `{body}` is the markdown that will completely replace the existing body.
 7. Report both lists to the Orchestrator and exit.
-   When the *before merging* list is non-empty, also report the id of the verification-plan comment you posted (or replaced) in step 6, so the Orchestrator can hand it to the Verification Agent as a literal token rather than making the agent rediscover it.
+   When the *before merging* list is non-empty, also report the numeric id of the verification-plan comment you posted (or replaced) in step 6 (the bare numeric id used as `{comment_id}` in step 6, not a URL or `#issuecomment-` fragment), so the Orchestrator can hand it to the Verification Agent as a literal token rather than making the agent rediscover it.
    The PR may be merged once every item on the *before merging* list is resolved.
    Follow-on issues do not gate the merge.
 

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -97,10 +97,8 @@ Only the before-merging list controls the merge gate.
    `curl -sX PATCH -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id} -d '{"body": "..."}'`,
    where `{comment_id}` is the id of the existing verification-plan comment, and `{body}` is the markdown that will completely replace the existing body.
 7. Report the following to the Orchestrator and exit:
-    a. the comment ID of the comment you just posted or updated
-    b. both lists
-   The PR may be merged once every item on the *before merging* list is resolved.
-   Follow-on issues do not gate the merge.
+    - the comment ID of the comment you just posted or updated
+    - both lists
 
 ## Boundaries
 

--- a/agents/verification_planning.md
+++ b/agents/verification_planning.md
@@ -97,6 +97,7 @@ Only the before-merging list controls the merge gate.
    `curl -sX PATCH -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id} -d '{"body": "..."}'`,
    where `{comment_id}` is the id of the existing verification-plan comment, and `{body}` is the markdown that will completely replace the existing body.
 7. Report both lists to the Orchestrator and exit.
+   When the *before merging* list is non-empty, also report the id of the verification-plan comment you posted (or replaced) in step 6, so the Orchestrator can hand it to the Verification Agent as a literal token rather than making the agent rediscover it.
    The PR may be merged once every item on the *before merging* list is resolved.
    Follow-on issues do not gate the merge.
 


### PR DESCRIPTION
Fixes #476.

## Problem

The Orchestrator dispatch template in `agents/dev_orchestration.md` carried only Role, repo, `Issue:`, and `Git branch:` tokens.
A dispatched Verification Agent is directed (via the Verification agent role statement and `pr_verify.md`) to re-fetch the Verification Planner comment on the PR, but the template supplied only an issue number, so the agent had to discover the PR and the planner comment itself.
The `gb4pc-verification-plan` marker fallback in `pr_verify.md` made this work, but only after an extra discovery search.

## Change

- Add a `PR:` token and a `Verification Planner comment:` token to the dispatch template, with guidance on when each is filled. Both are literals the Orchestrator already holds (the PR number, and the comment id the planner reports), so adding them does not require the Orchestrator to read the PR or the comment.
- The Verification-Planner dispatch step now fills the `PR:` token and records the planner's reported verification-plan comment id.
- The Verification-Agent dispatch step now fills both the `PR:` token and the `Verification Planner comment:` token, so the agent goes straight to the right PR and plan without a discovery search.
- `verification_planning.md` step 7 now has the planner report the verification-plan comment id (when the before-merging list is non-empty) so the Orchestrator can pass it as a literal token.
- `pr_verify.md` entry point notes that its PR identifier and optional planner-comment location come from these template tokens; the marker fallback remains for when no comment id is supplied.

Documentation-only change to the `agents/` process docs; no code or tests are affected.

