### PR TITLE
Wire git fetch into SessionStart and PostToolUse hooks

### DIFF
--- a/.claude/hooks/post-tool-use-fetch.sh
+++ b/.claude/hooks/post-tool-use-fetch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# GB4PC -- Claude Code PostToolUse hook: git fetch after Agent tool calls.
+#
+# Configured in .claude/settings.json under PostToolUse with a matcher on
+# tool_name == "Agent".  Runs once each time a sub-agent finishes, so the
+# parent session sees any commits the sub-agent pushed before it exited.
+#
+# Failures are non-fatal: a warning is printed but the exit code is always 0
+# so the session continues even if the network is temporarily unavailable.
+
+set -uo pipefail
+
+# Resolve the repo root from the script's own path so this hook works in
+# worktrees as well as the main checkout.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+git -C "$REPO_ROOT" fetch --prune --quiet \
+    && echo "[post-tool-use] git fetch complete" \
+    || echo "[post-tool-use] warning: git fetch failed (offline? -- continuing)"
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -21,7 +21,7 @@ GRADLE_INIT="$HOME/.gradle/init.d/proxy-auth.gradle"
 
 echo "[session-start] GB4PC environment setup…"
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 0 — Fix JAVA_TOOL_OPTIONS proxy / DNS issue.
 #
 # The container's JAVA_TOOL_OPTIONS lists *.google.com and *.googleapis.com in
@@ -30,7 +30,7 @@ echo "[session-start] GB4PC environment setup…"
 # those entries makes Java route them through the proxy, the same way wget/curl
 # already do.  The fixed value is exported via $CLAUDE_ENV_FILE so it persists
 # for all subsequent tool invocations in this session.
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 if echo "${JAVA_TOOL_OPTIONS:-}" | grep -qE '\*\.(google|googleapis)\.com'; then
     # Strip each entry independently — order in the container value is not guaranteed.
     FIXED_JTO=$(echo "$JAVA_TOOL_OPTIONS" \
@@ -46,12 +46,12 @@ else
     echo "[session-start] Step 0: JAVA_TOOL_OPTIONS already clean — skip"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 1 — Gradle proxy authenticator.
 #
 # Java 9+ no longer auto-registers http.proxyUser/proxyPassword as an
 # Authenticator, so proxied HTTPS CONNECT tunnels get HTTP 407.
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 if [[ -f "$GRADLE_INIT" ]]; then
     echo "[session-start] Step 1: Gradle proxy-auth init.d present — skip"
 else
@@ -74,9 +74,9 @@ GROOVY
     echo "[session-start] Step 1: Gradle proxy-auth init.d written"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 2a — Android SDK command-line tools.
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 if [[ -x "$SDKMANAGER" ]]; then
     echo "[session-start] Step 2a: sdkmanager present — skip"
 else
@@ -103,9 +103,9 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]] \
         >> "$CLAUDE_ENV_FILE"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 2b — SDK licenses.
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 if [[ -f "$ANDROID_HOME_DIR/licenses/android-sdk-license" ]]; then
     echo "[session-start] Step 2b: SDK licenses present — skip"
 else
@@ -118,10 +118,10 @@ else
     echo "[session-start] Step 2b: licenses written"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 2c — SDK packages (only installs what is missing).
 # build-tools;34.0.0 is required by AGP 8.7.3 even though the project targets 35.
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 declare -A SDK_PACKAGES=(
     ["platforms;android-35"]="$ANDROID_HOME_DIR/platforms/android-35"
     ["build-tools;35.0.0"]="$ANDROID_HOME_DIR/build-tools/35.0.0"
@@ -146,9 +146,9 @@ else
     echo "[session-start] Step 2c: all SDK packages present — skip"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 # STEP 3 — Linting tools (pre-commit framework + ktlint).
-# ─────────────────────────────────────────────────────────────────────────────
+# ───────────────────────────────────────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LOCAL_BIN="$HOME/.local/bin"
 mkdir -p "$LOCAL_BIN"
@@ -197,5 +197,18 @@ else
     (cd "$REPO_ROOT" && "$PRECOMMIT_BIN" install)
     echo "[session-start] Step 3c: pre-commit hook wired"
 fi
+
+# ───────────────────────────────────────────────────────────────────────────────
+# STEP 4 -- Fetch remote refs.
+#
+# Keep local knowledge of the remote up to date at the start of every session.
+# git fetch is always safe (it never modifies the working tree), so no skip
+# guard is needed.  Failures are logged as warnings rather than aborting the
+# hook, so a transient network outage does not prevent the session from starting.
+# ───────────────────────────────────────────────────────────────────────────────
+echo "[session-start] Step 4: git fetch..."
+git -C "$REPO_ROOT" fetch --prune --quiet \
+    && echo "[session-start] Step 4: fetch complete" \
+    || echo "[session-start] Step 4: warning: git fetch failed (offline? -- continuing)"
 
 echo "[session-start] Complete. ANDROID_HOME=$ANDROID_HOME"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use-fetch.sh"
+          }
+        ]
+      }
     ]
   },
   "attribution": {

--- a/scripts/test_post_tool_use_fetch.sh
+++ b/scripts/test_post_tool_use_fetch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test_post_tool_use_fetch.sh -- Shell-based tests for
+# .claude/hooks/post-tool-use-fetch.sh.
+#
+# The hook runs "git fetch --prune --quiet" in the repo root.
+# These tests use a fake "git" on PATH to verify behaviour without
+# requiring a live network or a real remote.
+#
+# Covers:
+#   (a) Invokes git with the expected arguments (-C <repo> fetch --prune --quiet)
+#   (b) Exits 0 when git fetch succeeds
+#   (c) Exits 0 even when git fetch fails (offline-safe -- never aborts session)
+#   (d) Prints a warning line when git fetch fails
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../.claude/hooks/post-tool-use-fetch.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Create a temp dir for fake git binaries and a scratch git-args capture file.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GIT_ARGS_FILE="$TMP_DIR/git_args"
+
+# -- (a) & (b) Verify git is called with expected args and hook exits 0 --------
+echo ""
+echo "=== (a)+(b) git called with correct args; exits 0 on success ==="
+
+# Fake git: record args, succeed.
+cat > "$TMP_DIR/git" << 'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$GIT_ARGS_FILE"
+exit 0
+EOF
+# GIT_ARGS_FILE must be visible inside the fake git.
+export GIT_ARGS_FILE
+chmod +x "$TMP_DIR/git"
+
+OUTPUT=$(PATH="$TMP_DIR:$PATH" bash "$HOOK" 2>&1)
+EXIT_CODE=$?
+
+RECORDED_ARGS="$(cat "$GIT_ARGS_FILE" 2>/dev/null || true)"
+# Expected: "-C <some-path> fetch --prune --quiet"
+if echo "$RECORDED_ARGS" | grep -qE '^-C .+ fetch --prune --quiet$'; then
+    pass "(a) git called with -C <path> fetch --prune --quiet"
+else
+    fail "(a) unexpected git args: '$RECORDED_ARGS'"
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "(b) exit 0 on success"
+else
+    fail "(b) expected exit 0, got $EXIT_CODE"
+fi
+
+# -- (c) & (d) Verify hook exits 0 even when git fetch fails ------------------
+echo ""
+echo "=== (c)+(d) exits 0 and prints warning when git fetch fails ==="
+
+rm -f "$GIT_ARGS_FILE"
+
+# Fake git: succeed for non-fetch subcommands (none expected here), fail for fetch.
+cat > "$TMP_DIR/git" << 'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$GIT_ARGS_FILE"
+# Fail when called as: git -C <path> fetch ...
+if [[ "$*" == *"fetch"* ]]; then
+    exit 1
+fi
+exit 0
+EOF
+chmod +x "$TMP_DIR/git"
+
+OUTPUT=$(PATH="$TMP_DIR:$PATH" bash "$HOOK" 2>&1)
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "(c) exit 0 even when git fetch fails"
+else
+    fail "(c) expected exit 0 on fetch failure, got $EXIT_CODE"
+fi
+
+if echo "$OUTPUT" | grep -qi "warning"; then
+    pass "(d) warning message printed on fetch failure"
+else
+    fail "(d) no warning message found in output: '$OUTPUT'"
+fi
+
+# -- Summary ------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
🤖 Author

Fixes #496

## What changed

**SessionStart (`session-start.sh`):** Added Step 4 -- a `git fetch --prune --quiet` at the end of the existing session-start hook.
This ensures the local repo's remote-tracking refs are current from the moment a Claude Code for Web session begins.

**PostToolUse (new `post-tool-use-fetch.sh` + `settings.json`):** Added a new PostToolUse hook matched to the `Agent` tool.
Every time a sub-agent finishes, this hook runs `git fetch --prune --quiet` so the parent session immediately sees any commits the sub-agent pushed.

Both hooks treat fetch failures as non-fatal: they print a warning and exit 0, so a transient network outage cannot block a session from starting or continuing.

## Test plan

- `scripts/test_post_tool_use_fetch.sh` (new, 4 cases): verifies the hook passes the correct arguments to git, exits 0 on success, exits 0 on fetch failure, and prints a warning on failure.
- No automated test for the `session-start.sh` step (consistent with the existing untested steps in that script, which depend on a full Android/remote environment).
- [ ] Manual: open a new Claude Code for Web session and confirm "[session-start] Step 4: fetch complete" appears in the hook output.
