### PR TITLE
Add Cannot-implement Reviewer signal and clarify abort triggers

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -129,10 +129,9 @@ The Orchestrator does not read or judge the Author's explanation; it only notes 
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
 - `LGTM`
-- `Changes requested`: in-repo changes the Author can make.
-  Use only when the feedback is addressable by editing the repository.
-- `LGTM; out-of-repo action required`: the code is correct and needs no in-repo change, but something outside the repository (e.g. renaming a label, updating external config) must happen before the PR can merge.
-  The Reviewer describes the specifics in a PR comment for the user to read.
+- `Changes requested`
+- `Cannot implement`: the coding phase cannot be completed--the requirements are incomplete, unattainable, or self-contradictory, or no code change could address the issue.
+  The Reviewer describes the specifics in a PR comment.
 
 Orchestrator-to-user terminal CI lines:
 - `CI cleared on PR #{N}.`
@@ -228,6 +227,7 @@ No-PR routing:
 
 ```text
   if Reviewer requested changes -> goto newAuthor
+  if Reviewer gave `Cannot implement` -> escalate to user; stop
   if Reviewer gave LGTM:
     The issue is resolved without a code change, and the Reviewer agreed.
     Do NOT launch the CI Monitor and do NOT dispatch a Verification Planner; both presuppose a PR.
@@ -240,8 +240,8 @@ PR routing (Monitor loop):
 
 ```text
   if Reviewer requested changes -> goto newAuthor
-  if Reviewer gave `LGTM; out-of-repo action required` -> escalate to user; stop
-    (do NOT launch the CI Monitor and do NOT route to a new Author round; the Reviewer's PR comment describes what the user must do)
+  if Reviewer gave `Cannot implement` -> escalate to user; stop
+    (do NOT route to a new Author round; the Reviewer's PR comment describes why)
   if Reviewer gave LGTM:
     Orchestrator launches a Monitor tool call running `python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000). Record the task ID returned by the Monitor tool call for use in silentVanish recovery, and clear the silentVanish re-launch flag (this original launch is not a re-launch).
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -383,7 +383,12 @@ If the stall cannot be explained by a known recoverable cause (e.g., a Monitor t
 
 ## When to abort
 
-Stop the automated cycle and escalate to the User **after four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)--the fallback when the loop stalls but neither party has explicitly given up.
+Stop the automated cycle and escalate to the User in either of these cases:
+
+- A sub-agent emits `Cannot implement` (see the routing fences above): escalate immediately, without waiting for further rounds.
+  This covers a Programmer that gives up or an issue that cannot be solved as stated; the Reviewer confirms it by emitting `Cannot implement`.
+- The Programmer / Reviewer loop runs **four rounds** without reaching consensus (unless the user gave a different threshold).
+  This is the fallback for a loop that stalls in disagreement; once four rounds are reached the cap applies unconditionally, even when both parties are still actively disputing.
 
 ## Concluding PR orchestration
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -382,10 +382,7 @@ If the stall cannot be explained by a known recoverable cause (e.g., a Monitor t
 
 ## When to abort
 
-Stop the automated cycle and escalate to the User in these cases:
-
-- **If the Programmer gives up** or claims the issue cannot be solved as stated--escalate immediately, without waiting for additional rounds.
-- **After four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)--the fallback when the loop stalls but neither party has explicitly given up.
+Stop the automated cycle and escalate to the User **after four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)--the fallback when the loop stalls but neither party has explicitly given up.
 
 ## Concluding PR orchestration
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -128,8 +128,9 @@ When the Author emits `No PR; position posted on the issue`, dispatch the Review
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
-- `LGTM`
-- `Changes requested`
+- `LGTM`: the committed changes are correct and complete.
+  If extra work outside the repo is require before merging, it should be explained clearly in a PR comment.
+- `Changes requested`: the Author is asked to take another turn, to correct or complete its prior work.
 - `Cannot implement`: the coding phase cannot be completed--the requirements are incomplete, unattainable, or self-contradictory, or no code change could address the issue.
   The Reviewer describes the specifics in a PR comment.
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -129,10 +129,10 @@ The Orchestrator does not read or judge the Author's explanation; it only notes 
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
 - `LGTM`: the committed changes are correct and complete.
-  If extra work outside the repo is require before merging, it should be explained clearly in a PR comment.
+  If extra work outside the repo is required before merging, it should be explained clearly in a PR comment.
 - `Changes requested`: the Author is asked to take another turn, to correct or complete its prior work.
 - `Cannot implement`: the coding phase cannot be completed--the requirements are incomplete, unattainable, or self-contradictory, or no code change could address the issue.
-  The Reviewer describes the specifics in a PR comment.
+  The Reviewer describes the specifics in a PR comment, or in an issue comment on the no-PR path (where there is no PR to comment on).
 
 Orchestrator-to-user terminal CI lines:
 - `CI cleared on PR #{N}.`

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -129,7 +129,10 @@ The Orchestrator does not read or judge the Author's explanation; it only notes 
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
 - `LGTM`
-- `Changes requested`
+- `Changes requested`: in-repo changes the Author can make.
+  Use only when the feedback is addressable by editing the repository.
+- `LGTM; out-of-repo action required`: the code is correct and needs no in-repo change, but something outside the repository (e.g. renaming a label, updating external config) must happen before the PR can merge.
+  The Reviewer describes the specifics in a PR comment for the user to read.
 
 Orchestrator-to-user terminal CI lines:
 - `CI cleared on PR #{N}.`
@@ -237,6 +240,8 @@ PR routing (Monitor loop):
 
 ```text
   if Reviewer requested changes -> goto newAuthor
+  if Reviewer gave `LGTM; out-of-repo action required` -> escalate to user; stop
+    (do NOT launch the CI Monitor and do NOT route to a new Author round; the Reviewer's PR comment describes what the user must do)
   if Reviewer gave LGTM:
     Orchestrator launches a Monitor tool call running `python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000). Record the task ID returned by the Monitor tool call for use in silentVanish recovery, and clear the silentVanish re-launch flag (this original launch is not a re-launch).
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -241,8 +241,7 @@ PR routing (Monitor loop):
 
 ```text
   if Reviewer requested changes -> goto newAuthor
-  if Reviewer gave `Cannot implement` -> escalate to user; stop
-    (do NOT route to a new Author round; the Reviewer's PR comment describes why)
+  if Reviewer gave `Cannot implement` -> escalate to user; stop (do NOT route to a new Author round; leave the PR open for the user to close; the Reviewer's PR comment describes why)
   if Reviewer gave LGTM:
     Orchestrator launches a Monitor tool call running `python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000). Record the task ID returned by the Monitor tool call for use in silentVanish recovery, and clear the silentVanish re-launch flag (this original launch is not a re-launch).
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -379,8 +379,8 @@ If the stall cannot be explained by a known recoverable cause (e.g., a Monitor t
 
 Stop the automated cycle and escalate to the User in these cases:
 
-- **After four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)
-- **If the Programmer gives up** or claims the issue cannot be solved as stated
+- **If the Programmer gives up** or claims the issue cannot be solved as stated--escalate immediately, without waiting for additional rounds.
+- **After four rounds** of the Programmer / Reviewer loop not reaching consensus (unless the user gave a different threshold)--the fallback when the loop stalls but neither party has explicitly given up.
 
 ## Concluding PR orchestration
 


### PR DESCRIPTION
Improvements to `agents/dev_orchestration.md`, surfaced while orchestrating issue #498 / PR #521 (where the loop spun because the Reviewer had no clean way to say "the code is right but coding cannot finish this").

## Changes

### New Reviewer signal: `Cannot implement`

The Reviewer's outcome vocabulary was `LGTM` / `Changes requested` only.
When the coding phase cannot be completed (requirements incomplete, unattainable, or self-contradictory, or no code change could address the issue), `Changes requested` was misleading: it implies the Author can fix it with another in-repo round and loops the Orchestrator back pointlessly.

Added `Cannot implement`, routed to immediate user escalation (not a new Author round) in both the PR and no-PR routing fences.
Also gave each outcome an explicit definition so `LGTM` and `Changes requested` are unambiguous.

### Clearer abort triggers

The "When to abort" section now lists both escalation paths: immediate escalation when a sub-agent emits `Cannot implement`, and the four-round cap as the fallback for a stalled loop (stated to apply unconditionally once reached, even mid-dispute).

### Review fixes

- Pointed the `Cannot implement` explanation at an issue comment on the no-PR path (where there is no PR to comment on).
- On `Cannot implement` with an open PR, the PR is left for the user to close, matching the existing "the Orchestrator does not close it" pattern.
- Inlined the routing parenthetical so it unambiguously belongs to the `Cannot implement` branch.
- Fixed an `is require` -> `is required` typo.

## Test plan

- [x] Verify the changed sections read clearly in context (no automated test covers doc prose).