### PR TITLE
Rename label "for ai to do" to "orchestrate"

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -95,7 +95,7 @@ so the `labels` field is never sent and all existing labels remain.
 
 **Evidence (empirically verified 2026-05):**
 - `labels: ["planning needed"]` → correctly replaces ALL labels with just that one
-  (REPLACE semantics — "for ai to do" was removed in the same call). Non-empty arrays work.
+  (REPLACE semantics — "orchestrate" was removed in the same call). Non-empty arrays work.
 - `labels: []` → no change; all labels remain. Confirmed by a follow-up `get_labels` read.
 
 **Implication:** There is no way to remove *all* labels from an issue using

--- a/.github/workflows/enforce-mutually-exclusive-labels.yml
+++ b/.github/workflows/enforce-mutually-exclusive-labels.yml
@@ -8,7 +8,7 @@ name: Enforce mutually exclusive labels
 #   [p1, p2, p3]
 #   [needs verification, verified]
 #   [change requested, change done]
-#   [for ai to do, orchestrating]
+#   [orchestrate, orchestrating]
 #
 # Mutually exclusive prefix groups:
 #   c-a-*   (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -79,7 +79,7 @@ When you begin orchestrating a PR (the first thing you do once you have entered 
 
 | Remove label | Add label |
 |---|---|
-| `for ai to do` | `orchestrating` |
+| `orchestrate` | `orchestrating` |
 
 ## Model selection
 

--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -9,7 +9,7 @@ Mutually exclusive sets (fixed):
     [p1, p2, p3]
     [verification needed, verified]
     [changes requested, changes done]
-    [for ai to do, orchestrating]
+    [orchestrate, orchestrating]
 
 Mutually exclusive prefix groups (any label sharing a prefix is exclusive):
     c-a-*   (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
@@ -44,7 +44,7 @@ MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
     frozenset({"p1", "p2", "p3"}),
     frozenset({"verification needed", "verified"}),
     frozenset({"changes requested", "changes done"}),
-    frozenset({"for ai to do", "orchestrating"}),
+    frozenset({"orchestrate", "orchestrating"}),
 ]
 
 # Prefix-based exclusive groups: any two labels sharing a prefix are exclusive.

--- a/scripts/test_archive_stale_test_failures.py
+++ b/scripts/test_archive_stale_test_failures.py
@@ -209,7 +209,7 @@ class TestArchiveIssue(unittest.TestCase):
             42,
             "Old failure",
             _CUTOFF - timedelta(days=1),
-            ["test-failure", "ci", "for ai to do"],
+            ["test-failure", "ci", "orchestrate"],
         )
 
         with patch.object(astf, "gh_api") as mock_api:
@@ -220,7 +220,7 @@ class TestArchiveIssue(unittest.TestCase):
         self.assertIn("test-failure-archive", body["labels"])
         self.assertNotIn("test-failure", body["labels"])
         self.assertIn("ci", body["labels"])
-        self.assertIn("for ai to do", body["labels"])
+        self.assertIn("orchestrate", body["labels"])
 
     def test_archive_label_added_even_when_only_label(self):
         issue = _make_issue(

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -84,16 +84,16 @@ class TestFindConflictingSet(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("changes requested", result)
 
-    def test_for_ai_to_do_found(self):
-        result = emxl.find_conflicting_set("for ai to do")
+    def test_orchestrate_found(self):
+        result = emxl.find_conflicting_set("orchestrate")
         self.assertIsNotNone(result)
-        self.assertIn("for ai to do", result)
+        self.assertIn("orchestrate", result)
         self.assertIn("orchestrating", result)
 
     def test_orchestrating_found(self):
         result = emxl.find_conflicting_set("orchestrating")
         self.assertIsNotNone(result)
-        self.assertIn("for ai to do", result)
+        self.assertIn("orchestrate", result)
 
     def test_unknown_label_returns_none(self):
         self.assertIsNone(emxl.find_conflicting_set("bug"))
@@ -435,13 +435,13 @@ class TestMain(unittest.TestCase):
         delete_call = mock_api.call_args_list[1]
         self.assertIn("changes%20requested", delete_call[0][0])
 
-    def test_removes_for_ai_workflow_set(self):
+    def test_removes_orchestrate_workflow_set(self):
         with patch.dict(os.environ, {"ADDED_LABEL": "orchestrating", "ISSUE_NUMBER": "3"}):
             with patch.object(
                 emxl,
                 "gh_api",
                 side_effect=[
-                    self._make_issue_response(["for ai to do", "ci"]),
+                    self._make_issue_response(["orchestrate", "ci"]),
                     None,
                 ],
             ) as mock_api:
@@ -449,7 +449,7 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(result, 0)
         delete_call = mock_api.call_args_list[1]
-        self.assertIn("for%20ai%20to%20do", delete_call[0][0])
+        self.assertIn("orchestrate", delete_call[0][0])
 
     def test_exit_0_when_fetch_raises(self):
         with patch.object(emxl, "gh_api", side_effect=Exception("network error")):


### PR DESCRIPTION
## Summary

Rename the GitHub label "for ai to do" to "orchestrate" throughout the codebase, including code, documentation, and tests.

Fixes #498

## Changes

- Updated mutually exclusive label set in `enforce_mutually_exclusive_labels.py` and workflow
- Updated documentation in `dev_orchestration.md` and `.claude/environment.md`
- Updated test cases in `test_enforce_mutually_exclusive_labels.py` and `test_archive_stale_test_failures.py`

## Test plan

- All unit tests pass (64 tests in `test_enforce_mutually_exclusive_labels.py`, 24 tests in `test_archive_stale_test_failures.py`)
