### PR TITLE
Remove stray "no" from code block in pr_participation.md

### DIFF
--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -23,7 +23,7 @@
 
   (This is the PR-path mechanism. If the Author opened no PR, see "Reviewing an Author who declined to open a PR" below.)
 
-  ``` no
+  ```
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
   post review: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```


### PR DESCRIPTION
## Summary

Removed a stray "no" language tag from a markdown code fence in pr_participation.md. The fence on line 26 had an errant "no" that served no purpose and made the code block's formatting incorrect.

## Test plan

- Verify the markdown renders correctly without the invalid language tag
- Confirm the code block content is preserved and readable
