### PR TITLE
Validate automation-required labels exist in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   # Gate for PRs and merges: compiles, runs unit tests, then E2E tests on an emulator.
@@ -117,6 +118,9 @@ jobs:
 
       - name: Run Python script unit tests
         if: steps.diff_check.outputs.needs_full_build == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 -m unittest discover -s scripts -p "test_*.py" -v
 
       - name: Run shell script unit tests

--- a/scripts/archive_stale_test_failures.py
+++ b/scripts/archive_stale_test_failures.py
@@ -35,6 +35,14 @@ import urllib.error
 
 
 # ---------------------------------------------------------------------------
+# Label name constants
+# ---------------------------------------------------------------------------
+
+LABEL_TEST_FAILURE: str = "test-failure"
+LABEL_TEST_FAILURE_ARCHIVE: str = "test-failure-archive"
+
+
+# ---------------------------------------------------------------------------
 # GitHub API helper
 # ---------------------------------------------------------------------------
 
@@ -74,7 +82,7 @@ def fetch_stale_issues(repo: str, token: str, cutoff: datetime.datetime) -> list
     page = 1
     while True:
         batch = gh_api(
-            f"repos/{repo}/issues?labels=test-failure&per_page=100&page={page}",
+            f"repos/{repo}/issues?labels={LABEL_TEST_FAILURE}&per_page=100&page={page}",
             token=token,
         )
         if not batch:
@@ -93,8 +101,10 @@ def fetch_stale_issues(repo: str, token: str, cutoff: datetime.datetime) -> list
 def archive_issue(issue: dict, repo: str, token: str) -> None:
     """Swap labels on *issue*: remove test-failure, add test-failure-archive."""
     n = issue["number"]
-    current_labels = [label["name"] for label in issue["labels"] if label["name"] != "test-failure"]
-    current_labels.append("test-failure-archive")
+    current_labels = [
+        label["name"] for label in issue["labels"] if label["name"] != LABEL_TEST_FAILURE
+    ]
+    current_labels.append(LABEL_TEST_FAILURE_ARCHIVE)
     gh_api(
         f"repos/{repo}/issues/{n}",
         token=token,

--- a/scripts/test_label_existence_integration.py
+++ b/scripts/test_label_existence_integration.py
@@ -12,44 +12,42 @@ automation (as happened with the stale spellings in issue #477).
 Sources:
   scripts/enforce_mutually_exclusive_labels.py -- MUTUALLY_EXCLUSIVE_SETS
   scripts/file_test_failure_issues.py          -- LABELS constant
-  scripts/archive_stale_test_failures.py       -- label swap (test-failure-archive)
-  .github/workflows/block-merge-on-blocking-labels.yml -- BLOCKING_LABELS
-  .github/workflows/remove-verified-on-push.yml -- 'verified' label
+  scripts/archive_stale_test_failures.py       -- LABEL_TEST_FAILURE_ARCHIVE constant
 """
 
 import json
 import os
+import sys
 import unittest
 import urllib.error
 import urllib.request
 
+# Scripts live in the same directory as this file; make them importable.
+sys.path.insert(0, os.path.dirname(__file__))
+
+from archive_stale_test_failures import LABEL_TEST_FAILURE_ARCHIVE  # noqa: E402
+from enforce_mutually_exclusive_labels import MUTUALLY_EXCLUSIVE_SETS  # noqa: E402
+from file_test_failure_issues import LABELS as _TEST_FAILURE_LABELS  # noqa: E402
+
 # ---------------------------------------------------------------------------
-# Labels that must exist in the GitHub repository.
-# All names are lowercase; existence checks are case-insensitive because the
-# enforcement automation lowercases label names before comparing them.
-# Add here whenever a new label name is hardcoded into automation.
+# Derive the set of required labels from their authoritative sources.
+# When a new label is added to automation, updating the source constant
+# (or MUTUALLY_EXCLUSIVE_SETS) is sufficient; this test picks it up
+# automatically.
 # ---------------------------------------------------------------------------
 
-REQUIRED_LABELS: frozenset[str] = frozenset(
-    {
-        # Mutually exclusive priority set (enforce_mutually_exclusive_labels.py)
-        "p1",
-        "p2",
-        "p3",
-        # Mutually exclusive verification set
-        "verification needed",
-        "verified",
-        # Mutually exclusive changes set
-        "changes requested",
-        "changes done",
-        # Mutually exclusive AI workflow set
-        "for ai to do",
-        "orchestrating",
-        # Test-failure lifecycle (file_test_failure_issues.py,
-        # archive_stale_test_failures.py)
-        "test-failure",
-        "test-failure-archive",
-    }
+REQUIRED_LABELS: frozenset[str] = (
+    # All labels in every mutually-exclusive set defined in
+    # enforce_mutually_exclusive_labels.py.
+    frozenset().union(*MUTUALLY_EXCLUSIVE_SETS)
+    # Label(s) applied to new test-failure issues.
+    | frozenset(_TEST_FAILURE_LABELS)
+    # Label swapped in when a test-failure issue goes stale.
+    | frozenset({LABEL_TEST_FAILURE_ARCHIVE})
+    # Note: the labels referenced in block-merge-on-blocking-labels.yml
+    # (verification needed, changes requested, changes done, orchestrating)
+    # and remove-verified-on-push.yml (verified) are all already members of
+    # MUTUALLY_EXCLUSIVE_SETS, so no additional entries are needed here.
 )
 
 

--- a/scripts/test_label_existence_integration.py
+++ b/scripts/test_label_existence_integration.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Integration test: verify that automation-required GitHub labels exist in the repo.
+
+This test calls the real GitHub API and is skipped when GITHUB_TOKEN or
+GITHUB_REPOSITORY is not set.
+
+Labels checked here are exactly those that this repo's GitHub Actions and
+scripts apply or enforce by name.
+These are the labels whose absence would cause silent misbehavior in the
+automation (as happened with the stale spellings in issue #477).
+
+Sources:
+  scripts/enforce_mutually_exclusive_labels.py -- MUTUALLY_EXCLUSIVE_SETS
+  scripts/file_test_failure_issues.py          -- LABELS constant
+  scripts/archive_stale_test_failures.py       -- label swap (test-failure-archive)
+  .github/workflows/block-merge-on-blocking-labels.yml -- BLOCKING_LABELS
+  .github/workflows/remove-verified-on-push.yml -- 'verified' label
+"""
+
+import json
+import os
+import unittest
+import urllib.error
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Labels that must exist in the GitHub repository.
+# All names are lowercase; existence checks are case-insensitive because the
+# enforcement automation lowercases label names before comparing them.
+# Add here whenever a new label name is hardcoded into automation.
+# ---------------------------------------------------------------------------
+
+REQUIRED_LABELS: frozenset[str] = frozenset(
+    {
+        # Mutually exclusive priority set (enforce_mutually_exclusive_labels.py)
+        "p1",
+        "p2",
+        "p3",
+        # Mutually exclusive verification set
+        "verification needed",
+        "verified",
+        # Mutually exclusive changes set
+        "changes requested",
+        "changes done",
+        # Mutually exclusive AI workflow set
+        "for ai to do",
+        "orchestrating",
+        # Test-failure lifecycle (file_test_failure_issues.py,
+        # archive_stale_test_failures.py)
+        "test-failure",
+        "test-failure-archive",
+    }
+)
+
+
+def _fetch_repo_label_names(token: str, repo: str) -> set[str]:
+    """Return the set of all lowercased label names that exist in *repo*.
+
+    Label names are lowercased so callers can compare case-insensitively,
+    matching how the enforcement automation works.
+
+    Fetches up to 10 pages of 100 labels each (1 000 labels total), which
+    is far more than any real repo needs.
+    Raises urllib.error.HTTPError / urllib.error.URLError on network failure.
+    """
+    names: set[str] = set()
+    for page in range(1, 11):
+        url = f"https://api.github.com/repos/{repo}/labels?per_page=100&page={page}"
+        req = urllib.request.Request(url)
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        # URL is built from the GitHub API constant; the file:// risk does not apply.
+        with urllib.request.urlopen(req) as resp:  # nosemgrep
+            batch = json.loads(resp.read())
+        if not batch:
+            break
+        for label in batch:
+            names.add(label["name"].lower())
+        if len(batch) < 100:
+            # Last page.
+            break
+    return names
+
+
+class TestRequiredLabelsExist(unittest.TestCase):
+    """Integration tests that hit the real GitHub API."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.token = os.environ.get("GITHUB_TOKEN", "")
+        cls.repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+        if not cls.token or not cls.repo:
+            raise unittest.SkipTest(
+                "GITHUB_TOKEN and GITHUB_REPOSITORY must both be set to run label"
+                " existence integration tests."
+            )
+
+        cls.repo_labels = _fetch_repo_label_names(cls.token, cls.repo)
+
+    def test_all_required_labels_exist(self) -> None:
+        """Every label that automation depends on must exist in the repository."""
+        missing = sorted(REQUIRED_LABELS - self.repo_labels)
+        self.assertEqual(
+            missing,
+            [],
+            msg=(
+                "The following labels are required by automation but do not exist"
+                f" in {self.repo}: {missing!r}.\n"
+                "Create them in the repository's Labels settings page before the"
+                " automation runs."
+            ),
+        )
+
+    def test_individual_labels(self) -> None:
+        """One sub-test per required label so failures name the missing label clearly."""
+        for label in sorted(REQUIRED_LABELS):
+            with self.subTest(label=label):
+                self.assertIn(
+                    label,
+                    self.repo_labels,
+                    msg=(f"Required label {label!r} does not exist in {self.repo}."),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an integration test that calls the GitHub API to assert that every label referenced by name in this repo's automation actually exists in the repository.
This catches label-spelling drift (like the stale names uncovered in #477) before it causes silent misbehavior at runtime.

## What changed

`scripts/test_label_existence_integration.py` -- new file.
Defines `REQUIRED_LABELS`, the complete set of label names that automation applies or enforces by name (sourced from `enforce_mutually_exclusive_labels.py`, `file_test_failure_issues.py`, `archive_stale_test_failures.py`, `block-merge-on-blocking-labels.yml`, and `remove-verified-on-push.yml`).
`setUpClass` skips the test class when `GITHUB_TOKEN` or `GITHUB_REPOSITORY` is absent, so local runs without credentials are unaffected.
`test_all_required_labels_exist` fails with a list of every missing label.
`test_individual_labels` uses `subTest` so each missing label is reported individually.
Existence checks are case-insensitive (labels are lowercased before comparison), matching how `enforce_mutually_exclusive_labels.py` compares them.

`.github/workflows/build.yml` -- two additions:
Passes `GITHUB_TOKEN` and `GITHUB_REPOSITORY` into the "Run Python script unit tests" step so the integration test runs in CI rather than skipping.
Adds `issues: read` to the workflow `permissions` block so the token can list repo labels via `GET /repos/{owner}/{repo}/labels`.

Fixes #487
