### PR TITLE
Reserve CI test-failure issue body for an aggregate summary

### DIFF
--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -137,6 +137,47 @@ def _find_ocr_text(directory: Path, class_name: str, method_name: str) -> str | 
     return None
 
 
+# Workflow file that runs the test suites and files these issues. Used to link
+# the "Job" line in the issue summary body to the workflow definition.
+_WORKFLOW_FILE_PATH = ".github/workflows/build.yml"
+
+
+def make_summary_body(
+    failure: FailedTest,
+    github_server_url: str,
+    github_repository: str,
+    workflow_run_branch: str,
+) -> str:
+    """Build the aggregate summary body for a test-failure issue.
+
+    The issue description is reserved for information that applies to the whole
+    group of failures accumulated over time, not to any single run.
+    Per-run failure details (timestamp, message, stack trace) live in comments
+    instead, including the first occurrence (issue #504).
+
+    The "Job" field links to the workflow file that runs the suite and files
+    these issues.
+    The link targets the workflow on the failing branch when known, so it points
+    at the version that produced the failure.
+    """
+    ref = workflow_run_branch or "HEAD"
+    workflow_url = (
+        f"{github_server_url}/{github_repository}/blob/{ref}/{_WORKFLOW_FILE_PATH}"
+    )
+
+    return f"""\
+# Automated test failure
+
+| Field | Value |
+|-------|-------|
+| Job | [{failure.suite_label}]({workflow_url}) |
+| Class | `{failure.class_name}` |
+| Test | `{failure.method_name}` |
+
+Failed runs will be added as comments on this ticket over time.
+"""
+
+
 def make_issue_body(
     failure: FailedTest,
     directory: Path,
@@ -346,6 +387,7 @@ def process_failure(
 
     short_sha = sha[:7] if sha else "unknown"
     ts_str = timestamp.strftime("%Y-%m-%d %H:%M UTC")
+    comment_body = f"### Failed on {short_sha} @ {ts_str}\n\n{body}"
 
     found = find_existing_issue(token, repository, failure.class_name, failure.method_name)
     if found is not None:
@@ -357,12 +399,21 @@ def process_failure(
         )
         if state == "closed":
             reopen_issue(token, repository, existing)
-        comment_body = f"### Failed on {short_sha} @ {ts_str}\n\n{body}"
         add_issue_comment(token, repository, existing, comment_body)
     else:
-        issue_num = create_issue(token, repository, title, body)
+        # Reserve the issue body for the aggregate summary (issue #504); even the
+        # first occurrence's per-run details go into a comment, matching the
+        # treatment of subsequent failures above.
+        summary_body = make_summary_body(
+            failure=failure,
+            github_server_url=github_server_url,
+            github_repository=repository,
+            workflow_run_branch=workflow_run_branch,
+        )
+        issue_num = create_issue(token, repository, title, summary_body)
         if issue_num is not None:
             print(f"  Created issue #{issue_num}: {title}", file=sys.stderr)
+            add_issue_comment(token, repository, issue_num, comment_body)
         else:
             print(f"  Failed to create issue for: {title}", file=sys.stderr)
 

--- a/scripts/test_file_test_failure_issues.py
+++ b/scripts/test_file_test_failure_issues.py
@@ -341,6 +341,69 @@ class TestMakeIssueBody(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# make_summary_body tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSummaryBody(unittest.TestCase):
+    def setUp(self):
+        self.failure = ftfi.FailedTest(
+            class_name="com.example.BarTest",
+            method_name="testD",
+            failure_message="AssertionError: Expected true",
+            stack_trace="Expected true but was false",
+            suite_label="Unit Tests",
+            artifact_name="unit-test-results",
+        )
+
+    def _make_summary(self, **kwargs):
+        defaults = dict(
+            failure=self.failure,
+            github_server_url="https://github.com",
+            github_repository="aunger/gallery-button-for-pixel-camera",
+            workflow_run_branch="main",
+        )
+        defaults.update(kwargs)
+        return ftfi.make_summary_body(**defaults)
+
+    def test_has_automated_test_failure_heading(self):
+        self.assertIn("# Automated test failure", self._make_summary())
+
+    def test_contains_suite_label_as_job(self):
+        self.assertIn("Unit Tests", self._make_summary())
+
+    def test_contains_class_and_method(self):
+        body = self._make_summary()
+        self.assertIn("com.example.BarTest", body)
+        self.assertIn("testD", body)
+
+    def test_links_job_to_workflow_file_on_branch(self):
+        body = self._make_summary(workflow_run_branch="feature/foo")
+        self.assertIn(
+            "https://github.com/aunger/gallery-button-for-pixel-camera/blob/feature/foo/.github/workflows/build.yml",
+            body,
+        )
+
+    def test_workflow_link_falls_back_to_head_without_branch(self):
+        body = self._make_summary(workflow_run_branch="")
+        self.assertIn("/blob/HEAD/.github/workflows/build.yml", body)
+
+    def test_mentions_comments_aggregation(self):
+        self.assertIn(
+            "Failed runs will be added as comments on this ticket over time.",
+            self._make_summary(),
+        )
+
+    def test_excludes_per_run_details(self):
+        """The summary body must not contain timestamp, stack trace, or run-specific info."""
+        body = self._make_summary()
+        self.assertNotIn("### Stack trace", body)
+        self.assertNotIn("### Failure message", body)
+        self.assertNotIn("Detected at", body)
+        self.assertNotIn("### Failed on", body)
+
+
+# ---------------------------------------------------------------------------
 # _find_ocr_text tests
 # ---------------------------------------------------------------------------
 
@@ -541,6 +604,38 @@ class TestProcessFailure(unittest.TestCase):
         mock_create.return_value = 77
         self._call_process_failure()
         mock_create.assert_called_once()
+        # The first occurrence's per-run details go into a comment too (issue #504).
+        mock_comment.assert_called_once()
+        self.assertEqual(mock_comment.call_args[0][2], 77)
+        comment_body = mock_comment.call_args[0][3]
+        self.assertIn("### Failed on", comment_body)
+
+    @patch("file_test_failure_issues.add_issue_comment")
+    @patch("file_test_failure_issues.create_issue")
+    @patch("file_test_failure_issues.find_existing_issue")
+    def test_new_issue_body_is_aggregate_summary_not_run_details(
+        self, mock_find, mock_create, mock_comment
+    ):
+        """The created issue body is the aggregate summary, not per-run details (issue #504)."""
+        mock_find.return_value = None
+        mock_create.return_value = 77
+        self._call_process_failure()
+        created_body = mock_create.call_args[0][3]
+        self.assertIn("# Automated test failure", created_body)
+        self.assertIn("Failed runs will be added as comments", created_body)
+        # Per-run details (timestamp, sha, stack trace) must NOT be in the body.
+        self.assertNotIn("### Failed on", created_body)
+        self.assertNotIn(_FIXED_SHA[:7], created_body)
+        self.assertNotIn("### Stack trace", created_body)
+
+    @patch("file_test_failure_issues.add_issue_comment")
+    @patch("file_test_failure_issues.create_issue")
+    @patch("file_test_failure_issues.find_existing_issue")
+    def test_no_comment_when_issue_creation_fails(self, mock_find, mock_create, mock_comment):
+        """If the issue can't be created, don't try to comment on a nonexistent issue."""
+        mock_find.return_value = None
+        mock_create.return_value = None  # creation failed
+        self._call_process_failure()
         mock_comment.assert_not_called()
 
     @patch("file_test_failure_issues.reopen_issue")


### PR DESCRIPTION
🤖 Author

Fixes #504.

## Problem

For CI auto-filed issues (issues labeled `test-failure`), the issue body (description) held the details of the *first* failing run, while every subsequent failure was added as a comment. That left the description space unavailable for summary or aggregate information about the group of failures.

## Change

The issue body is now reserved for summary and aggregate information that applies to the whole group of failures accumulated over time. Even the first occurrence's per-run details now go into a comment, matching how subsequent failures are already handled.

- New `make_summary_body` builds a short aggregate summary for the issue description:
  - `Job`: the suite label, linked to the workflow file (`build.yml`) on the failing branch.
  - `Class`: the test class / suite category.
  - `Test`: the test case name.
  - A note: "Failed runs will be added as comments on this ticket over time."
- `process_failure` now, on first occurrence, creates the issue with this summary body and then immediately posts the per-run failure details (timestamp, message, stack trace) as a comment, identical to the comment a duplicate failure would receive.
- Subsequent failures continue to add comments only (unchanged).

The existing `make_issue_body` is retained and still produces the per-run detail block used for the comments.

## Notes

- The exact summary template in the issue is an example ("such as this"); the implementation uses the data the filer actually has (suite label, class, method) and links the `Job` line to the workflow file. The CI step name was not available as input to the filer, so it is not included.

## Tests

- Added `TestMakeSummaryBody` covering the summary structure, the workflow-file link (branch and `HEAD` fallback), and the exclusion of per-run details from the body.
- Updated `test_creates_issue_when_no_duplicate` to assert that a comment is now posted on creation, and added `test_new_issue_body_is_aggregate_summary_not_run_details` and `test_no_comment_when_issue_creation_fails`.

*Modified test `test_creates_issue_when_no_duplicate` to expect a comment on first occurrence instead of asserting no comment is posted, because the first occurrence's per-run details now go into a comment per issue #504.*

All 78 tests in `scripts/test_file_test_failure_issues.py` pass locally.

🦀

