### PR TITLE
Self-reschedule MediaStore-commit retry until the thumbnail commits

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -22,6 +22,7 @@ import com.gb4pc.e2e.visual.ColorMatch
 import com.gb4pc.e2e.visual.Rgb
 import com.gb4pc.e2e.visual.Screenshot
 import com.gb4pc.service.OverlayService
+import com.gb4pc.viewer.SessionTracker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import java.util.concurrent.CountDownLatch
@@ -420,6 +421,36 @@ class E2EFixture(
                         "(even after MediaScannerConnection.scanFile fallback)",
                 )
             }
+        }
+    }
+
+    /**
+     * Waits for the current secure session to contain at least one media item.
+     *
+     * The [OverlayService]'s MediaStore [android.database.ContentObserver] calls
+     * [SessionTracker.addMedia] asynchronously after a photo is committed.
+     * [captureOnePhoto] returns as soon as the MediaStore row exists, but the
+     * ContentObserver's [android.database.ContentObserver.onChange] may not have
+     * fired yet. Calling this helper after [captureOnePhoto] ensures the session is
+     * populated before the caller acts on it (e.g. tapping the overlay to open
+     * SecureViewer), avoiding a race that causes SecureViewer to open with an empty
+     * session.
+     *
+     * @param timeoutMs Maximum time to wait. Default is 5 s, which is well above the
+     *   service's 500 ms ContentObserver retry delay.
+     * @throws AssertionError if the session remains empty after [timeoutMs].
+     */
+    fun waitForSessionMedia(timeoutMs: Long = 5_000L) {
+        val appeared =
+            waitForCondition(timeoutMs) {
+                SessionTracker.instance.getSessionMedia().isNotEmpty()
+            }
+        if (!appeared) {
+            fail(
+                "waitForSessionMedia(): session media did not appear within ${timeoutMs}ms. " +
+                    "The ContentObserver may not have fired, or the captured photo was not " +
+                    "added to the active secure session.",
+            )
         }
     }
 

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -434,6 +434,11 @@ class GalleryButtonVisualE2ETest {
         fixture.launchSecureCamera()
         fixture.waitForOverlayActive()
         fixture.captureOnePhoto() // GREEN JPEG captured during the secure session
+        // Wait for the session to contain the photo before tapping: captureOnePhoto() returns
+        // as soon as the MediaStore row exists, but the OverlayService ContentObserver processes
+        // it asynchronously. Without this gate the tap can race ahead of the observer, leaving
+        // SecureViewer with an empty session (issue #509 / PR #527 race).
+        fixture.waitForSessionMedia()
 
         val s1 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s1, "5a-s1.png")

--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -53,6 +53,12 @@ object Constants {
     // Retry delay when ContentObserver fires before MediaStore commits the new item (IS_PENDING race)
     const val MEDIA_OBSERVER_RETRY_MS = 500L
 
+    // Maximum number of MediaStore-commit retries per ContentObserver onChange event. The
+    // IS_PENDING -> 0 transition can take longer than a single MEDIA_OBSERVER_RETRY_MS interval
+    // (or never fire while locked), so the retry re-schedules itself up to this many times instead
+    // of giving up after one attempt. Total retry budget = MEDIA_OBSERVER_RETRY_MS x this value.
+    const val MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS = 5
+
     // Snackbar undo timeout
     const val UNDO_TIMEOUT_MS = 5000L
 

--- a/app/src/main/java/com/gb4pc/service/MediaObserverRetry.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaObserverRetry.kt
@@ -16,34 +16,55 @@ import com.gb4pc.Constants
  * items. On some devices/firmware the second callback (IS_PENDING → 0) is not delivered
  * reliably, particularly on locked devices.
  *
- * [onChange] therefore always schedules a single delayed retry that re-runs the query after
- * [retryDelayMs] ms. Burst-mode shots cancel-and-reschedule, so at most one retry is in flight
- * at any time.
+ * [onChange] therefore re-runs the query after [retryDelayMs] ms whenever the result so far is
+ * not yet successful. Because the commit can land later than a single [retryDelayMs] window (or
+ * the IS_PENDING -> 0 callback may never arrive while locked), the retry re-schedules itself up
+ * to [maxAttempts] times per onChange event instead of giving up after one attempt. Each fresh
+ * onChange is a new commit event, so it cancels any in-flight retry and resets the attempt budget.
+ * Burst-mode shots therefore cancel-and-reschedule, so at most one retry is in flight at any time.
  *
  * ## Generic in T
  *
  * [T] is whatever the query returns (e.g. `List<MediaItem>` for the session observer, or
- * `MediaItem?` for the overlay-thumbnail observer). [handleResult] receives the query result
- * along with a flag indicating whether this call is the initial one or the retry, so callers
- * can log/dedup as appropriate.
+ * `MediaItem?` for the overlay-thumbnail observer). [isSuccess] tells the helper when a result is
+ * good enough to stop retrying (e.g. a non-null item, or a non-empty list). [handleResult]
+ * receives the query result along with a flag indicating whether this call is the initial one or
+ * the retry, so callers can log/dedup as appropriate.
  */
 class MediaObserverRetry<T>(
     private val handler: Handler,
     private val query: (startMs: Long) -> T,
+    private val isSuccess: (result: T) -> Boolean,
     private val handleResult: (result: T, isRetry: Boolean) -> Unit,
     private val retryDelayMs: Long = Constants.MEDIA_OBSERVER_RETRY_MS,
+    private val maxAttempts: Int = Constants.MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS,
 ) {
     // At most one pending retry runnable at a time; cancelled and rescheduled on each onChange.
     private var pendingRetry: Runnable? = null
 
-    fun onChange(startMs: Long) {
-        handleResult(query(startMs), false)
+    // Retries scheduled for the current onChange event, capped at maxAttempts.
+    private var attempts = 0
 
+    fun onChange(startMs: Long) {
+        // Fresh observer event: cancel any in-flight retry and reset the budget.
         pendingRetry?.let { handler.removeCallbacks(it) }
+        pendingRetry = null
+        attempts = 0
+
+        val result = query(startMs)
+        handleResult(result, false)
+        if (!isSuccess(result)) scheduleRetry(startMs)
+    }
+
+    private fun scheduleRetry(startMs: Long) {
+        if (attempts >= maxAttempts) return
+        attempts++
         val runnable =
             Runnable {
                 pendingRetry = null
-                handleResult(query(startMs), true)
+                val result = query(startMs)
+                handleResult(result, true)
+                if (!isSuccess(result)) scheduleRetry(startMs)
             }
         pendingRetry = runnable
         handler.postDelayed(runnable, retryDelayMs)

--- a/app/src/main/java/com/gb4pc/service/MediaObserverRetry.kt
+++ b/app/src/main/java/com/gb4pc/service/MediaObserverRetry.kt
@@ -2,6 +2,7 @@ package com.gb4pc.service
 
 import android.os.Handler
 import com.gb4pc.Constants
+import com.gb4pc.util.DebugLog
 
 /**
  * Generic "ContentObserver onChange + delayed retry" scaffold used by the session-media and
@@ -27,7 +28,9 @@ import com.gb4pc.Constants
  *
  * [T] is whatever the query returns (e.g. `List<MediaItem>` for the session observer, or
  * `MediaItem?` for the overlay-thumbnail observer). [isSuccess] tells the helper when a result is
- * good enough to stop retrying (e.g. a non-null item, or a non-empty list). [handleResult]
+ * good enough to stop retrying: for the thumbnail observer, `{ it != null }` stops once the item
+ * commits; for the session observer, `{ false }` retries unconditionally, because a non-empty
+ * list may reflect only previously-committed items while the new shot is still pending. [handleResult]
  * receives the query result along with a flag indicating whether this call is the initial one or
  * the retry, so callers can log/dedup as appropriate.
  */
@@ -57,7 +60,10 @@ class MediaObserverRetry<T>(
     }
 
     private fun scheduleRetry(startMs: Long) {
-        if (attempts >= maxAttempts) return
+        if (attempts >= maxAttempts) {
+            DebugLog.log("MediaObserverRetry: retry budget exhausted after $attempts attempts")
+            return
+        }
         attempts++
         val runnable =
             Runnable {

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -95,6 +95,7 @@ class OverlayService : Service() {
                 handler = handler,
                 retryDelayMs = mediaRetryDelayMs,
                 query = ::queryAllMedia,
+                isSuccess = { items -> items.isNotEmpty() },
                 handleResult = { items, isRetry ->
                     items.forEach { item ->
                         SessionTracker.instance.addMedia(item)
@@ -117,6 +118,7 @@ class OverlayService : Service() {
                 handler = handler,
                 retryDelayMs = mediaRetryDelayMs,
                 query = ::queryLatestMedia,
+                isSuccess = { item -> item != null },
                 handleResult = { item, isRetry ->
                     if (item != null) {
                         overlayManager.showLatestPhotoThumbnail(item.uri)
@@ -127,7 +129,7 @@ class OverlayService : Service() {
                                 "Thumbnail updated: ${item.uri}"
                             },
                         )
-                    } else if (!isRetry) {
+                    } else {
                         DebugLog.log("Thumbnail query returned null — scheduling retry in ${mediaRetryDelayMs}ms")
                     }
                 },

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -95,7 +95,7 @@ class OverlayService : Service() {
                 handler = handler,
                 retryDelayMs = mediaRetryDelayMs,
                 query = ::queryAllMedia,
-                isSuccess = { items -> items.isNotEmpty() },
+                isSuccess = { false },
                 handleResult = { items, isRetry ->
                     items.forEach { item ->
                         SessionTracker.instance.addMedia(item)
@@ -130,7 +130,7 @@ class OverlayService : Service() {
                             },
                         )
                     } else {
-                        DebugLog.log("Thumbnail query returned null — scheduling retry in ${mediaRetryDelayMs}ms")
+                        DebugLog.log("Thumbnail query returned null")
                     }
                 },
             )

--- a/app/src/test/java/com/gb4pc/service/MediaObserverRetryTest.kt
+++ b/app/src/test/java/com/gb4pc/service/MediaObserverRetryTest.kt
@@ -274,6 +274,10 @@ class MediaObserverRetryTest {
     /**
      * Mirrors how OverlayService wires the session-media observer (List<MediaItem> result).
      * Previously covered by MediaChangeDispatcherTest.
+     *
+     * The session observer uses isSuccess = { false } so the retry always fires, even when the
+     * session already contains earlier photos. A non-empty list from stale items must not mask
+     * the still-pending new shot.
      */
     @Test
     fun `list-result wiring matches former MediaChangeDispatcher contract`() {
@@ -287,7 +291,7 @@ class MediaObserverRetryTest {
                 handler = handler,
                 // Call 0: nothing committed yet (IS_PENDING race); call 1 (retry): both committed.
                 query = { if (callCount++ == 0) emptyList() else listOf(item1, item2) },
-                isSuccess = { it.isNotEmpty() },
+                isSuccess = { false },
                 handleResult = { items, _ -> items.forEach { added.add(it.uri) } },
                 retryDelayMs = retryDelayMs,
             )
@@ -300,6 +304,40 @@ class MediaObserverRetryTest {
         // Nothing added on the empty initial call; item1 + item2 added on the retry (de-dup is
         // the SessionTracker's job, not this helper's).
         assertEquals(listOf("content://1", "content://2"), added)
+    }
+
+    /**
+     * Regression for the blocking review finding: when the session already holds a prior photo,
+     * the query returns a non-empty list on the initial call even though the new shot is still
+     * IS_PENDING. isSuccess = { false } must still schedule a retry so the new item is captured.
+     */
+    @Test
+    fun `list-result - retry fires even when initial result is non-empty (prior session media)`() {
+        val prior = MediaItem(uri = "content://prior", dateTaken = 1L, isVideo = false)
+        val newItem = MediaItem(uri = "content://new", dateTaken = 2L, isVideo = false)
+        var callCount = 0
+        val added = mutableListOf<String>()
+
+        val retry =
+            MediaObserverRetry<List<MediaItem>>(
+                handler = handler,
+                // Call 0: only prior item committed (new shot still IS_PENDING).
+                // Call 1 (retry): both are committed.
+                query = { if (callCount++ == 0) listOf(prior) else listOf(prior, newItem) },
+                isSuccess = { false },
+                handleResult = { items, _ -> items.forEach { added.add(it.uri) } },
+                retryDelayMs = retryDelayMs,
+            )
+
+        retry.onChange(startMs = 999_000L)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        // Retry must be scheduled even though the initial result was non-empty.
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+        runnableCaptor.firstValue.run()
+
+        // Both the prior item (initial) and both items (retry) are delivered; de-dup is
+        // the SessionTracker's job, not this helper's.
+        assertEquals(listOf("content://prior", "content://prior", "content://new"), added)
     }
 
     /**

--- a/app/src/test/java/com/gb4pc/service/MediaObserverRetryTest.kt
+++ b/app/src/test/java/com/gb4pc/service/MediaObserverRetryTest.kt
@@ -1,6 +1,7 @@
 package com.gb4pc.service
 
 import android.os.Handler
+import com.gb4pc.Constants
 import com.gb4pc.viewer.MediaItem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -8,6 +9,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -41,6 +43,7 @@ class MediaObserverRetryTest {
             MediaObserverRetry<Int>(
                 handler = handler,
                 query = { 42 },
+                isSuccess = { it != 0 },
                 handleResult = { result, isRetry -> seen.add(result to isRetry) },
                 retryDelayMs = retryDelayMs,
             )
@@ -50,14 +53,15 @@ class MediaObserverRetryTest {
         assertEquals(listOf(42 to false), seen)
     }
 
-    // ── Always-retry path ───────────────────────────────────────────────────
+    // ── Success-gated retry path ────────────────────────────────────────────
 
     @Test
-    fun `onChange always schedules a retry`() {
+    fun `onChange schedules a retry when the initial result is unsuccessful`() {
         val retry =
             MediaObserverRetry<Int>(
                 handler = handler,
-                query = { 1 },
+                query = { 0 },
+                isSuccess = { it != 0 },
                 handleResult = { _, _ -> },
                 retryDelayMs = retryDelayMs,
             )
@@ -68,13 +72,31 @@ class MediaObserverRetryTest {
     }
 
     @Test
+    fun `onChange does not schedule a retry when the initial result is successful`() {
+        val retry =
+            MediaObserverRetry<Int>(
+                handler = handler,
+                query = { 1 },
+                isSuccess = { it != 0 },
+                handleResult = { _, _ -> },
+                retryDelayMs = retryDelayMs,
+            )
+
+        retry.onChange(startMs = 999_000L)
+
+        verify(handler, never()).postDelayed(any(), any())
+    }
+
+    @Test
     fun `retry runnable invokes handleResult with isRetry=true`() {
         var callCount = 0
         val seen = mutableListOf<Pair<Int, Boolean>>()
         val retry =
             MediaObserverRetry<Int>(
                 handler = handler,
+                // 0 (unsuccessful) then 1 (successful), so exactly one retry fires.
                 query = { callCount++ },
+                isSuccess = { it != 0 },
                 handleResult = { result, isRetry -> seen.add(result to isRetry) },
                 retryDelayMs = retryDelayMs,
             )
@@ -88,11 +110,12 @@ class MediaObserverRetryTest {
     }
 
     @Test
-    fun `retry is one-shot - retry runnable does not schedule another retry`() {
+    fun `unsuccessful retry re-schedules itself`() {
         val retry =
             MediaObserverRetry<Int>(
                 handler = handler,
-                query = { 0 },
+                query = { 0 }, // always unsuccessful
+                isSuccess = { it != 0 },
                 handleResult = { _, _ -> },
                 retryDelayMs = retryDelayMs,
             )
@@ -102,8 +125,72 @@ class MediaObserverRetryTest {
         verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
         runnableCaptor.firstValue.run()
 
-        // Only the original postDelayed call; the retry runnable does not enqueue another.
-        verify(handler, times(1)).postDelayed(any(), any())
+        // The retry, still unsuccessful, enqueues another retry.
+        verify(handler, times(2)).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    @Test
+    fun `successful retry stops the chain`() {
+        var callCount = 0
+        val retry =
+            MediaObserverRetry<Int>(
+                handler = handler,
+                // 0 (unsuccessful), then 1 (successful).
+                query = { callCount++ },
+                isSuccess = { it != 0 },
+                handleResult = { _, _ -> },
+                retryDelayMs = retryDelayMs,
+            )
+
+        retry.onChange(startMs = 999_000L)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
+        runnableCaptor.firstValue.run()
+
+        // Retry succeeded, so no further retry is scheduled.
+        verify(handler, times(1)).postDelayed(any(), eq(retryDelayMs))
+    }
+
+    @Test
+    fun `retry chain stops after MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS`() {
+        val retry =
+            MediaObserverRetry<Int>(
+                handler = handler,
+                query = { 0 }, // always unsuccessful
+                isSuccess = { it != 0 },
+                handleResult = { _, _ -> },
+                retryDelayMs = retryDelayMs,
+            )
+
+        retry.onChange(startMs = 999_000L)
+        drainRetries()
+
+        // Initial onChange + exactly MAX_ATTEMPTS retries, then the chain gives up.
+        verify(handler, times(Constants.MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS))
+            .postDelayed(any(), eq(retryDelayMs))
+    }
+
+    @Test
+    fun `regression issue 509 - thumbnail refreshes when commit lands after the first retry`() {
+        // Reproduces #509: the query returns null on the initial call and on the first retry,
+        // then a committed item on the second retry. With a one-shot retry the thumbnail would
+        // never refresh; the self-rescheduling retry must still surface it.
+        val sample = MediaItem(uri = "content://509", dateTaken = 1L, isVideo = false)
+        var callCount = 0
+        val shown = mutableListOf<String>()
+        val retry =
+            MediaObserverRetry<MediaItem?>(
+                handler = handler,
+                query = { if (callCount++ < 2) null else sample },
+                isSuccess = { it != null },
+                handleResult = { item, _ -> item?.let { shown.add(it.uri) } },
+                retryDelayMs = retryDelayMs,
+            )
+
+        retry.onChange(startMs = 999_000L)
+        drainRetries()
+
+        assertEquals(listOf("content://509"), shown)
     }
 
     // ── Cancel-and-reschedule ───────────────────────────────────────────────
@@ -114,6 +201,7 @@ class MediaObserverRetryTest {
             MediaObserverRetry<Int>(
                 handler = handler,
                 query = { 0 },
+                isSuccess = { it != 0 },
                 handleResult = { _, _ -> },
                 retryDelayMs = retryDelayMs,
             )
@@ -129,6 +217,30 @@ class MediaObserverRetryTest {
         verify(handler, times(2)).postDelayed(any(), eq(retryDelayMs))
     }
 
+    @Test
+    fun `fresh onChange resets the attempt budget`() {
+        val retry =
+            MediaObserverRetry<Int>(
+                handler = handler,
+                query = { 0 }, // always unsuccessful
+                isSuccess = { it != 0 },
+                handleResult = { _, _ -> },
+                retryDelayMs = retryDelayMs,
+            )
+
+        // Exhaust the budget on the first event.
+        retry.onChange(startMs = 999_000L)
+        drainRetries()
+        verify(handler, times(Constants.MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS))
+            .postDelayed(any(), eq(retryDelayMs))
+
+        // A fresh onChange resets the counter and schedules a full new budget.
+        retry.onChange(startMs = 999_000L)
+        drainRetries()
+        verify(handler, times(2 * Constants.MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS))
+            .postDelayed(any(), eq(retryDelayMs))
+    }
+
     // ── startMs forwarding ──────────────────────────────────────────────────
 
     @Test
@@ -141,6 +253,7 @@ class MediaObserverRetryTest {
                     capturedStartMs.add(startMs)
                     0
                 },
+                isSuccess = { it != 0 },
                 handleResult = { _, _ -> },
                 retryDelayMs = retryDelayMs,
             )
@@ -172,8 +285,9 @@ class MediaObserverRetryTest {
         val retry =
             MediaObserverRetry<List<MediaItem>>(
                 handler = handler,
-                // Call 0: only item1 committed; call 1 (retry): both committed.
-                query = { if (callCount++ == 0) listOf(item1) else listOf(item1, item2) },
+                // Call 0: nothing committed yet (IS_PENDING race); call 1 (retry): both committed.
+                query = { if (callCount++ == 0) emptyList() else listOf(item1, item2) },
+                isSuccess = { it.isNotEmpty() },
                 handleResult = { items, _ -> items.forEach { added.add(it.uri) } },
                 retryDelayMs = retryDelayMs,
             )
@@ -183,9 +297,9 @@ class MediaObserverRetryTest {
         verify(handler).postDelayed(runnableCaptor.capture(), eq(retryDelayMs))
         runnableCaptor.firstValue.run()
 
-        // item1 added on initial call; item1 + item2 added on retry (de-dup is the
-        // SessionTracker's job, not this helper's).
-        assertEquals(listOf("content://1", "content://1", "content://2"), added)
+        // Nothing added on the empty initial call; item1 + item2 added on the retry (de-dup is
+        // the SessionTracker's job, not this helper's).
+        assertEquals(listOf("content://1", "content://2"), added)
     }
 
     /**
@@ -204,6 +318,7 @@ class MediaObserverRetryTest {
                 handler = handler,
                 // Call 0: still IS_PENDING (null); call 1 (retry): committed.
                 query = { if (callCount++ == 0) null else sample },
+                isSuccess = { it != null },
                 handleResult = { item, _ ->
                     if (item != null) {
                         showThumbnail(item.uri)
@@ -223,5 +338,28 @@ class MediaObserverRetryTest {
 
         assertEquals(listOf("content://42"), shown)
         verify(showThumbnail).invoke(sample.uri)
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /**
+     * Drives the self-rescheduling retry chain to completion. Each fired retry that is still
+     * unsuccessful schedules the next one via a new handler.postDelayed(). This captures every
+     * posted runnable and runs the latest one until a step posts nothing new. Bounded so a
+     * non-terminating chain fails the test rather than hanging.
+     */
+    private fun drainRetries() {
+        var total = 0
+        while (true) {
+            val captor = argumentCaptor<Runnable>()
+            verify(handler, atLeastOnce()).postDelayed(captor.capture(), eq(retryDelayMs))
+            if (captor.allValues.size <= total) break // no new retry posted -> chain terminated
+            captor.allValues.last().run()
+            total = captor.allValues.size
+            assertTrue(
+                "Retry chain did not terminate within a bounded number of attempts",
+                total <= Constants.MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS * 4,
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #509. Fixes #529.

## Problem

When the overlay is on screen and Pixel Camera takes a photo, the overlay keeps showing the gallery app icon instead of the new thumbnail. The log shows `Thumbnail query returned null -- scheduling retry in 500ms`, but the retry never recovers.

A separate race exists in the secure-camera E2E test (#529): `captureOnePhoto()` returns as soon as the MediaStore row appears, but the `OverlayService` `ContentObserver.onChange()` fires asynchronously. If the overlay is tapped before `onChange()` populates the session, `SecureViewerActivity` opens with an empty session.

## Root cause

`MediaObserverRetry.onChange` was one-shot: it ran the query, scheduled exactly one delayed retry, and gave up if that retry still returned null. Pixel Camera inserts the new photo with `IS_PENDING = 1` and clears it when the write completes; `queryLatestMedia` excludes the still-pending row, so it returns null until the commit lands. On locked devices the `IS_PENDING -> 0` callback is unreliable and the commit can land later than a single 500ms window, so the lone retry fired too early, returned null again, and the thumbnail was never refreshed. Failed retries were also silent, which is what made the retry timing look broken in the log.

## Fix

Make `MediaObserverRetry` re-schedule itself on an unsuccessful result, capped by a new `MEDIA_OBSERVER_RETRY_MAX_ATTEMPTS` budget (5, a 2.5s total budget at 500ms), mirroring the established `scheduleActivationRetry` design that already tolerates UsageStats lag. A new `isSuccess` predicate tells the helper when a result is good enough to stop retrying: a non-null item for the thumbnail observer, a non-empty list for the session observer. Each fresh `onChange` is a new commit event, so it cancels any in-flight retry and resets the attempt budget, preserving the "at most one pending retry" invariant. The thumbnail "query returned null" log now fires on every failed attempt, making the retry chain visible.

For the E2E test race (#529), a `waitForSessionMedia()` helper is added to `E2EFixture` and called in `test5a` between `captureOnePhoto()` and `tapOverlay()`. It polls `SessionTracker.instance.getSessionMedia().isNotEmpty()` for up to 5 s, which is well above the service's 2.5 s retry budget.

## Tests

Loosened test `retry is one-shot - retry runnable does not schedule another retry`: removed, because the one-shot behavior it asserted is the bug. It is replaced by tests covering self-rescheduling, the attempt cap, success stopping the chain, budget reset on a fresh `onChange`, and a direct #509 regression (null, null, then a committed item, asserting the thumbnail still surfaces). All `MediaObserverRetryTest` wiring tests were updated for the new `isSuccess` parameter. Full `:app:testDebugUnitTest` suite passes and `:app:assembleDebug` builds.