### PR TITLE
Add automated coverage for the detect-launch-retry notification path

### DIFF
--- a/scripts/test_detect_launch_retry.sh
+++ b/scripts/test_detect_launch_retry.sh
@@ -27,11 +27,23 @@
 #   (j) Comment body has real newlines and an intact code fence (Bug 1)
 #   (k) Logcat with quotes, backslashes, tabs -> valid, correctly escaped JSON (Bug 2)
 #   (l) No GITHUB_RUN_ID -> shorter comment body, still valid JSON
-#   (m) GITHUB_ACTIONS unset -> no curl is invoked at all
+#   (m) GITHUB_ACTIONS cleared -> no curl is invoked at all
 #
 # Always exits 0 on success, non-zero on failure.
 
 set -uo pipefail
+
+# Isolate the whole suite from the ambient environment. A real GitHub Actions
+# runner always exports GITHUB_ACTIONS=true and GITHUB_REPOSITORY (and may export
+# a GITHUB_TOKEN), and this suite runs in that very environment via the
+# `for test_script in scripts/test_*.sh` sweep in .github/workflows/build.yml.
+# Clearing these here means the detection tests (a)-(g) never reach the
+# issue-filing path, and every test asserts the script's GITHUB_ACTIONS-gated
+# behavior on its own terms rather than by accident of what CI happens to set.
+# The notification tests (h)-(l) set the variables they need explicitly in
+# run_notify, and (m) clears them again for its own invocation, so this global
+# reset does not weaken any of them.
+unset GITHUB_ACTIONS GITHUB_TOKEN GITHUB_REPOSITORY
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DETECT="$SCRIPT_DIR/detect_launch_retry.sh"
@@ -291,21 +303,29 @@ else
   fail "comment body unexpectedly mentions a run when no run id is set: $BODY"
 fi
 
-# ── (m) GITHUB_ACTIONS unset -> no curl is invoked at all ─────────────────────
+# ── (m) GITHUB_ACTIONS cleared -> no curl is invoked at all ───────────────────
 echo ""
-echo "=== (m) GITHUB_ACTIONS unset -> no curl is invoked ==="
+echo "=== (m) GITHUB_ACTIONS cleared -> no curl is invoked ==="
 : > "$CURL_LOG"
 rm -f "$POST_BODY_FILE"
-# Run with the fake curl on PATH but without GITHUB_ACTIONS: the gated block
-# must not execute, so the fake curl must never be touched.
-PATH="$FAKE_BIN:$PATH" CURL_LOG="$CURL_LOG" POST_BODY_FILE="$POST_BODY_FILE" \
+# Run with the fake curl on PATH but with the GITHUB_ACTIONS gate cleared: the
+# gated block must not execute, so the fake curl must never be touched. We use
+# `env -u` to actively remove GITHUB_ACTIONS (and the token/repo it implies) from
+# the child's environment rather than merely omitting them from a prefix
+# assignment. A prefix assignment leaves inherited variables in place, so on a
+# real GitHub Actions runner (which always exports GITHUB_ACTIONS=true and
+# GITHUB_REPOSITORY) they would otherwise leak in and the gate would fire. This
+# asserts the actual GITHUB_ACTIONS-gated behavior regardless of the ambient CI
+# environment.
+env -u GITHUB_ACTIONS -u GITHUB_TOKEN -u GITHUB_REPOSITORY \
+  PATH="$FAKE_BIN:$PATH" CURL_LOG="$CURL_LOG" POST_BODY_FILE="$POST_BODY_FILE" \
   bash "$DETECT" "$TMP/h.txt" > /dev/null 2>&1
 RC=$?
-if [[ "$RC" -eq 10 ]]; then pass "detection still exits 10 with GITHUB_ACTIONS unset"; else fail "expected exit 10, got $RC"; fi
+if [[ "$RC" -eq 10 ]]; then pass "detection still exits 10 with GITHUB_ACTIONS cleared"; else fail "expected exit 10, got $RC"; fi
 if [[ -s "$CURL_LOG" ]]; then
-  fail "curl was invoked even though GITHUB_ACTIONS was unset: $(cat "$CURL_LOG")"
+  fail "curl was invoked even though GITHUB_ACTIONS was cleared: $(cat "$CURL_LOG")"
 else
-  pass "no curl invoked when GITHUB_ACTIONS is unset"
+  pass "no curl invoked when GITHUB_ACTIONS is cleared"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/test_detect_launch_retry.sh
+++ b/scripts/test_detect_launch_retry.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 # test_detect_launch_retry.sh -- Shell-based tests for detect_launch_retry.sh.
 #
-# Tests run without GITHUB_ACTIONS=true, so no issue-filing or ::warning output
-# is triggered. These tests cover only the detection and exit-code behavior.
+# The detection/exit-code tests (a)-(g) run without GITHUB_ACTIONS=true, so the
+# issue-filing and ::warning path is not exercised by them.
+#
+# The notification tests (h)-(m) DO exercise that GITHUB_ACTIONS-gated path. They
+# run the script with GITHUB_ACTIONS=true but with a fake `curl` on PATH instead
+# of the real one, so no live GitHub token or network is needed. The fake curl
+# serves a canned issue-state response for the GET, records the PATCH (reopen),
+# and captures the POST request body so the test can assert on the comment JSON.
+# This gives end-to-end coverage of the reopen-if-closed branch and the
+# comment-body construction (issue #463), the exact path where the two review
+# bugs lived (Bug 1: backslash-n not rendering as newlines; Bug 2: raw logcat
+# interpolated into JSON without escaping).
 #
 # Covers:
 #   (a) Attempt-1-only logcat (the steady state across 26+ runs) -> no signal, exit 0
@@ -12,6 +22,12 @@
 #   (e) A "first-launch teardown race" Log.w -> signal, exit 10
 #   (f) Reads from stdin when no path argument is given
 #   (g) "attempt 1/3" and "overlay active on attempt 1" alone never match
+#   (h) Closed issue -> reopen PATCH {"state":"open"} is sent, then a comment POST
+#   (i) Open issue -> no reopen PATCH, comment POST still sent
+#   (j) Comment body has real newlines and an intact code fence (Bug 1)
+#   (k) Logcat with quotes, backslashes, tabs -> valid, correctly escaped JSON (Bug 2)
+#   (l) No GITHUB_RUN_ID -> shorter comment body, still valid JSON
+#   (m) GITHUB_ACTIONS unset -> no curl is invoked at all
 #
 # Always exits 0 on success, non-zero on failure.
 
@@ -34,6 +50,68 @@ run_file() {
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+
+# ── Fake curl, used by the notification tests (h)-(m) ─────────────────────────
+# Stands in for the real curl on PATH. It distinguishes the three calls the
+# script makes by their method/URL:
+#   - GET  issues/364           -> prints a canned issue JSON whose "state" is
+#                                  taken from $FAKE_ISSUE_STATE (default "open").
+#   - PATCH issues/364          -> appends "PATCH <url>" and the -d body to
+#                                  $CURL_LOG (this is the reopen call).
+#   - POST issues/364/comments  -> appends "POST <url>" to $CURL_LOG and writes
+#                                  the -d body (the comment JSON) to $POST_BODY_FILE.
+# It always succeeds so the script's `curl -fsSL` calls do not trip set -e.
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/curl" <<'FAKE'
+#!/usr/bin/env bash
+method="GET"; data=""; url=""; prev=""
+for a in "$@"; do
+  case "$prev" in
+    -X) method="$a" ;;
+    -d) data="$a" ;;
+  esac
+  case "$a" in
+    https://*) url="$a" ;;
+  esac
+  prev="$a"
+done
+if [[ "$method" == "PATCH" ]]; then
+  { echo "PATCH $url"; echo "$data"; } >> "$CURL_LOG"
+  exit 0
+fi
+if [[ "$method" == "POST" ]]; then
+  echo "POST $url" >> "$CURL_LOG"
+  printf '%s' "$data" > "$POST_BODY_FILE"
+  exit 0
+fi
+echo "GET $url" >> "$CURL_LOG"
+printf '{"number":364,"state":"%s","title":"watch item"}' "${FAKE_ISSUE_STATE:-open}"
+exit 0
+FAKE
+chmod +x "$FAKE_BIN/curl"
+
+# Run DETECT against the live notification path with the fake curl on PATH.
+# Args: <logcat-file> <issue-state: open|closed> [run-id]
+# Resets the curl log and post-body file, sets RC to the script's exit code, and
+# leaves $CURL_LOG / $POST_BODY_FILE for the caller to inspect.
+CURL_LOG="$TMP/curl.log"
+POST_BODY_FILE="$TMP/post-body.json"
+run_notify() {
+  : > "$CURL_LOG"
+  rm -f "$POST_BODY_FILE"
+  local logcat="$1" state="$2" run_id="${3:-}"
+  PATH="$FAKE_BIN:$PATH" \
+    CURL_LOG="$CURL_LOG" POST_BODY_FILE="$POST_BODY_FILE" \
+    GITHUB_ACTIONS=true \
+    GITHUB_TOKEN=fake-token \
+    GITHUB_REPOSITORY=aunger/gallery-button-for-pixel-camera \
+    GITHUB_SERVER_URL=https://github.com \
+    GITHUB_RUN_ID="$run_id" \
+    FAKE_ISSUE_STATE="$state" \
+    bash "$DETECT" "$logcat" > /dev/null 2>&1
+  RC=$?
+}
 
 # ── (a) Attempt-1-only logcat -> no signal, exit 0 ───────────────────────────
 echo ""
@@ -104,6 +182,131 @@ OUT="$(printf '%s\n%s\n' \
   'GB4PC_E2E: launchPixelCamera: overlay active on attempt 1' | bash "$DETECT" 2>&1)"
 RC=$?
 if [[ "$RC" -eq 0 ]]; then pass "attempt 1 lines do not trigger"; else fail "expected exit 0, got $RC out='$OUT'"; fi
+
+# ── (h) closed issue -> reopen PATCH is sent, then a comment POST ─────────────
+echo ""
+echo "=== (h) closed issue -> reopen PATCH then comment POST ==="
+printf '%s\n' '07:29:05.000  GB4PC_E2E: launchPixelCamera: am start attempt 2/3' > "$TMP/h.txt"
+run_notify "$TMP/h.txt" closed 12345
+if [[ "$RC" -eq 10 ]]; then pass "notification path exits 10"; else fail "expected exit 10, got $RC"; fi
+if grep -q '^PATCH .*/issues/364$' "$CURL_LOG"; then
+  pass "reopen PATCH sent for closed issue"
+else
+  fail "expected a PATCH to issues/364, log was: $(cat "$CURL_LOG")"
+fi
+if grep -qF '{"state":"open"}' "$CURL_LOG"; then
+  pass "reopen PATCH body is {\"state\":\"open\"}"
+else
+  fail "expected reopen body {\"state\":\"open\"}, log was: $(cat "$CURL_LOG")"
+fi
+if grep -q '^POST .*/issues/364/comments$' "$CURL_LOG"; then
+  pass "comment POST sent"
+else
+  fail "expected a POST to issues/364/comments, log was: $(cat "$CURL_LOG")"
+fi
+
+# ── (i) open issue -> no reopen PATCH, comment POST still sent ─────────────────
+echo ""
+echo "=== (i) open issue -> no reopen PATCH, comment POST still sent ==="
+run_notify "$TMP/h.txt" open 12345
+if grep -q '^PATCH ' "$CURL_LOG"; then
+  fail "unexpected PATCH for an already-open issue: $(cat "$CURL_LOG")"
+else
+  pass "no reopen PATCH when issue already open"
+fi
+if grep -q '^POST .*/issues/364/comments$' "$CURL_LOG"; then
+  pass "comment POST still sent when issue already open"
+else
+  fail "expected a comment POST, log was: $(cat "$CURL_LOG")"
+fi
+
+# ── (j) comment body has real newlines and an intact code fence (Bug 1) ───────
+echo ""
+echo "=== (j) comment body has real newlines and an intact code fence (Bug 1) ==="
+run_notify "$TMP/h.txt" open 12345
+# jq -r '.body' fails outright if the JSON is malformed, so a successful parse
+# is itself part of the assertion.
+BODY="$(jq -r '.body' "$POST_BODY_FILE" 2>/dev/null)"
+PARSE_RC=$?
+if [[ "$PARSE_RC" -ne 0 ]]; then
+  fail "comment JSON did not parse: $(cat "$POST_BODY_FILE")"
+elif [[ "$(printf '%s' "$BODY" | wc -l)" -ge 3 ]]; then
+  pass "comment body contains real newlines (multi-line)"
+else
+  fail "comment body has no real line breaks (Bug 1 regression): $BODY"
+fi
+# The code fence must be on its own lines: a literal backslash-n would have left
+# the fence glued to surrounding text on a single line.
+FENCE='```'
+if printf '%s\n' "$BODY" | grep -qx "$FENCE"; then
+  pass "code fence appears on its own line"
+else
+  fail "code fence is not on its own line (Bug 1 regression): $BODY"
+fi
+if ! printf '%s' "$BODY" | grep -q '\\n'; then
+  pass "comment body contains no literal backslash-n"
+else
+  fail "comment body contains literal backslash-n (Bug 1 regression): $BODY"
+fi
+# The run link is rendered with the run id and URL.
+if printf '%s' "$BODY" | grep -qF '[run 12345](https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/12345)'; then
+  pass "comment body links to the triggering run"
+else
+  fail "comment body is missing the run link: $BODY"
+fi
+
+# ── (k) logcat with quotes, backslashes, tabs -> valid, escaped JSON (Bug 2) ──
+echo ""
+echo "=== (k) logcat with quotes/backslashes/tabs -> valid escaped JSON (Bug 2) ==="
+# A logcat line carrying every character class that broke the old hand-rolled
+# JSON: a double quote, a backslash, and a literal tab.
+printf '%s\n' 'GB4PC_E2E: am start attempt 2/3 "quoted" back\slash	tabbed' > "$TMP/k.txt"
+run_notify "$TMP/k.txt" open 12345
+if jq -e . "$POST_BODY_FILE" > /dev/null 2>&1; then
+  pass "comment JSON is well-formed despite quotes/backslashes/tabs"
+else
+  fail "comment JSON is malformed (Bug 2 regression): $(cat "$POST_BODY_FILE")"
+fi
+# The raw logcat must round-trip through the JSON unchanged.
+BODY="$(jq -r '.body' "$POST_BODY_FILE" 2>/dev/null)"
+if printf '%s' "$BODY" | grep -qF 'am start attempt 2/3 "quoted" back\slash	tabbed'; then
+  pass "logcat with special characters round-trips through the JSON intact"
+else
+  fail "logcat content was corrupted in the JSON body: $BODY"
+fi
+
+# ── (l) no GITHUB_RUN_ID -> shorter comment body, still valid JSON ────────────
+echo ""
+echo "=== (l) no GITHUB_RUN_ID -> shorter comment body, still valid JSON ==="
+run_notify "$TMP/h.txt" open ""
+if jq -e . "$POST_BODY_FILE" > /dev/null 2>&1; then
+  pass "comment JSON is well-formed without a run id"
+else
+  fail "comment JSON is malformed without a run id: $(cat "$POST_BODY_FILE")"
+fi
+BODY="$(jq -r '.body' "$POST_BODY_FILE" 2>/dev/null)"
+if ! printf '%s' "$BODY" | grep -q 'run'; then
+  pass "comment body omits the run link when no run id is set"
+else
+  fail "comment body unexpectedly mentions a run when no run id is set: $BODY"
+fi
+
+# ── (m) GITHUB_ACTIONS unset -> no curl is invoked at all ─────────────────────
+echo ""
+echo "=== (m) GITHUB_ACTIONS unset -> no curl is invoked ==="
+: > "$CURL_LOG"
+rm -f "$POST_BODY_FILE"
+# Run with the fake curl on PATH but without GITHUB_ACTIONS: the gated block
+# must not execute, so the fake curl must never be touched.
+PATH="$FAKE_BIN:$PATH" CURL_LOG="$CURL_LOG" POST_BODY_FILE="$POST_BODY_FILE" \
+  bash "$DETECT" "$TMP/h.txt" > /dev/null 2>&1
+RC=$?
+if [[ "$RC" -eq 10 ]]; then pass "detection still exits 10 with GITHUB_ACTIONS unset"; else fail "expected exit 10, got $RC"; fi
+if [[ -s "$CURL_LOG" ]]; then
+  fail "curl was invoked even though GITHUB_ACTIONS was unset: $(cat "$CURL_LOG")"
+else
+  pass "no curl invoked when GITHUB_ACTIONS is unset"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Fixes #463.

## Background

Issue #463 (from PR #447) asks to verify, or add automated coverage for, the live notification path of `scripts/detect_launch_retry.sh` end-to-end.
That path (reopen issue #364 if closed, then POST a comment with the matching logcat lines and a link to the triggering run) is gated on `GITHUB_ACTIONS=true` plus a live `GITHUB_TOKEN`, and was not exercised by any test.
Both correctness bugs found during PR #447 review lived entirely in this untested path and were fixed by inspection only:

- Bug 1: a backslash-n in a double-quoted bash string is not a newline, so the comment body and its markdown code fence would not render.
- Bug 2: raw `$MATCHES` was interpolated into a JSON literal without escaping, so logcat text with quotes, backslashes, tabs, or newlines would produce malformed JSON.

## Approach

This PR takes the "add automated coverage" option, which is stronger than a one-off manual API call: it is deterministic, requires no live token, and guards against regression on every build.

New notification tests (h)-(m) in `scripts/test_detect_launch_retry.sh` run the script with `GITHUB_ACTIONS=true` but with a fake `curl` on `PATH`.
The fake curl serves a canned issue-state response for the GET, records the reopen PATCH, and captures the comment POST body so the test can assert on the exact JSON the script would send to GitHub.

The tests assert end-to-end that:

- a closed issue gets a reopen PATCH `{"state":"open"}` followed by a comment POST, while an already-open issue gets only the comment POST;
- the comment body has real newlines and an intact code fence, with no literal backslash-n (covers Bug 1);
- logcat containing quotes, backslashes, and tabs yields well-formed JSON that round-trips the content intact (covers Bug 2);
- the no-run-id branch still produces valid JSON;
- nothing calls curl when `GITHUB_ACTIONS` is unset.

No production code is changed; only the test file.

## Validation

- `bash scripts/test_detect_launch_retry.sh`: 23 passed, 0 failed.
- Confirmed the new tests have teeth by temporarily reintroducing each original bug:
  - reintroducing Bug 1 (literal backslash-n) -> 8 failures;
  - reintroducing Bug 2 (raw interpolation into JSON) -> 6 failures;
  - script restored -> 23/23 pass.
- The test is auto-discovered by the existing `test_*.sh` CI sweep, so it runs on every build without any workflow change.

🦀
