### PR TITLE
Rewrite test5a to assert the real secure-camera SecureViewer path

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,12 +20,8 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-# test5a is an intentional red-light test for the secure-camera overlay
-# regression tracked by issue #156 (a separate, larger fix than #231/#232).
-# Its doc comment in GalleryButtonVisualE2ETest.kt explicitly requires it to
-# "remain a visible red" until #156 lands in its own PR. PR #400 fixed the
-# captureOnePhoto()/clearCameraRoll() preconditions that #232 actually
-# reported, so the test now reaches its real, documented-as-failing GREEN
-# coverage assertion instead of timing out earlier. Remove this entry only
-# when #156 is fixed.
-com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen    # issue #156
+# (No entries: test5a was rewritten under issue #486 — Option A to exercise
+# real locked-path product behaviour, capturing the GREEN photo inside the
+# secure session so the locked tap's SecureViewer can display it, rather than
+# asserting the impossible "mock gallery green" the old capture-then-lock
+# version expected. It is now a green-light test and no longer allowlisted.)

--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,7 +20,7 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-# (No entries: test5a was rewritten under issue #486 — Option A to exercise
+# (No entries: test5a was rewritten under issue #486, Option A, to exercise
 # real locked-path product behaviour, capturing the GREEN photo inside the
 # secure session so the locked tap's SecureViewer can display it, rather than
 # asserting the impossible "mock gallery green" the old capture-then-lock

--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,8 +20,4 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-# (No entries: test5a was rewritten under issue #486, Option A, to exercise
-# real locked-path product behaviour, capturing the GREEN photo inside the
-# secure session so the locked tap's SecureViewer can display it, rather than
-# asserting the impossible "mock gallery green" the old capture-then-lock
-# version expected. It is now a green-light test and no longer allowlisted.)
+# (No entries.)

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -569,6 +569,40 @@ class E2EFixture(
         return lastCoverage
     }
 
+    /**
+     * Polls screenshots until the GREEN (#00C853) region forms a band whose bounding box spans
+     * at least [minWidthFraction] of the screen width, or [timeoutMs] elapses. Returns the final
+     * measured width fraction regardless of whether the threshold was reached.
+     *
+     * Used by the secure-camera test: `SecureViewerActivity` renders the photo with a
+     * center-inside `SubsamplingScaleImageView`, so a 16:9 capture letterboxes to full screen
+     * width but only a fraction of the height. A central-region coverage poll (as in
+     * [waitForGreenCoverage]) does not predict that band, so this poll measures the band's width
+     * directly, matching the band-shaped assertion in `test5a`.
+     *
+     * @param minWidthFraction  Fraction of screen width the green bbox must span before stopping.
+     * @param timeoutMs         Maximum wait time in milliseconds.
+     * @param intervalMs        Sleep between successive capture attempts.
+     */
+    fun waitForGreenBand(
+        minWidthFraction: Float = 0.80f,
+        timeoutMs: Long = 15_000L,
+        intervalMs: Long = 500L,
+    ): Float {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var lastWidthFraction = 0f
+        while (System.currentTimeMillis() < deadline) {
+            val screen = Screenshot.captureScreen()
+            val greenMask = ColorMatch.mask(screen, Rgb.GREEN)
+            val widthFraction =
+                if (greenMask.width > 0) greenMask.bbox.width().toFloat() / greenMask.width else 0f
+            lastWidthFraction = widthFraction
+            if (widthFraction >= minWidthFraction) return widthFraction
+            Thread.sleep(intervalMs)
+        }
+        return lastWidthFraction
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     /**

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -570,37 +570,50 @@ class E2EFixture(
     }
 
     /**
-     * Polls screenshots until the GREEN (#00C853) region forms a band whose bounding box spans
-     * at least [minWidthFraction] of the screen width, or [timeoutMs] elapses. Returns the final
-     * measured width fraction regardless of whether the threshold was reached.
+     * Polls screenshots until the GREEN (#00C853) region forms a *letterboxed* band: its bounding
+     * box spans at least [minWidthFraction] of the screen width while occupying at most
+     * [maxHeightFraction] of the screen height. Returns true if such a band appeared before
+     * [timeoutMs] elapsed, false otherwise.
      *
-     * Used by the secure-camera test: `SecureViewerActivity` renders the photo with a
-     * center-inside `SubsamplingScaleImageView`, so a 16:9 capture letterboxes to full screen
-     * width but only a fraction of the height. A central-region coverage poll (as in
-     * [waitForGreenCoverage]) does not predict that band, so this poll measures the band's width
+     * Used by the secure-camera test. `SecureViewerActivity` renders the photo with a center-inside
+     * `SubsamplingScaleImageView`, so a 16:9 capture letterboxes to full screen width but only a
+     * fraction of the height (~25% on the Pixel 6 CI device). A central-region coverage poll (as in
+     * [waitForGreenCoverage]) does not predict that band, so this poll measures the band's geometry
      * directly, matching the band-shaped assertion in `test5a`.
      *
+     * The height bound is load-bearing, not cosmetic. Before the locked tap fires, the solid-green
+     * `MockCameraActivity` is in the foreground, so the green region already spans the *full* width
+     * (and the full height). A width-only poll would return immediately on that pre-tap frame and
+     * never wait for `SecureViewerActivity` to come to front; the assertion would then run against
+     * the mock-camera screenshot. Requiring the band to be *letterboxed* (full width but not full
+     * height) makes the poll wait for the SecureViewer render specifically: the full-height
+     * mock-camera green does not satisfy [maxHeightFraction], while the ~25%-tall SecureViewer band
+     * does.
+     *
      * @param minWidthFraction  Fraction of screen width the green bbox must span before stopping.
+     * @param maxHeightFraction Maximum fraction of screen height the green bbox may span (excludes
+     *                          the full-screen mock-camera green that precedes the tap).
      * @param timeoutMs         Maximum wait time in milliseconds.
      * @param intervalMs        Sleep between successive capture attempts.
      */
     fun waitForGreenBand(
         minWidthFraction: Float = 0.80f,
+        maxHeightFraction: Float = 0.70f,
         timeoutMs: Long = 15_000L,
         intervalMs: Long = 500L,
-    ): Float {
+    ): Boolean {
         val deadline = System.currentTimeMillis() + timeoutMs
-        var lastWidthFraction = 0f
         while (System.currentTimeMillis() < deadline) {
             val screen = Screenshot.captureScreen()
             val greenMask = ColorMatch.mask(screen, Rgb.GREEN)
             val widthFraction =
                 if (greenMask.width > 0) greenMask.bbox.width().toFloat() / greenMask.width else 0f
-            lastWidthFraction = widthFraction
-            if (widthFraction >= minWidthFraction) return widthFraction
+            val heightFraction =
+                if (greenMask.height > 0) greenMask.bbox.height().toFloat() / greenMask.height else 0f
+            if (widthFraction >= minWidthFraction && heightFraction <= maxHeightFraction) return true
             Thread.sleep(intervalMs)
         }
-        return lastWidthFraction
+        return false
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -469,20 +469,35 @@ class E2EFixture(
     }
 
     /**
-     * Launches the mock camera via the secure-camera action and asserts the keyguard is locked.
+     * Launches the mock camera via the secure-camera action, waits for the overlay to activate
+     * over the keyguard, and asserts the keyguard is still locked.
      *
-     * Sends `am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE` then immediately
-     * checks [KeyguardManager.isKeyguardLocked]. If the keyguard is not locked the fixture
-     * fails before any screenshot is taken — a silent keyguard dismissal would make Tests
-     * 4a/5a pass for the wrong reason.
+     * Targets the mock-camera package explicitly with `-p $pcPackage`. Without `-p`, an
+     * `am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE` lands on the system intent
+     * resolver / disambiguation chooser instead of launching [com.gb4pc.mockcamera.MockCameraActivity]
+     * directly (the CI logcat shows a `ResolverListAdapter` entry and *no* `CameraDevice.onOpened`),
+     * so the activity never reaches onResume(), the camera never opens,
+     * `CameraManager.AvailabilityCallback.onCameraUnavailable` never fires, and the overlay never
+     * activates — `waitForOverlayActive()` then times out. Pinning the package launches the mock
+     * camera the same way [launchPixelCamera] does for the non-secure action.
      *
-     * Call [lockScreen] before this method to guarantee the device is locked first.
+     * Uses the same bounded relaunch-until-overlay-active path as [launchPixelCamera] (issue #233):
+     * the first secure launch can also be torn down before onResume(), and a re-issued `am start`
+     * recovers it. The retry's `onBeforeRetry` is a no-op here so the keyguard this secure flow
+     * relies on is left in place (unlike the non-secure launch, which re-dismisses the swipe
+     * keyguard between attempts).
+     *
+     * After the launch, [KeyguardManager.isKeyguardLocked] must still be true: a silent keyguard
+     * dismissal would make Tests 4a/5a pass for the wrong reason. Call [lockScreen] before this
+     * method to guarantee the device is locked first.
      */
     fun launchSecureCamera() {
-        uiAutomation
-            .executeShellCommand(
-                "am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE",
-            ).close()
+        launchAndAwaitOverlay(
+            label = "launchSecureCamera",
+            amCommand = "am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE -p $pcPackage",
+            // Do NOT dismiss the keyguard between attempts: this secure flow requires it locked.
+            onBeforeRetry = {},
+        )
 
         val keyguard = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         if (!keyguard.isKeyguardLocked) {

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -129,33 +129,54 @@ class E2EFixture(
         // dismissal must run on every launch, not only once in setUp().
         wakeAndDismissKeyguard()
 
-        // Issue #233: On the API-35 CI emulator the *first* STILL_IMAGE_CAMERA launch of a
-        // suite is frequently torn down inside its own OPEN window-transition before the
-        // activity reaches onResume(). WindowManager force-removes the just-created
-        // ActivityRecord ("Force removing ActivityRecord{... MockCameraActivity}" / "Attempted
-        // to add application window with unknown token ... Aborting"), so MockCameraActivity
-        // never calls openCamera(), CameraManager.AvailabilityCallback.onCameraUnavailable
-        // never fires, and the overlay never activates -- the test then times out at 30 s.
-        // A re-issued `am start` after the transition has settled reliably brings the activity
-        // up (every non-first launch in CI opens the camera within ~30 ms), so retry the launch
-        // until the overlay activates, which is the observable proof the camera reached
-        // onResume() and opened. The retry is bounded so a genuinely broken launch still fails
-        // the caller's own activation assertion rather than hanging.
-        //
-        // The activation check below treats isOverlayActive becoming true as proof that *this*
-        // launch reached onResume(). That proof is only sound from a known-inactive baseline: if
-        // a previous test's overlay is still active when launchPixelCamera() is called (setUp()'s
-        // waitForOverlayInactive() and the mid-test goHome()/stopPixelCamera() flows do not assert
-        // deactivation), waitForCondition would read the stale true on its first poll and return
-        // before this launch's `am start` had any effect. Wait for a clean inactive baseline first
-        // so each attempt observes a genuine false -> true transition. Bounded so it cannot hang.
+        // Issue #233: the first STILL_IMAGE_CAMERA launch of a suite is frequently torn down before
+        // the activity reaches onResume(), so the overlay never activates. launchAndAwaitOverlay
+        // retries the launch (bounded) until the overlay activates; see its kdoc for the rationale.
+        launchAndAwaitOverlay(
+            label = "launchPixelCamera",
+            amCommand = "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage",
+            // The screen can re-sleep between attempts, so re-dismiss the swipe keyguard before
+            // re-issuing `am start` on this non-secure launch.
+            onBeforeRetry = { wakeAndDismissKeyguard() },
+        )
+    }
+
+    /**
+     * Issues [amCommand] up to [LAUNCH_ATTEMPTS] times, returning as soon as
+     * [OverlayService.isOverlayActive] becomes true (the observable proof that the mock camera
+     * reached onResume() and opened the camera, firing onCameraUnavailable).
+     *
+     * Issue #233: On the API-35 CI emulator the *first* camera launch of a suite is frequently
+     * torn down inside its own OPEN window-transition before the activity reaches onResume().
+     * WindowManager force-removes the just-created ActivityRecord ("Force removing
+     * ActivityRecord{... MockCameraActivity}"), so MockCameraActivity never calls openCamera(),
+     * CameraManager.AvailabilityCallback.onCameraUnavailable never fires, and the overlay never
+     * activates. A re-issued `am start` after the transition has settled reliably brings the
+     * activity up (every non-first launch in CI opens the camera within ~30 ms), so this retries
+     * until the overlay activates. The retry is bounded so a genuinely broken launch still fails
+     * the caller's own activation assertion rather than hanging.
+     *
+     * The activation check treats isOverlayActive becoming true as proof that *this* launch
+     * reached onResume(). That proof is only sound from a known-inactive baseline: if a previous
+     * test's overlay is still active when this is called, waitForCondition would read the stale
+     * true on its first poll and return before this launch's `am start` had any effect. So a
+     * clean inactive baseline is awaited first (bounded, so it cannot hang).
+     *
+     * @param label        Prefix for the diagnostic logcat lines (the calling helper's name).
+     * @param amCommand    The full `am start ...` shell command to (re-)issue each attempt.
+     * @param onBeforeRetry Run before each *re-issued* attempt (not before the first), e.g. to
+     *                      re-dismiss a swipe keyguard. The secure-camera path passes a no-op so
+     *                      the keyguard it relies on is left in place.
+     */
+    private fun launchAndAwaitOverlay(
+        label: String,
+        amCommand: String,
+        onBeforeRetry: () -> Unit,
+    ) {
         waitForCondition(LAUNCH_BASELINE_MS) { !OverlayService.isOverlayActive }
         repeat(LAUNCH_ATTEMPTS) { attempt ->
-            Log.i(TAG, "launchPixelCamera: am start attempt ${attempt + 1}/$LAUNCH_ATTEMPTS")
-            uiAutomation
-                .executeShellCommand(
-                    "am start -a android.media.action.STILL_IMAGE_CAMERA -p $pcPackage",
-                ).close()
+            Log.i(TAG, "$label: am start attempt ${attempt + 1}/$LAUNCH_ATTEMPTS")
+            uiAutomation.executeShellCommand(amCommand).close()
             // The first attempt gets the full healthy-activation window so a slow-but-healthy
             // launch is never mistaken for a failed one and re-issued (which would itself race the
             // OPEN transition). Only the teardown failure mode survives that window, and recovery
@@ -163,22 +184,21 @@ class E2EFixture(
             // companion-object note for the budget rationale.
             val verifyMs = if (attempt == 0) LAUNCH_FIRST_VERIFY_MS else LAUNCH_RETRY_VERIFY_MS
             if (waitForCondition(verifyMs) { OverlayService.isOverlayActive }) {
-                Log.i(TAG, "launchPixelCamera: overlay active on attempt ${attempt + 1}")
+                Log.i(TAG, "$label: overlay active on attempt ${attempt + 1}")
                 return
             }
             if (attempt < LAUNCH_ATTEMPTS - 1) {
-                // The previous launch was torn down before the camera opened. Re-dismiss the
-                // keyguard (the screen can re-sleep between attempts) and try again.
+                // The previous launch was torn down before the camera opened. Try again.
                 Log.w(
                     TAG,
-                    "launchPixelCamera: overlay still inactive after $verifyMs ms on attempt " +
+                    "$label: overlay still inactive after $verifyMs ms on attempt " +
                         "${attempt + 1} (first-launch teardown race); re-issuing am start",
                 )
-                wakeAndDismissKeyguard()
+                onBeforeRetry()
             } else {
                 Log.w(
                     TAG,
-                    "launchPixelCamera: overlay still inactive after $LAUNCH_ATTEMPTS attempts; " +
+                    "$label: overlay still inactive after $LAUNCH_ATTEMPTS attempts; " +
                         "letting the caller's own assertion fail",
                 )
             }

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -355,8 +355,7 @@ class GalleryButtonVisualE2ETest {
     /**
      * Verifies the real locked-path product behaviour: tapping the overlay in secure-camera
      * mode (screen locked) when the in-progress secure session contains a GREEN photo opens
-     * the app's own [com.gb4pc.viewer.SecureViewerActivity] and displays that photo
-     * (full-screen GREEN coverage > 40%).
+     * the app's own [com.gb4pc.viewer.SecureViewerActivity] and displays that photo.
      *
      * **Why the capture happens after the session starts (issue #486 — Option A).**
      *
@@ -378,7 +377,28 @@ class GalleryButtonVisualE2ETest {
      * This version mirrors the genuine secure-camera use case: lock, launch the secure camera so
      * the overlay activates and the session begins, then capture the GREEN photo *inside* that
      * session. The ContentObserver adds it to the session, so the locked tap's `SecureViewer`
-     * has a green item to show and the coverage assertion is satisfiable by real product code.
+     * has a green item to show.
+     *
+     * **Why this asserts the GREEN *band*, not full-screen 40% like test3a.**
+     *
+     * test3a opens the mock gallery, whose `LastPhotoActivity` ImageView uses `centerCrop`
+     * (`e2e-mock-gallery/.../activity_last_photo.xml`), so the green photo fills ~100% of the
+     * screen and full-screen coverage > 40% is reachable. The locked path here opens
+     * `SecureViewerActivity`, which renders with `SubsamplingScaleImageView` and never calls
+     * `setMinimumScaleType(...)`, so it uses the library default `SCALE_TYPE_CENTER_INSIDE`
+     * (letterbox-fit, not crop). The capture is 1920×1080 (16:9 landscape;
+     * `MockCameraActivity.CAPTURE_WIDTH/HEIGHT`); on the Pixel 6 CI device (1080×2400 portrait)
+     * it fits to full width with a band ≈ 1080×608 px centred against the viewer's solid-black
+     * background, i.e. only ≈ 25% of the full screen. A full-screen > 40% assertion is therefore
+     * structurally unreachable on this render path regardless of overlay/session correctness.
+     *
+     * Instead we assert two geometry-justified properties of the displayed green region, both of
+     * which a correctly displayed letterboxed photo satisfies with margin and an empty/black
+     * SecureViewer (or a no-op tap that leaves the lock screen or black secure-camera screen up)
+     * fails outright:
+     *  1. The green region spans most of the screen *width* (the letterbox fits to full width).
+     *  2. Within the green region's own bounding box, coverage is high (the photo is solid green).
+     * The empty cases produce an empty green mask, so both checks report 0 and fail.
      */
     @Test
     fun test5a_secureCameraLockedPopulatedGalleryShowsGreen() {
@@ -399,11 +419,11 @@ class GalleryButtonVisualE2ETest {
 
         fixture.tapOverlay() // locked tap → SecureViewer renders the session's GREEN photo
 
-        // Poll up to 15 s for SecureViewer's photo to render — like test3a, a fixed pause races
-        // the activity's cold start (process spawn + image decode). waitForGreenCoverage's return
-        // value is discarded; the assertion below re-measures full-screen coverage on a fresh
-        // screenshot against the 40% threshold.
-        fixture.waitForGreenCoverage(minCoverage = 0.40f, timeoutMs = 15_000L)
+        // Poll up to 15 s for a wide GREEN band to appear — SecureViewer's cold start (process
+        // spawn + SubsamplingScaleImageView decode) races a fixed pause. The poll's threshold and
+        // region match the band-shaped assertion below (it measures the same wide-band metric),
+        // unlike a central-region poll which would not predict a full-width letterboxed band.
+        fixture.waitForGreenBand(minWidthFraction = 0.80f, timeoutMs = 15_000L)
 
         val s2 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s2, "5a-s2.png")
@@ -411,15 +431,25 @@ class GalleryButtonVisualE2ETest {
         val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
         Screenshot.saveForArtifact(maskToBitmap(greenMask), "5a-green-mask.png")
 
-        val coverage = ColorMatch.coverageFraction(greenMask)
-        if (coverage <= 0.40f) {
+        // The displayed photo is a solid-green 16:9 image letterboxed to full width by
+        // SecureViewer's center-inside SubsamplingScaleImageView (see kdoc above).
+        val bandWidthFraction = greenMask.bbox.width().toFloat() / greenMask.width
+        val bboxArea = greenMask.bbox.width() * greenMask.bbox.height()
+        val withinBandCoverage = if (bboxArea > 0) greenMask.pixelCount.toFloat() / bboxArea else 0f
+
+        if (bandWidthFraction <= 0.80f || withinBandCoverage <= 0.80f) {
             fail(
-                "test5a_secureCameraLockedPopulatedGalleryShowsGreen: GREEN coverage after tap " +
-                    "is ${coverage * 100f}% — expected > 40%. " +
-                    "The locked tap should open SecureViewerActivity showing the GREEN photo " +
-                    "captured during the secure session, but the screen is not green. Check the " +
-                    "5a-s1/5a-s2 artifacts and the GB4PC_Overlay / Logic: logcat: the session may " +
-                    "be empty (capture did not land in-session) or the overlay was not tappable.",
+                "test5a_secureCameraLockedPopulatedGalleryShowsGreen: the locked tap should open " +
+                    "SecureViewerActivity showing the GREEN photo captured during the secure " +
+                    "session, but the displayed green region is not a solid full-width band. " +
+                    "Measured: band spans ${bandWidthFraction * 100f}% of screen width " +
+                    "(expected > 80%), green coverage within its bounding box is " +
+                    "${withinBandCoverage * 100f}% (expected > 80%); green pixels=" +
+                    "${greenMask.pixelCount}, bbox=${greenMask.bbox}, " +
+                    "screen=${greenMask.width}x${greenMask.height}. " +
+                    "Check the 5a-s1/5a-s2 artifacts and the GB4PC_Overlay / Logic: logcat: the " +
+                    "session may be empty (capture did not land in-session) or the overlay was " +
+                    "not tappable.",
             )
         }
     }

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -350,42 +350,60 @@ class GalleryButtonVisualE2ETest {
         }
     }
 
-    // ── test5a — Secure camera + populated gallery: EXPECTED TO FAIL ─────────
+    // ── test5a — Secure camera + populated session: SecureViewer shows GREEN ─
 
     /**
-     * RED-LIGHT TEST — intentional failure at baseline.
+     * Verifies the real locked-path product behaviour: tapping the overlay in secure-camera
+     * mode (screen locked) when the in-progress secure session contains a GREEN photo opens
+     * the app's own [com.gb4pc.viewer.SecureViewerActivity] and displays that photo
+     * (full-screen GREEN coverage > 40%).
      *
-     * Verifies that tapping the overlay in secure-camera mode (screen locked) when the camera
-     * roll contains a GREEN photo opens the gallery and displays the photo (coverage > 40%).
+     * **Why the capture happens after the session starts (issue #486 — Option A).**
      *
-     * This test is a regression marker for the known secure-camera overlay issue: the overlay
-     * is currently not rendered (or not tappable) in secure-camera mode, so the tap is a no-op
-     * and the screen stays on the camera feed, failing the GREEN coverage assertion.
+     * A locked tap does NOT launch the configured gallery package; production
+     * [com.gb4pc.overlay.TapActionResolver] resolves the locked case to
+     * `TapAction.LaunchSecureViewer`, so the screen that opens is `SecureViewerActivity`, not
+     * the mock gallery. `SecureViewerActivity` renders only the current secure session's media
+     * ([com.gb4pc.viewer.SessionTracker.getSessionMedia]); it does not query MediaStore directly.
      *
-     * Tracking issue: #156 — Do NOT skip, ignore, or quarantine this test. It must remain
-     * a visible red until the secure-camera overlay path is restored in a separate PR.
+     * The secure session is (re)started when the overlay activates while locked
+     * ([com.gb4pc.service.OverlayServiceLogic.showOverlay] → `SessionTracker.startSession()`),
+     * and `startSession()` clears any prior media. The session is then populated only by the
+     * OverlayService `ContentObserver`, which adds MediaStore rows whose `DATE_ADDED` is at or
+     * after session start. A photo captured *before* locking is therefore structurally excluded
+     * from the session — which is why the earlier version of this test (capture-then-lock) could
+     * never make the assertion pass and was filed as a red-light test against the mis-cited
+     * issue #156 (a plan-tracking checklist, not a bug report).
+     *
+     * This version mirrors the genuine secure-camera use case: lock, launch the secure camera so
+     * the overlay activates and the session begins, then capture the GREEN photo *inside* that
+     * session. The ContentObserver adds it to the session, so the locked tap's `SecureViewer`
+     * has a green item to show and the coverage assertion is satisfiable by real product code.
      */
     @Test
     fun test5a_secureCameraLockedPopulatedGalleryShowsGreen() {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
-        // Capture the photo while the camera activity is running — MockCameraActivity's
-        // BroadcastReceiver is only registered in onResume(), so launching the camera first
-        // is required. After capture, return to home and stop the camera before locking.
-        fixture.launchPixelCamera()
-        fixture.waitForOverlayActive()
-        fixture.captureOnePhoto() // GREEN JPEG now in MediaStore
-        fixture.goHome()
-        fixture.stopPixelCamera()
         fixture.lockScreen()
+        // Launch the secure camera so the overlay activates while locked. showOverlay() starts
+        // the secure session and registers the MediaStore ContentObserver, so the capture below
+        // lands inside the session. waitForOverlayActive() confirms the session has begun before
+        // capturing — MockCameraActivity also only registers its shutter receiver in onResume(),
+        // so it must be foregrounded first.
         fixture.launchSecureCamera()
-        fixture.pause(1000)
+        fixture.waitForOverlayActive()
+        fixture.captureOnePhoto() // GREEN JPEG captured during the secure session
 
         val s1 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s1, "5a-s1.png")
 
-        fixture.tapOverlay() // taps overlay position; no-op at baseline (overlay blocked)
-        fixture.pause(1000)
+        fixture.tapOverlay() // locked tap → SecureViewer renders the session's GREEN photo
+
+        // Poll up to 15 s for SecureViewer's photo to render — like test3a, a fixed pause races
+        // the activity's cold start (process spawn + image decode). waitForGreenCoverage's return
+        // value is discarded; the assertion below re-measures full-screen coverage on a fresh
+        // screenshot against the 40% threshold.
+        fixture.waitForGreenCoverage(minCoverage = 0.40f, timeoutMs = 15_000L)
 
         val s2 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s2, "5a-s2.png")
@@ -398,9 +416,10 @@ class GalleryButtonVisualE2ETest {
             fail(
                 "test5a_secureCameraLockedPopulatedGalleryShowsGreen: GREEN coverage after tap " +
                     "is ${coverage * 100f}% — expected > 40%. " +
-                    "This is the expected baseline failure for the secure-camera overlay regression " +
-                    "(issue #156). The overlay is not rendered or not tappable while the keyguard " +
-                    "is active, so the gallery did not open.",
+                    "The locked tap should open SecureViewerActivity showing the GREEN photo " +
+                    "captured during the secure session, but the screen is not green. Check the " +
+                    "5a-s1/5a-s2 artifacts and the GB4PC_Overlay / Logic: logcat: the session may " +
+                    "be empty (capture did not land in-session) or the overlay was not tappable.",
             )
         }
     }

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -423,11 +423,12 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.lockScreen()
-        // Launch the secure camera so the overlay activates while locked. showOverlay() starts
-        // the secure session and registers the MediaStore ContentObserver, so the capture below
-        // lands inside the session. waitForOverlayActive() confirms the session has begun before
-        // capturing — MockCameraActivity also only registers its shutter receiver in onResume(),
-        // so it must be foregrounded first.
+        // Launch the secure camera so the overlay activates while locked. launchSecureCamera()
+        // pins the mock-camera package and waits for the overlay to activate; showOverlay() then
+        // starts the secure session and registers the MediaStore ContentObserver, so the capture
+        // below lands inside the session. The explicit waitForOverlayActive() re-confirms the
+        // session has begun before capturing — MockCameraActivity also only registers its shutter
+        // receiver in onResume(), so it must be foregrounded first.
         fixture.launchSecureCamera()
         fixture.waitForOverlayActive()
         fixture.captureOnePhoto() // GREEN JPEG captured during the secure session

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -379,7 +379,7 @@ class GalleryButtonVisualE2ETest {
      * session. The ContentObserver adds it to the session, so the locked tap's `SecureViewer`
      * has a green item to show.
      *
-     * **Why this asserts the GREEN *band*, not full-screen 40% like test3a.**
+     * **Why this asserts a letterboxed GREEN *band*, not full-screen 40% like test3a.**
      *
      * test3a opens the mock gallery, whose `LastPhotoActivity` ImageView uses `centerCrop`
      * (`e2e-mock-gallery/.../activity_last_photo.xml`), so the green photo fills ~100% of the
@@ -389,16 +389,34 @@ class GalleryButtonVisualE2ETest {
      * (letterbox-fit, not crop). The capture is 1920×1080 (16:9 landscape;
      * `MockCameraActivity.CAPTURE_WIDTH/HEIGHT`); on the Pixel 6 CI device (1080×2400 portrait)
      * it fits to full width with a band ≈ 1080×608 px centred against the viewer's solid-black
-     * background, i.e. only ≈ 25% of the full screen. A full-screen > 40% assertion is therefore
-     * structurally unreachable on this render path regardless of overlay/session correctness.
+     * background, i.e. ≈ 100% of the width but only ≈ 25% of the height (≈ 25% of the full
+     * screen). A full-screen > 40% assertion is therefore structurally unreachable on this render
+     * path regardless of overlay/session correctness.
      *
-     * Instead we assert two geometry-justified properties of the displayed green region, both of
-     * which a correctly displayed letterboxed photo satisfies with margin and an empty/black
-     * SecureViewer (or a no-op tap that leaves the lock screen or black secure-camera screen up)
-     * fails outright:
+     * **Why the assertion must check the band *height*, not just its width and solidity.**
+     *
+     * The screen on view at the moment of the tap is *not* the lock screen or a black screen — it
+     * is the solid-green `MockCameraActivity` (the secure camera, foregrounded above), which is the
+     * same `Rgb.GREEN` as the captured photo. So the relevant failure case for this flow is a
+     * *no-op tap*: if the overlay is not composited / not tappable over the secure-camera keyguard,
+     * `tapOverlay()` silently does nothing, `SecureViewerActivity` never opens, and the green mock
+     * camera stays on screen — full width *and* full height. Width-only + within-bbox-solidity
+     * checks would both pass on that full-screen green, so the test would go green for a tap that
+     * did nothing. The discriminator is the band *height*: the real SecureViewer render is
+     * letterboxed to ≈ 25% of the screen height with black bars above and below, whereas the
+     * leftover mock-camera green fills ≈ 100% of the height. We therefore additionally require the
+     * green band to occupy only a minority of the screen height (a letterbox, not a fill) and
+     * confirm the letterbox positively by checking that the strip above the band is essentially
+     * green-free (SecureViewer's black background, not more mock-camera green).
+     *
+     * The three geometry-justified checks, all satisfied with margin by a correct letterboxed
+     * render and failed by the no-op / empty cases:
      *  1. The green region spans most of the screen *width* (the letterbox fits to full width).
      *  2. Within the green region's own bounding box, coverage is high (the photo is solid green).
-     * The empty cases produce an empty green mask, so both checks report 0 and fail.
+     *  3. The green region occupies only a minority of the screen *height* (it is letterboxed, not
+     *     a full-screen fill), and the strip above it is green-free (the black letterbox bar).
+     * An empty/black SecureViewer produces an empty mask, failing 1 and 2. A no-op tap leaving the
+     * full-screen mock-camera green up fails 3 (full height, and no black bar above the band).
      */
     @Test
     fun test5a_secureCameraLockedPopulatedGalleryShowsGreen() {
@@ -419,11 +437,13 @@ class GalleryButtonVisualE2ETest {
 
         fixture.tapOverlay() // locked tap → SecureViewer renders the session's GREEN photo
 
-        // Poll up to 15 s for a wide GREEN band to appear — SecureViewer's cold start (process
-        // spawn + SubsamplingScaleImageView decode) races a fixed pause. The poll's threshold and
-        // region match the band-shaped assertion below (it measures the same wide-band metric),
-        // unlike a central-region poll which would not predict a full-width letterboxed band.
-        fixture.waitForGreenBand(minWidthFraction = 0.80f, timeoutMs = 15_000L)
+        // Poll up to 15 s for the letterboxed GREEN band to appear — SecureViewer's cold start
+        // (process spawn + SubsamplingScaleImageView decode) races a fixed pause. The poll requires
+        // the same letterbox geometry as the assertion below (full width, height a minority of the
+        // screen), so it does not short-circuit on the full-screen mock-camera green that is on
+        // screen before the tap, and it predicts the assertion rather than measuring a different
+        // quantity.
+        fixture.waitForGreenBand(minWidthFraction = 0.80f, maxHeightFraction = 0.70f, timeoutMs = 15_000L)
 
         val s2 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s2, "5a-s2.png")
@@ -434,19 +454,39 @@ class GalleryButtonVisualE2ETest {
         // The displayed photo is a solid-green 16:9 image letterboxed to full width by
         // SecureViewer's center-inside SubsamplingScaleImageView (see kdoc above).
         val bandWidthFraction = greenMask.bbox.width().toFloat() / greenMask.width
+        val bandHeightFraction = greenMask.bbox.height().toFloat() / greenMask.height
         val bboxArea = greenMask.bbox.width() * greenMask.bbox.height()
         val withinBandCoverage = if (bboxArea > 0) greenMask.pixelCount.toFloat() / bboxArea else 0f
 
-        if (bandWidthFraction <= 0.80f || withinBandCoverage <= 0.80f) {
+        // The black letterbox bar above the band positively confirms SecureViewer's background
+        // rather than leftover full-screen mock-camera green. Measure the green coverage of the top
+        // strip (the screen above where the ~25%-tall centred band starts). With the band centred,
+        // its top edge sits at ~37% of the screen height, so the top 25% strip is entirely within
+        // the upper letterbox bar and must be essentially green-free.
+        val topStrip = android.graphics.Rect(0, 0, greenMask.width, (greenMask.height * 0.25f).toInt())
+        val topStripGreen = ColorMatch.coverageFraction(greenMask, topStrip)
+
+        if (bandWidthFraction <= 0.80f ||
+            withinBandCoverage <= 0.80f ||
+            bandHeightFraction >= 0.70f ||
+            topStripGreen >= 0.10f
+        ) {
             fail(
                 "test5a_secureCameraLockedPopulatedGalleryShowsGreen: the locked tap should open " +
                     "SecureViewerActivity showing the GREEN photo captured during the secure " +
-                    "session, but the displayed green region is not a solid full-width band. " +
+                    "session as a letterboxed band over a black background, but the displayed green " +
+                    "region is not a solid, full-width, letterboxed band. " +
                     "Measured: band spans ${bandWidthFraction * 100f}% of screen width " +
                     "(expected > 80%), green coverage within its bounding box is " +
-                    "${withinBandCoverage * 100f}% (expected > 80%); green pixels=" +
-                    "${greenMask.pixelCount}, bbox=${greenMask.bbox}, " +
+                    "${withinBandCoverage * 100f}% (expected > 80%), band height is " +
+                    "${bandHeightFraction * 100f}% of the screen (expected < 70%, i.e. a letterbox " +
+                    "not a full-screen fill), and the top strip is ${topStripGreen * 100f}% green " +
+                    "(expected < 10%, i.e. a black letterbox bar, not leftover mock-camera green); " +
+                    "green pixels=${greenMask.pixelCount}, bbox=${greenMask.bbox}, " +
                     "screen=${greenMask.width}x${greenMask.height}. " +
+                    "A full-height green band with no black bar above it means the locked tap was a " +
+                    "no-op and the secure camera is still in front (overlay not composited / not " +
+                    "tappable over the keyguard). " +
                     "Check the 5a-s1/5a-s2 artifacts and the GB4PC_Overlay / Logic: logcat: the " +
                     "session may be empty (capture did not land in-session) or the overlay was " +
                     "not tappable.",


### PR DESCRIPTION
🤖 Author

- Fixes #486 
- Fixes #232 
- Fixes #81 

## What was wrong

`test5a_secureCameraLockedPopulatedGalleryShowsGreen` asserted something the product cannot do. On the locked path, `TapActionResolver.resolve` returns `TapAction.LaunchSecureViewer`, so a locked overlay tap opens the app's own `SecureViewerActivity`, not the configured (mock) gallery. `SecureViewerActivity` renders only the current secure session's media (`SessionTracker.getSessionMedia()`); it never queries MediaStore directly.

The old test captured the GREEN photo while the device was still **unlocked**, before any secure session existed. When the overlay later activates while locked, `OverlayServiceLogic.showOverlay()` calls `SessionTracker.startSession()`, which clears media, and the session is then populated only by the `OverlayService` ContentObserver, which adds rows with `DATE_ADDED >= session start`. A photo captured before locking is therefore structurally excluded from the session, so `SecureViewer` had nothing green to show and full-screen GREEN coverage was 0.0%. The assertion (tap then mock-gallery green > 40%) was impossible to satisfy with an overlay-rendering fix alone, which is why the test had been parked as a permanent red-light citing #156 (a plan-tracking checklist, not a bug report).

The owner chose **Option A** on #486: fix the test to match real product behaviour.

## The fix

Rewrite the test to mirror the genuine secure-camera use case:

1. `clearCameraRoll()`, `lockScreen()`.
2. `launchSecureCamera()` so the overlay activates while locked. `showOverlay()` starts the secure session and registers the MediaStore ContentObserver.
3. `waitForOverlayActive()` confirms the session has begun (and that the mock camera reached `onResume()`, where it registers its shutter receiver).
4. `captureOnePhoto()` writes the GREEN JPEG **inside** the session, so the ContentObserver adds it to `SessionTracker`.
5. `tapOverlay()` opens `SecureViewerActivity`, which renders the session's green photo.
6. Assert the displayed green region is a solid, full-width, **letterboxed** band (see next section).

This makes the test a genuine green-light test of real product code, so it is removed from `.github/allowed-test-failures.txt`.

## Assertion: a letterboxed GREEN band, not full-screen 40%

The original draft kept test3a's full-screen >40% threshold. That is correct for test3a, which opens the mock gallery whose `LastPhotoActivity` ImageView uses `centerCrop` and fills ~100% of the screen. But the locked path opens `SecureViewerActivity`, which renders with `SubsamplingScaleImageView` and never calls `setMinimumScaleType(...)`, so it uses the library default `SCALE_TYPE_CENTER_INSIDE` (letterbox-fit, not crop). The capture is 1920x1080 (16:9 landscape; `MockCameraActivity.CAPTURE_WIDTH/HEIGHT`); on the Pixel 6 CI device (1080x2400 portrait) it fits to full width as a band of about 1080x608 px, only about 25% of the full screen, against `SecureViewer`'s solid-black background. A full-screen >40% assertion is geometrically unreachable on this render path even with a flawless overlay/session/launch chain.

### Why band width and solidity alone are not enough

The screen on view at the instant of the tap is **not** the lock screen or a black screen, it is the solid-green `MockCameraActivity` (the secure camera, foregrounded in step 2), which is the same `Rgb.GREEN` as the captured photo. So the relevant failure case is a **no-op tap**: if the overlay is not composited / not tappable over the secure-camera keyguard, `tapOverlay()` silently does nothing, `SecureViewerActivity` never opens, and that full-screen green stays up. A band-width check (>80%) and a within-bbox-solidity check (>80%) both pass on full-screen green, so those two checks alone let a no-op tap pass green, defeating the point of un-allowlisting the test.

### The discriminator is band height plus a black letterbox bar

The real SecureViewer render and the no-op mock-camera frame differ in **height**: the letterboxed render is ~25% of the screen height with black bars above and below, whereas leftover mock-camera green fills ~100%. The assertion now checks four geometry-justified properties:

1. The green bbox spans >80% of screen width (the letterbox fits to full width).
2. Coverage within that bbox is >80% (the photo is solid green).
3. The green bbox occupies <70% of the screen height (a letterbox, not a full-screen fill: ~25% real vs ~100% no-op, so 0.70 separates them with margin both ways).
4. The top 25% strip is <10% green (the upper black letterbox bar, positively confirming SecureViewer's background rather than leftover mock-camera green; with the ~25%-tall band centred, its top edge is at ~37% of the height, so the top-25% strip is entirely within the upper black bar).

An empty/black `SecureViewer`, or a tap that leaves the lock screen up, yields an empty green mask and fails 1 and 2. A no-op tap that leaves the full-screen mock-camera green up fails 3 and 4. The poll that gates the wait (`waitForGreenBand`) now requires the same letterbox geometry (full width AND height a minority of the screen), so it does not short-circuit on the pre-tap full-screen green and it predicts the assertion.

## CI-failure fix: actually launch the mock camera in the locked path

The first CI run of this rewrite (commit `857d383`) failed: `test5a` timed out at `waitForOverlayActive()` because the overlay never activated in the locked secure-camera path. Confirmed from the run's logcat, the cause was a test-fixture launch defect, not a product gap:

- `launchSecureCamera()` issued `am start -a android.media.action.STILL_IMAGE_CAMERA_SECURE` **without `-p $pcPackage`**, so the launch hit the system intent-resolver chooser (logcat shows a `ResolverListAdapter` entry and **no** `MockCameraActivity: CameraDevice.onOpened`) instead of `MockCameraActivity`. The activity never reached `onResume()`/`openCamera()`, so `onCameraUnavailable` never fired and the overlay's locked-activation bypass never ran. (The non-secure `launchPixelCamera()` never hit this; it already pins `-p $pcPackage`.)

Fix:

- `launchSecureCamera()` now targets the mock-camera package with `-p $pcPackage`, and reuses the bounded relaunch-until-overlay-active loop from issue #233 (extracted as `launchAndAwaitOverlay`), with a no-op retry hook so the keyguard the secure flow requires is left in place. The refactor is its own commit, separate from the behaviour change.
- This also makes `test4a` (the other caller) exercise a genuinely active overlay before its tap, where it previously passed incidentally. `test4a`'s code and assertion are untouched.

## Notes

- The instrumented E2E test runs on the emulator in CI; no manual verification step is added because CI already executes it.
- The androidTest Kotlin sources compile cleanly (`:app:compileDebugAndroidTestKotlin`), the pre-commit ktlint hook passes, `:app:testDebugUnitTest` passes, and `scripts/test_check_allowed_failures.py` still passes with the now-empty allowlist.
- No assertion or test requirement was loosened. The checks still require a substantial, solid green image to be displayed by real product code; they only stop asserting a full-screen fill that this render path geometrically cannot produce, and they now additionally reject the full-screen-green no-op case the earlier draft accepted.
