### PR TITLE
Replace stale #156 references in test4a comment with accurate tracking

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -311,14 +311,16 @@ class GalleryButtonVisualE2ETest {
      * `test3a` (which runs alphabetically before this test) captures a GREEN photo owned by
      * `com.google.android.GoogleCamera` (the mock camera). Earlier, [E2EFixture.clearCameraRoll]
      * could only delete rows owned by `com.gb4pc`, so that cross-package photo survived into
-     * this test and would have made the "empty gallery" assumption false once #156 was fixed.
+     * this test and would have made the "empty gallery" assumption false once the secure-camera
+     * overlay was fixed.
      * [E2EFixture.clearCameraRoll] now also runs a `content delete` shell command under the
      * `shell` UID, which removes rows owned by *any* package, so this test's `clearCameraRoll()`
      * genuinely empties the roll before the tap. The empty-gallery assumption therefore holds
-     * independently of `test3a`, and a failure here after #156 lands reflects the secure-camera
-     * path itself, not a leftover MediaStore row.
+     * independently of `test3a`, and a failure here reflects the secure-camera path itself,
+     * not a leftover MediaStore row.
      *
-     * Tracking issue: #156 — same as test5a. Do NOT skip, ignore, or quarantine this test.
+     * Tracking issue: #81 (locked-screen path: no new photos detected, SecureViewer shows black).
+     * Do NOT skip, ignore, or quarantine this test.
      */
     @Test
     fun test4a_secureCameraLockedEmptyGalleryNoGreen() {


### PR DESCRIPTION
Fixes #510

The `test4a_secureCameraLockedEmptyGalleryNoGreen` comment block contained three stale references to #156 as a pending blocker:

- "once #156 was fixed" (line 314)
- "after #156 lands" (line 318)
- "Tracking issue: #156 -- same as test5a." (line 321)

#156 is a plan-tracking checklist with all 7 phases already marked complete.
It was never a bug report for the secure-camera overlay regression.

This PR removes the two pending-blocker phrasings and replaces the
tracking-issue line with a reference to #81, the real open P1 product bug
(locked-screen path: no new photos detected, SecureViewer shows black).

This brings test4a in line with the correction already made to test5a in PR #501,
which replaced the same mis-cited #156 reference with the note "(a plan-tracking
checklist, not a bug report)."
