### PR TITLE
Accumulate CI run history in sticky PR comment with pass/fail/skip labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -622,6 +622,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_PR_URL: ${{ github.event.pull_request.html_url }}
           SUMMARY_WRITTEN: ${{ needs.build-and-test.outputs.needs_full_build }}

--- a/scripts/post_pr_ci_summary_link.py
+++ b/scripts/post_pr_ci_summary_link.py
@@ -9,9 +9,14 @@ that job's summary anchor, e.g.:
 
     https://github.com/<owner>/<repo>/actions/runs/<run_id>#summary-<job_id>
 
-It looks up the numeric job ID via the REST Jobs API (the anchor embeds the
-job ID, not the run ID), matching on job name and the current run attempt so
-re-runs don't pick up a stale job from a previous attempt.
+The comment accumulates a chronological list of CI runs for the PR. Each
+invocation appends one new list item of the form:
+
+    - [build-and-test 1234 pass](https://.../#summary-<job_id>)
+
+If a list item for the same job name and run number already exists it is
+replaced in place, making the script safe to re-run within the same workflow
+run. The list is capped to the most recent 20 entries.
 
 The comment is "sticky": a hidden HTML marker lets subsequent runs on the same
 PR find and edit the existing comment in place rather than piling up a new one
@@ -25,14 +30,14 @@ Environment:
     GITHUB_REPOSITORY     "owner/repo" (required).
     GITHUB_SERVER_URL     Server base URL, e.g. "https://github.com".
     GITHUB_RUN_ID         Workflow run ID.
+    GITHUB_RUN_NUMBER     Human-facing run number shown in the GitHub UI.
     GITHUB_RUN_ATTEMPT    Run attempt number (disambiguates re-runs).
     WORKFLOW_RUN_PR_URL   The triggering PR's html_url (empty on a plain push).
     SUMMARY_WRITTEN       "true" when build-and-test actually wrote the
                           pass/fail summary (its needs_full_build output).
-                          Docs-only PRs skip that step, so the job's
-                          "Summary" section has nothing to link to, and the
-                          comment says so instead of posting a misleading
-                          link.
+                          Docs-only PRs skip that step, so no summary table
+                          exists; these runs show result "skip" and link to
+                          the bare run URL.
     JOB_NAME              Name of the job whose summary to link (default
                           "build-and-test").
 
@@ -42,12 +47,29 @@ Exit code is always 0 (display only; a missing link must never fail the build).
 import os
 import re
 import sys
+from typing import NamedTuple
 
 import requests
 
 MARKER = "<!-- gb4pc-ci-summary-link -->"
 
 DEFAULT_JOB_NAME = "build-and-test"
+
+# Maximum number of list items to keep in the comment (oldest are dropped).
+MAX_ITEMS = 20
+
+# Regex matching a single Markdown list item as written by build_comment_body.
+# Captures: job_name, run_number (str), result, url.
+_ITEM_RE = re.compile(r"^- \[([^\s\]]+) (\d+) ([^\]]+)\]\(([^)]+)\)\s*$")
+
+
+class CIItem(NamedTuple):
+    """One CI-run entry in the sticky comment list."""
+
+    job_name: str
+    run_number: str  # kept as str to avoid integer-parsing surprises
+    result: str
+    url: str
 
 
 def _github_headers(token: str) -> dict[str, str]:
@@ -113,18 +135,46 @@ def find_job_id(
     return str(job["id"]) if job is not None else None
 
 
-def build_comment_body(summary_url: str, summary_written: bool) -> str:
-    if summary_written:
-        link_text = "View the build-and-test summary for this PR"
-    else:
-        link_text = "View this PR's build-and-test run"
-    body = f"{MARKER}\n### CI test summary\n\n[{link_text}]({summary_url}).\n"
-    if not summary_written:
-        body += (
-            "\n(This PR did not need a full build, so no pass/fail summary "
-            "was written; the link above goes to the run itself.)\n"
-        )
-    return body
+def result_label(conclusion: str | None) -> str:
+    """Map a GitHub job conclusion to a short human-readable result label.
+
+    Returns one of: "pass", "fail", "skip", "unknown".
+    """
+    if conclusion == "success":
+        return "pass"
+    if conclusion in ("failure", "timed_out", "cancelled"):
+        return "fail"
+    if conclusion == "skipped":
+        return "skip"
+    return "unknown"
+
+
+def parse_existing_items(body: str) -> list[CIItem]:
+    """Extract CI run list items already present in a comment body.
+
+    Returns a list of CIItem tuples in the order they appear in the body,
+    skipping any lines that do not match the expected list-item pattern.
+    """
+    items: list[CIItem] = []
+    for line in body.splitlines():
+        m = _ITEM_RE.match(line)
+        if m:
+            items.append(
+                CIItem(
+                    job_name=m.group(1),
+                    run_number=m.group(2),
+                    result=m.group(3),
+                    url=m.group(4),
+                )
+            )
+    return items
+
+
+def build_comment_body(items: list[CIItem]) -> str:
+    """Render the sticky comment body from a list of CIItem entries."""
+    lines = [f"- [{item.job_name} {item.run_number} {item.result}]({item.url})" for item in items]
+    list_block = "\n".join(lines)
+    return f"{MARKER}\n### CI test summary\n\n{list_block}\n"
 
 
 def find_existing_comment(
@@ -189,6 +239,7 @@ def main(argv: list[str] | None = None) -> int:
     repository = os.environ.get("GITHUB_REPOSITORY", "")
     server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
     run_id = os.environ.get("GITHUB_RUN_ID", "")
+    run_number = os.environ.get("GITHUB_RUN_NUMBER", "")
     run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
     pr_url = os.environ.get("WORKFLOW_RUN_PR_URL", "")
     summary_written = os.environ.get("SUMMARY_WRITTEN", "") == "true"
@@ -213,19 +264,66 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     run_url = f"{server_url}/{repository}/actions/runs/{run_id}"
-    if summary_written:
-        job_id = find_job_id(token, repository, run_id, run_attempt, job_name)
-        summary_url = f"{run_url}#summary-{job_id}" if job_id else run_url
-    else:
-        # No summary was written for this run (for example, a docs-only PR
-        # skips the heavy build/test steps); link to the bare run instead of
-        # an anchor that has nothing meaningful behind it.
-        summary_url = run_url
 
-    body = build_comment_body(summary_url, summary_written)
-    existing_id, _existing_body = find_existing_comment(token, repository, pr_number)
+    # Always look up the job so we can read its conclusion (needed for the
+    # result label regardless of whether a summary was written).
+    job = find_job(token, repository, run_id, run_attempt, job_name)
+    job_id = str(job["id"]) if job is not None else None
+    conclusion = job.get("conclusion") if job is not None else None
+
+    if summary_written and job_id:
+        item_url = f"{run_url}#summary-{job_id}"
+    else:
+        item_url = run_url
+
+    if summary_written:
+        label = result_label(conclusion)
+    else:
+        # Docs-only PR: no full build ran; show "skip" to convey that.
+        label = "skip"
+
+    current_item = CIItem(
+        job_name=job_name,
+        run_number=run_number or run_id,
+        result=label,
+        url=item_url,
+    )
+
+    # Fetch existing comment (id and body) once, so we can preserve prior items
+    # and avoid a second list-comments call in upsert_comment.
+    existing_id, existing_body = find_existing_comment(token, repository, pr_number)
+
+    prior_items = parse_existing_items(existing_body) if existing_body is not None else []
+
+    # Merge: replace any existing item for the same (job_name, run_number) pair,
+    # otherwise append. This makes the script idempotent within a run.
+    merged: list[CIItem] = []
+    replaced = False
+    for item in prior_items:
+        if item.job_name == current_item.job_name and item.run_number == current_item.run_number:
+            merged.append(current_item)
+            replaced = True
+        else:
+            merged.append(item)
+    if not replaced:
+        merged.append(current_item)
+
+    # Cap to the most recent MAX_ITEMS entries.
+    if len(merged) > MAX_ITEMS:
+        merged = merged[-MAX_ITEMS:]
+
+    body = build_comment_body(merged)
+
+    # When existing_body fetch failed (existing_id is None but we know a prior
+    # comment exists): prefer not to post a fresh comment that would skip history.
+    # However we cannot distinguish "no prior comment" from "fetch failed" when
+    # existing_id is None and existing_body is None. The safe path: if
+    # existing_id is None we either POST (first run) or POST again (fetch
+    # failed). The latter risks a duplicate comment, but preserves history in
+    # the existing comment and only adds a new one. This matches the recommended
+    # policy: do not PATCH without the existing id.
     if upsert_comment(token, repository, pr_number, body, existing_id):
-        print(f"Posted CI summary link to PR #{pr_number}: {summary_url}")
+        print(f"Posted CI summary link to PR #{pr_number}: {item_url}")
     return 0
 
 

--- a/scripts/post_pr_ci_summary_link.py
+++ b/scripts/post_pr_ci_summary_link.py
@@ -58,17 +58,18 @@ def _github_headers(token: str) -> dict[str, str]:
     }
 
 
-def find_job_id(
+def find_job(
     token: str,
     repository: str,
     run_id: str,
     run_attempt: str,
     job_name: str,
-) -> str | None:
-    """Return the numeric ID of *job_name* in this run's current attempt.
+) -> dict | None:
+    """Return the job dict for *job_name* in this run's current attempt.
 
     Filters on `run_attempt` (when known) so a re-run picks the job from the
     attempt actually in flight, not a stale one from an earlier attempt.
+    Returns the full job dict (including `id` and `conclusion`), or None.
     """
     url = f"https://api.github.com/repos/{repository}/actions/runs/{run_id}/jobs"
     try:
@@ -94,7 +95,22 @@ def find_job_id(
 
     if not candidates:
         return None
-    return str(candidates[0]["id"])
+    return candidates[0]
+
+
+def find_job_id(
+    token: str,
+    repository: str,
+    run_id: str,
+    run_attempt: str,
+    job_name: str,
+) -> str | None:
+    """Return the numeric ID of *job_name* in this run's current attempt.
+
+    Thin wrapper around find_job for callers that only need the job ID.
+    """
+    job = find_job(token, repository, run_id, run_attempt, job_name)
+    return str(job["id"]) if job is not None else None
 
 
 def build_comment_body(summary_url: str, summary_written: bool) -> str:
@@ -111,8 +127,13 @@ def build_comment_body(summary_url: str, summary_written: bool) -> str:
     return body
 
 
-def find_existing_comment(token: str, repository: str, pr_number: str) -> int | None:
-    """Return the ID of our prior sticky comment on the PR, if any."""
+def find_existing_comment(
+    token: str, repository: str, pr_number: str
+) -> tuple[int, str] | tuple[None, None]:
+    """Return (id, body) of our prior sticky comment on the PR, if any.
+
+    Returns (None, None) when no marker comment is found or on API error.
+    """
     url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
     try:
         resp = requests.get(
@@ -123,20 +144,26 @@ def find_existing_comment(token: str, repository: str, pr_number: str) -> int | 
         )
         resp.raise_for_status()
         for comment in resp.json():
-            if MARKER in (comment.get("body") or ""):
-                return comment["id"]
+            body = comment.get("body") or ""
+            if MARKER in body:
+                return comment["id"], body
     except Exception as exc:  # noqa: BLE001
         print(f"Warning: failed to list comments on PR #{pr_number}: {exc}", file=sys.stderr)
-    return None
+    return None, None
 
 
-def upsert_comment(token: str, repository: str, pr_number: str, body: str) -> bool:
-    """Create the sticky comment, or edit it in place if it already exists."""
-    existing = find_existing_comment(token, repository, pr_number)
+def upsert_comment(
+    token: str, repository: str, pr_number: str, body: str, existing_id: int | None = None
+) -> bool:
+    """Create the sticky comment, or edit it in place if it already exists.
+
+    When *existing_id* is provided the caller has already fetched the comment;
+    pass it here so we do not make a redundant list-comments API call.
+    """
     headers = _github_headers(token)
     try:
-        if existing is not None:
-            url = f"https://api.github.com/repos/{repository}/issues/comments/{existing}"
+        if existing_id is not None:
+            url = f"https://api.github.com/repos/{repository}/issues/comments/{existing_id}"
             resp = requests.patch(url, headers=headers, json={"body": body}, timeout=30)
         else:
             url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
@@ -144,7 +171,7 @@ def upsert_comment(token: str, repository: str, pr_number: str, body: str) -> bo
         resp.raise_for_status()
         return True
     except Exception as exc:  # noqa: BLE001
-        verb = "update" if existing is not None else "post"
+        verb = "update" if existing_id is not None else "post"
         print(f"Warning: failed to {verb} CI summary link comment: {exc}", file=sys.stderr)
         return False
 
@@ -196,7 +223,8 @@ def main(argv: list[str] | None = None) -> int:
         summary_url = run_url
 
     body = build_comment_body(summary_url, summary_written)
-    if upsert_comment(token, repository, pr_number, body):
+    existing_id, _existing_body = find_existing_comment(token, repository, pr_number)
+    if upsert_comment(token, repository, pr_number, body, existing_id):
         print(f"Posted CI summary link to PR #{pr_number}: {summary_url}")
     return 0
 

--- a/scripts/post_pr_ci_summary_link.py
+++ b/scripts/post_pr_ci_summary_link.py
@@ -59,8 +59,8 @@ DEFAULT_JOB_NAME = "build-and-test"
 MAX_ITEMS = 20
 
 # Regex matching a single Markdown list item as written by build_comment_body.
-# Captures: job_name, run_number (str), result, url.
-_ITEM_RE = re.compile(r"^- \[([^\s\]]+) (\d+) ([^\]]+)\]\(([^)]+)\)\s*$")
+# Captures: job_name, run_number (str), result (single non-whitespace token), url.
+_ITEM_RE = re.compile(r"^- \[([^\s\]]+) (\d+) (\S+)\]\(([^)]+)\)\s*$")
 
 
 class CIItem(NamedTuple):
@@ -70,6 +70,20 @@ class CIItem(NamedTuple):
     run_number: str  # kept as str to avoid integer-parsing surprises
     result: str
     url: str
+
+
+class CommentLookup(NamedTuple):
+    """Result of a find_existing_comment call.
+
+    Distinguishes three outcomes:
+      - Found:     fetch_ok=True,  comment_id=<int>, body=<str>
+      - Not found: fetch_ok=True,  comment_id=None,  body=None
+      - API error: fetch_ok=False, comment_id=None,  body=None
+    """
+
+    fetch_ok: bool
+    comment_id: int | None
+    body: str | None
 
 
 def _github_headers(token: str) -> dict[str, str]:
@@ -171,18 +185,29 @@ def parse_existing_items(body: str) -> list[CIItem]:
 
 
 def build_comment_body(items: list[CIItem]) -> str:
-    """Render the sticky comment body from a list of CIItem entries."""
+    """Render the sticky comment body from a list of CIItem entries.
+
+    *items* must be non-empty; callers are responsible for ensuring at least
+    one entry is present before calling this function.
+    """
+    if not items:
+        raise ValueError("build_comment_body requires at least one item")
     lines = [f"- [{item.job_name} {item.run_number} {item.result}]({item.url})" for item in items]
     list_block = "\n".join(lines)
     return f"{MARKER}\n### CI test summary\n\n{list_block}\n"
 
 
-def find_existing_comment(
-    token: str, repository: str, pr_number: str
-) -> tuple[int, str] | tuple[None, None]:
-    """Return (id, body) of our prior sticky comment on the PR, if any.
+def find_existing_comment(token: str, repository: str, pr_number: str) -> CommentLookup:
+    """Locate our prior sticky comment on the PR.
 
-    Returns (None, None) when no marker comment is found or on API error.
+    Returns a CommentLookup with three possible states:
+      - Found:     fetch_ok=True,  comment_id=<int>, body=<str>
+      - Not found: fetch_ok=True,  comment_id=None,  body=None
+      - API error: fetch_ok=False, comment_id=None,  body=None
+
+    Distinguishing "not found" from "API error" lets callers skip the upsert
+    safely when the fetch failed rather than posting a new comment that would
+    orphan any existing history.
     """
     url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
     try:
@@ -196,10 +221,11 @@ def find_existing_comment(
         for comment in resp.json():
             body = comment.get("body") or ""
             if MARKER in body:
-                return comment["id"], body
+                return CommentLookup(fetch_ok=True, comment_id=comment["id"], body=body)
     except Exception as exc:  # noqa: BLE001
         print(f"Warning: failed to list comments on PR #{pr_number}: {exc}", file=sys.stderr)
-    return None, None
+        return CommentLookup(fetch_ok=False, comment_id=None, body=None)
+    return CommentLookup(fetch_ok=True, comment_id=None, body=None)
 
 
 def upsert_comment(
@@ -289,11 +315,22 @@ def main(argv: list[str] | None = None) -> int:
         url=item_url,
     )
 
-    # Fetch existing comment (id and body) once, so we can preserve prior items
-    # and avoid a second list-comments call in upsert_comment.
-    existing_id, existing_body = find_existing_comment(token, repository, pr_number)
+    # Fetch existing comment once so we can preserve prior items and pass the
+    # comment ID directly to upsert_comment, avoiding a redundant API call.
+    lookup = find_existing_comment(token, repository, pr_number)
 
-    prior_items = parse_existing_items(existing_body) if existing_body is not None else []
+    if not lookup.fetch_ok:
+        # The list-comments API call failed. We cannot safely determine whether
+        # a prior sticky comment already exists, so we must not POST a new one:
+        # doing so would create an orphaned comment that loses the prior history.
+        # Leave whatever comment is already there untouched and skip this run.
+        print(
+            "Warning: skipping CI summary link comment: could not fetch existing comments.",
+            file=sys.stderr,
+        )
+        return 0
+
+    prior_items = parse_existing_items(lookup.body) if lookup.body is not None else []
 
     # Merge: replace any existing item for the same (job_name, run_number) pair,
     # otherwise append. This makes the script idempotent within a run.
@@ -313,16 +350,7 @@ def main(argv: list[str] | None = None) -> int:
         merged = merged[-MAX_ITEMS:]
 
     body = build_comment_body(merged)
-
-    # When existing_body fetch failed (existing_id is None but we know a prior
-    # comment exists): prefer not to post a fresh comment that would skip history.
-    # However we cannot distinguish "no prior comment" from "fetch failed" when
-    # existing_id is None and existing_body is None. The safe path: if
-    # existing_id is None we either POST (first run) or POST again (fetch
-    # failed). The latter risks a duplicate comment, but preserves history in
-    # the existing comment and only adds a new one. This matches the recommended
-    # policy: do not PATCH without the existing id.
-    if upsert_comment(token, repository, pr_number, body, existing_id):
+    if upsert_comment(token, repository, pr_number, body, lookup.comment_id):
         print(f"Posted CI summary link to PR #{pr_number}: {item_url}")
     return 0
 

--- a/scripts/test_post_pr_ci_summary_link.py
+++ b/scripts/test_post_pr_ci_summary_link.py
@@ -54,8 +54,68 @@ class TestBuildCommentBody(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# find_job_id
+# find_job / find_job_id
 # ---------------------------------------------------------------------------
+
+
+class TestFindJob(unittest.TestCase):
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_full_dict_for_matching_job(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {"id": 111, "name": "build-and-test", "run_attempt": 1, "conclusion": "success"},
+                {"id": 222, "name": "file-issues", "run_attempt": 1, "conclusion": "success"},
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 111)
+        self.assertEqual(result["conclusion"], "success")
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_filters_by_run_attempt_when_jobs_repeat(self, mock_requests):
+        """A re-run leaves a stale job from a prior attempt; pick the live one."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {"id": 111, "name": "build-and-test", "run_attempt": 1, "conclusion": "failure"},
+                {"id": 333, "name": "build-and-test", "run_attempt": 2, "conclusion": "success"},
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job("token", "owner/repo", "999", "2", "build-and-test")
+        self.assertEqual(result["id"], 333)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_falls_back_to_unfiltered_match_when_attempt_unknown(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {"id": 111, "name": "build-and-test", "run_attempt": 1, "conclusion": "success"}
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job("token", "owner/repo", "999", "", "build-and-test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 111)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_when_no_matching_job(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [{"id": 222, "name": "file-issues", "run_attempt": 1}]
+        }
+        mock_requests.get.return_value = mock_resp
+        result = link.find_job("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertIsNone(result)
+
+    @patch("post_pr_ci_summary_link.requests")
+    def test_returns_none_on_api_error(self, mock_requests):
+        mock_requests.get.side_effect = Exception("network error")
+        result = link.find_job("token", "owner/repo", "999", "1", "build-and-test")
+        self.assertIsNone(result)
 
 
 class TestFindJobId(unittest.TestCase):
@@ -120,64 +180,62 @@ class TestFindJobId(unittest.TestCase):
 
 class TestFindExistingComment(unittest.TestCase):
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_id_of_comment_with_marker(self, mock_requests):
+    def test_returns_id_and_body_of_comment_with_marker(self, mock_requests):
         mock_resp = MagicMock()
+        old_body = f"{link.MARKER}\nold link"
         mock_resp.json.return_value = [
             {"id": 1, "body": "unrelated comment"},
-            {"id": 2, "body": f"{link.MARKER}\nold link"},
+            {"id": 2, "body": old_body},
         ]
         mock_requests.get.return_value = mock_resp
-        result = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertEqual(result, 2)
+        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertEqual(comment_id, 2)
+        self.assertEqual(body, old_body)
 
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_none_when_no_marker_present(self, mock_requests):
+    def test_returns_none_none_when_no_marker_present(self, mock_requests):
         mock_resp = MagicMock()
         mock_resp.json.return_value = [{"id": 1, "body": "unrelated comment"}]
         mock_requests.get.return_value = mock_resp
-        result = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertIsNone(result)
+        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertIsNone(comment_id)
+        self.assertIsNone(body)
 
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_none_on_api_error(self, mock_requests):
+    def test_returns_none_none_on_api_error(self, mock_requests):
         mock_requests.get.side_effect = Exception("network error")
-        result = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertIsNone(result)
+        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertIsNone(comment_id)
+        self.assertIsNone(body)
 
 
 class TestUpsertComment(unittest.TestCase):
-    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.requests")
-    def test_creates_comment_when_none_exists(self, mock_requests, mock_find):
-        mock_find.return_value = None
+    def test_creates_comment_when_no_existing_id(self, mock_requests):
         mock_resp = MagicMock()
         mock_requests.post.return_value = mock_resp
-        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        result = link.upsert_comment("token", "owner/repo", "42", "body", existing_id=None)
         self.assertTrue(result)
         mock_requests.post.assert_called_once()
         mock_requests.patch.assert_not_called()
         url = mock_requests.post.call_args[0][0]
         self.assertIn("/issues/42/comments", url)
 
-    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.requests")
-    def test_edits_existing_comment_in_place(self, mock_requests, mock_find):
-        mock_find.return_value = 99
+    def test_edits_existing_comment_in_place(self, mock_requests):
         mock_resp = MagicMock()
         mock_requests.patch.return_value = mock_resp
-        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        result = link.upsert_comment("token", "owner/repo", "42", "body", existing_id=99)
         self.assertTrue(result)
         mock_requests.patch.assert_called_once()
         mock_requests.post.assert_not_called()
         url = mock_requests.patch.call_args[0][0]
         self.assertIn("/issues/comments/99", url)
 
-    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_false_on_api_error(self, mock_requests, mock_find):
-        mock_find.return_value = None
+    def test_returns_false_on_api_error(self, mock_requests):
         mock_requests.post.side_effect = Exception("server error")
-        result = link.upsert_comment("token", "owner/repo", "42", "body")
+        result = link.upsert_comment("token", "owner/repo", "42", "body", existing_id=None)
         self.assertFalse(result)
 
 
@@ -200,34 +258,44 @@ class TestMain(unittest.TestCase):
         env.update(overrides)
         return env
 
+    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
     @patch("post_pr_ci_summary_link.find_job_id")
-    def test_posts_link_with_summary_anchor_when_job_id_found(self, mock_find_job, mock_upsert):
+    def test_posts_link_with_summary_anchor_when_job_id_found(
+        self, mock_find_job, mock_upsert, mock_find_existing
+    ):
         mock_find_job.return_value = "111"
         mock_upsert.return_value = True
+        mock_find_existing.return_value = (None, None)
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
         self.assertIn("https://github.com/owner/repo/actions/runs/999#summary-111", body)
 
+    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
     @patch("post_pr_ci_summary_link.find_job_id")
-    def test_falls_back_to_run_url_when_job_id_missing(self, mock_find_job, mock_upsert):
+    def test_falls_back_to_run_url_when_job_id_missing(
+        self, mock_find_job, mock_upsert, mock_find_existing
+    ):
         mock_find_job.return_value = None
         mock_upsert.return_value = True
+        mock_find_existing.return_value = (None, None)
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
         self.assertIn("https://github.com/owner/repo/actions/runs/999", body)
         self.assertNotIn("#summary-", body)
 
+    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
     @patch("post_pr_ci_summary_link.find_job_id")
     def test_links_to_bare_run_and_explains_when_summary_not_written(
-        self, mock_find_job, mock_upsert
+        self, mock_find_job, mock_upsert, mock_find_existing
     ):
         """Docs-only PRs skip the summary step; do not claim one exists."""
         mock_upsert.return_value = True
+        mock_find_existing.return_value = (None, None)
         with patch.dict(os.environ, self._env(SUMMARY_WRITTEN="false"), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
@@ -239,10 +307,14 @@ class TestMain(unittest.TestCase):
         # link to anyway.
         mock_find_job.assert_not_called()
 
+    @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
     @patch("post_pr_ci_summary_link.find_job_id")
-    def test_treats_missing_summary_written_as_false(self, mock_find_job, mock_upsert):
+    def test_treats_missing_summary_written_as_false(
+        self, mock_find_job, mock_upsert, mock_find_existing
+    ):
         mock_upsert.return_value = True
+        mock_find_existing.return_value = (None, None)
         env = self._env()
         del env["SUMMARY_WRITTEN"]
         with patch.dict(os.environ, env, clear=True):

--- a/scripts/test_post_pr_ci_summary_link.py
+++ b/scripts/test_post_pr_ci_summary_link.py
@@ -33,24 +33,130 @@ class TestPrNumberFromUrl(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# result_label
+# ---------------------------------------------------------------------------
+
+
+class TestResultLabel(unittest.TestCase):
+    def test_success_maps_to_pass(self):
+        self.assertEqual(link.result_label("success"), "pass")
+
+    def test_failure_maps_to_fail(self):
+        self.assertEqual(link.result_label("failure"), "fail")
+
+    def test_timed_out_maps_to_fail(self):
+        self.assertEqual(link.result_label("timed_out"), "fail")
+
+    def test_cancelled_maps_to_fail(self):
+        self.assertEqual(link.result_label("cancelled"), "fail")
+
+    def test_skipped_maps_to_skip(self):
+        self.assertEqual(link.result_label("skipped"), "skip")
+
+    def test_none_maps_to_unknown(self):
+        self.assertEqual(link.result_label(None), "unknown")
+
+    def test_unexpected_string_maps_to_unknown(self):
+        self.assertEqual(link.result_label("action_required"), "unknown")
+
+    def test_neutral_maps_to_unknown(self):
+        self.assertEqual(link.result_label("neutral"), "unknown")
+
+
+# ---------------------------------------------------------------------------
+# parse_existing_items
+# ---------------------------------------------------------------------------
+
+
+class TestParseExistingItems(unittest.TestCase):
+    def test_empty_body_returns_empty_list(self):
+        self.assertEqual(link.parse_existing_items(""), [])
+
+    def test_parses_single_item(self):
+        body = (
+            f"{link.MARKER}\n### CI test summary\n\n"
+            "- [build-and-test 1234 pass](https://example.com/run#summary-111)\n"
+        )
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].job_name, "build-and-test")
+        self.assertEqual(items[0].run_number, "1234")
+        self.assertEqual(items[0].result, "pass")
+        self.assertEqual(items[0].url, "https://example.com/run#summary-111")
+
+    def test_parses_multiple_items(self):
+        body = (
+            f"{link.MARKER}\n### CI test summary\n\n"
+            "- [build-and-test 1 pass](https://example.com/1)\n"
+            "- [build-and-test 2 fail](https://example.com/2)\n"
+            "- [build-and-test 3 skip](https://example.com/3)\n"
+        )
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 3)
+        self.assertEqual(items[0].run_number, "1")
+        self.assertEqual(items[1].result, "fail")
+        self.assertEqual(items[2].result, "skip")
+
+    def test_ignores_header_and_non_list_lines(self):
+        body = (
+            f"{link.MARKER}\n### CI test summary\n\n"
+            "Some random prose line.\n"
+            "- [build-and-test 42 pass](https://example.com)\n"
+            "Another prose line.\n"
+        )
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].run_number, "42")
+
+    def test_tolerates_trailing_whitespace(self):
+        body = "- [build-and-test 7 fail](https://example.com)  \n"
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].run_number, "7")
+
+    def test_parses_bare_run_url_without_anchor(self):
+        body = "- [build-and-test 5 skip](https://github.com/owner/repo/actions/runs/999)\n"
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].result, "skip")
+
+
+# ---------------------------------------------------------------------------
 # build_comment_body
 # ---------------------------------------------------------------------------
 
 
 class TestBuildCommentBody(unittest.TestCase):
-    def test_includes_marker_and_link_when_summary_written(self):
-        body = link.build_comment_body("https://example.com/run#summary-1", True)
+    def test_includes_marker_and_heading(self):
+        items = [link.CIItem("build-and-test", "1234", "pass", "https://example.com")]
+        body = link.build_comment_body(items)
         self.assertIn(link.MARKER, body)
-        self.assertIn("https://example.com/run#summary-1", body)
-        self.assertIn("View the build-and-test summary for this PR", body)
+        self.assertIn("### CI test summary", body)
 
-    def test_notes_missing_summary_when_not_written(self):
-        body = link.build_comment_body("https://example.com/run", False)
-        self.assertIn(link.MARKER, body)
-        self.assertIn("https://example.com/run", body)
-        # Should not claim there is a pass/fail summary to view.
-        self.assertNotIn("build-and-test summary", body)
-        self.assertIn("did not need a full build", body)
+    def test_renders_list_item_with_job_run_result(self):
+        items = [link.CIItem("build-and-test", "1234", "pass", "https://example.com/run")]
+        body = link.build_comment_body(items)
+        self.assertIn("- [build-and-test 1234 pass](https://example.com/run)", body)
+
+    def test_renders_multiple_items_in_order(self):
+        items = [
+            link.CIItem("build-and-test", "1", "pass", "https://example.com/1"),
+            link.CIItem("build-and-test", "2", "fail", "https://example.com/2"),
+        ]
+        body = link.build_comment_body(items)
+        pos1 = body.index("1 pass")
+        pos2 = body.index("2 fail")
+        self.assertLess(pos1, pos2)
+
+    def test_renders_fail_result(self):
+        items = [link.CIItem("build-and-test", "99", "fail", "https://example.com")]
+        body = link.build_comment_body(items)
+        self.assertIn("99 fail", body)
+
+    def test_renders_skip_result(self):
+        items = [link.CIItem("build-and-test", "5", "skip", "https://example.com")]
+        body = link.build_comment_body(items)
+        self.assertIn("5 skip", body)
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +346,133 @@ class TestUpsertComment(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# main
+# merge / append / dedup logic (exercised via main)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeLogic(unittest.TestCase):
+    """Integration-style tests for the merge/append/dedup behaviour in main."""
+
+    def _env(self, **overrides):
+        env = {
+            "GITHUB_TOKEN": "token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_RUN_ID": "999",
+            "GITHUB_RUN_NUMBER": "42",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "WORKFLOW_RUN_PR_URL": "https://github.com/owner/repo/pull/7",
+            "SUMMARY_WRITTEN": "true",
+        }
+        env.update(overrides)
+        return env
+
+    def _job_resp(self, conclusion="success"):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {
+                    "id": 111,
+                    "name": "build-and-test",
+                    "run_attempt": 1,
+                    "conclusion": conclusion,
+                }
+            ]
+        }
+        return mock_resp
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_first_run_creates_single_item_list(
+        self, mock_requests, mock_upsert, mock_find_existing
+    ):
+        mock_requests.get.return_value = self._job_resp("success")
+        mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].run_number, "42")
+        self.assertEqual(items[0].result, "pass")
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_second_push_appends_new_item(self, mock_requests, mock_upsert, mock_find_existing):
+        """A new push (different run number) appends a second list item."""
+        existing_body = (
+            f"{link.MARKER}\n### CI test summary\n\n"
+            "- [build-and-test 41 pass]"
+            "(https://github.com/owner/repo/actions/runs/998#summary-111)\n"
+        )
+        mock_requests.get.return_value = self._job_resp("failure")
+        mock_find_existing.return_value = (55, existing_body)
+        mock_upsert.return_value = True
+        with patch.dict(
+            os.environ, self._env(GITHUB_RUN_NUMBER="42", GITHUB_RUN_ID="999"), clear=True
+        ):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].run_number, "41")
+        self.assertEqual(items[0].result, "pass")
+        self.assertEqual(items[1].run_number, "42")
+        self.assertEqual(items[1].result, "fail")
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_same_run_number_replaces_in_place(
+        self, mock_requests, mock_upsert, mock_find_existing
+    ):
+        """Re-running the same run number replaces the item, not duplicates it."""
+        existing_body = (
+            f"{link.MARKER}\n### CI test summary\n\n"
+            "- [build-and-test 42 fail]"
+            "(https://github.com/owner/repo/actions/runs/999#summary-111)\n"
+        )
+        mock_requests.get.return_value = self._job_resp("success")
+        mock_find_existing.return_value = (55, existing_body)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER="42"), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].run_number, "42")
+        self.assertEqual(items[0].result, "pass")
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_list_capped_to_max_items(self, mock_requests, mock_upsert, mock_find_existing):
+        """When existing items exceed MAX_ITEMS, oldest are dropped."""
+        existing_lines = "\n".join(
+            f"- [build-and-test {i} pass](https://example.com/{i})"
+            for i in range(1, link.MAX_ITEMS + 1)
+        )
+        existing_body = f"{link.MARKER}\n### CI test summary\n\n{existing_lines}\n"
+        mock_requests.get.return_value = self._job_resp("success")
+        mock_find_existing.return_value = (55, existing_body)
+        mock_upsert.return_value = True
+        new_run = str(link.MAX_ITEMS + 1)
+        with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER=new_run), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        items = link.parse_existing_items(body)
+        self.assertEqual(len(items), link.MAX_ITEMS)
+        # Oldest (run 1) should be gone; newest should be present.
+        run_numbers = [item.run_number for item in items]
+        self.assertNotIn("1", run_numbers)
+        self.assertIn(new_run, run_numbers)
+
+
+# ---------------------------------------------------------------------------
+# main: environment variable handling
 # ---------------------------------------------------------------------------
 
 
@@ -251,6 +483,7 @@ class TestMain(unittest.TestCase):
             "GITHUB_REPOSITORY": "owner/repo",
             "GITHUB_SERVER_URL": "https://github.com",
             "GITHUB_RUN_ID": "999",
+            "GITHUB_RUN_NUMBER": "42",
             "GITHUB_RUN_ATTEMPT": "1",
             "WORKFLOW_RUN_PR_URL": "https://github.com/owner/repo/pull/42",
             "SUMMARY_WRITTEN": "true",
@@ -258,15 +491,29 @@ class TestMain(unittest.TestCase):
         env.update(overrides)
         return env
 
+    def _job_resp(self, job_id=111, conclusion="success"):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "jobs": [
+                {
+                    "id": job_id,
+                    "name": "build-and-test",
+                    "run_attempt": 1,
+                    "conclusion": conclusion,
+                }
+            ]
+        }
+        return mock_resp
+
     @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
-    @patch("post_pr_ci_summary_link.find_job_id")
+    @patch("post_pr_ci_summary_link.requests")
     def test_posts_link_with_summary_anchor_when_job_id_found(
-        self, mock_find_job, mock_upsert, mock_find_existing
+        self, mock_requests, mock_upsert, mock_find_existing
     ):
-        mock_find_job.return_value = "111"
-        mock_upsert.return_value = True
+        mock_requests.get.return_value = self._job_resp(111, "success")
         mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
@@ -274,13 +521,43 @@ class TestMain(unittest.TestCase):
 
     @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
-    @patch("post_pr_ci_summary_link.find_job_id")
-    def test_falls_back_to_run_url_when_job_id_missing(
-        self, mock_find_job, mock_upsert, mock_find_existing
+    @patch("post_pr_ci_summary_link.requests")
+    def test_posts_pass_result_when_job_succeeded(
+        self, mock_requests, mock_upsert, mock_find_existing
     ):
-        mock_find_job.return_value = None
-        mock_upsert.return_value = True
+        mock_requests.get.return_value = self._job_resp(111, "success")
         mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("42 pass", body)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_posts_fail_result_when_job_failed(
+        self, mock_requests, mock_upsert, mock_find_existing
+    ):
+        mock_requests.get.return_value = self._job_resp(111, "failure")
+        mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("42 fail", body)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_falls_back_to_run_url_when_job_id_missing(
+        self, mock_requests, mock_upsert, mock_find_existing
+    ):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"jobs": []}
+        mock_requests.get.return_value = mock_resp
+        mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
@@ -289,39 +566,64 @@ class TestMain(unittest.TestCase):
 
     @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
-    @patch("post_pr_ci_summary_link.find_job_id")
-    def test_links_to_bare_run_and_explains_when_summary_not_written(
-        self, mock_find_job, mock_upsert, mock_find_existing
-    ):
-        """Docs-only PRs skip the summary step; do not claim one exists."""
-        mock_upsert.return_value = True
+    @patch("post_pr_ci_summary_link.requests")
+    def test_docs_only_pr_shows_skip_result(self, mock_requests, mock_upsert, mock_find_existing):
+        """Docs-only PRs (SUMMARY_WRITTEN=false) show 'skip' as the result."""
+        mock_requests.get.return_value = self._job_resp(111, "success")
         mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(SUMMARY_WRITTEN="false"), clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
-        self.assertIn("https://github.com/owner/repo/actions/runs/999", body)
+        self.assertIn("skip", body)
         self.assertNotIn("#summary-", body)
-        self.assertNotIn("build-and-test summary", body)
-        self.assertIn("did not need a full build", body)
-        # The job-ID lookup is unnecessary work when there's no summary to
-        # link to anyway.
-        mock_find_job.assert_not_called()
 
     @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
-    @patch("post_pr_ci_summary_link.find_job_id")
+    @patch("post_pr_ci_summary_link.requests")
     def test_treats_missing_summary_written_as_false(
-        self, mock_find_job, mock_upsert, mock_find_existing
+        self, mock_requests, mock_upsert, mock_find_existing
     ):
-        mock_upsert.return_value = True
+        mock_requests.get.return_value = self._job_resp(111, "success")
         mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
         env = self._env()
         del env["SUMMARY_WRITTEN"]
         with patch.dict(os.environ, env, clear=True):
             self.assertEqual(link.main([]), 0)
         body = mock_upsert.call_args[0][3]
         self.assertNotIn("#summary-", body)
-        mock_find_job.assert_not_called()
+        self.assertIn("skip", body)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    @patch("post_pr_ci_summary_link.requests")
+    def test_reads_github_run_number(self, mock_requests, mock_upsert, mock_find_existing):
+        """The run number should appear as the second token in the list item."""
+        mock_requests.get.return_value = self._job_resp(111, "success")
+        mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER="1337"), clear=True):
+            self.assertEqual(link.main([]), 0)
+        body = mock_upsert.call_args[0][3]
+        self.assertIn("1337", body)
+
+    @patch("post_pr_ci_summary_link.find_existing_comment")
+    @patch("post_pr_ci_summary_link.upsert_comment")
+    def test_does_not_clobber_history_when_fetch_fails(self, mock_upsert, mock_find_existing):
+        """When find_existing_comment fails (returns (None, None)) and no prior
+        comment is known, a fresh POST is made rather than a PATCH that would
+        overwrite unknown prior content."""
+        mock_find_existing.return_value = (None, None)
+        mock_upsert.return_value = True
+        with patch("post_pr_ci_summary_link.find_job") as mock_find_job:
+            mock_find_job.return_value = {"id": 111, "conclusion": "success"}
+            with patch.dict(os.environ, self._env(), clear=True):
+                self.assertEqual(link.main([]), 0)
+        # upsert_comment should be called with existing_id=None (POST, not PATCH).
+        call_args = mock_upsert.call_args
+        existing_id = call_args[0][4] if len(call_args[0]) > 4 else call_args[1].get("existing_id")
+        self.assertIsNone(existing_id)
 
     @patch("post_pr_ci_summary_link.upsert_comment")
     def test_skips_when_not_a_pull_request_run(self, mock_upsert):

--- a/scripts/test_post_pr_ci_summary_link.py
+++ b/scripts/test_post_pr_ci_summary_link.py
@@ -127,6 +127,10 @@ class TestParseExistingItems(unittest.TestCase):
 
 
 class TestBuildCommentBody(unittest.TestCase):
+    def test_raises_on_empty_items(self):
+        with self.assertRaises(ValueError):
+            link.build_comment_body([])
+
     def test_includes_marker_and_heading(self):
         items = [link.CIItem("build-and-test", "1234", "pass", "https://example.com")]
         body = link.build_comment_body(items)
@@ -294,25 +298,28 @@ class TestFindExistingComment(unittest.TestCase):
             {"id": 2, "body": old_body},
         ]
         mock_requests.get.return_value = mock_resp
-        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertEqual(comment_id, 2)
-        self.assertEqual(body, old_body)
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertTrue(result.fetch_ok)
+        self.assertEqual(result.comment_id, 2)
+        self.assertEqual(result.body, old_body)
 
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_none_none_when_no_marker_present(self, mock_requests):
+    def test_returns_fetch_ok_with_none_when_no_marker_present(self, mock_requests):
         mock_resp = MagicMock()
         mock_resp.json.return_value = [{"id": 1, "body": "unrelated comment"}]
         mock_requests.get.return_value = mock_resp
-        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertIsNone(comment_id)
-        self.assertIsNone(body)
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertTrue(result.fetch_ok)
+        self.assertIsNone(result.comment_id)
+        self.assertIsNone(result.body)
 
     @patch("post_pr_ci_summary_link.requests")
-    def test_returns_none_none_on_api_error(self, mock_requests):
+    def test_returns_fetch_ok_false_on_api_error(self, mock_requests):
         mock_requests.get.side_effect = Exception("network error")
-        comment_id, body = link.find_existing_comment("token", "owner/repo", "42")
-        self.assertIsNone(comment_id)
-        self.assertIsNone(body)
+        result = link.find_existing_comment("token", "owner/repo", "42")
+        self.assertFalse(result.fetch_ok)
+        self.assertIsNone(result.comment_id)
+        self.assertIsNone(result.body)
 
 
 class TestUpsertComment(unittest.TestCase):
@@ -388,7 +395,9 @@ class TestMergeLogic(unittest.TestCase):
         self, mock_requests, mock_upsert, mock_find_existing
     ):
         mock_requests.get.return_value = self._job_resp("success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -409,7 +418,9 @@ class TestMergeLogic(unittest.TestCase):
             "(https://github.com/owner/repo/actions/runs/998#summary-111)\n"
         )
         mock_requests.get.return_value = self._job_resp("failure")
-        mock_find_existing.return_value = (55, existing_body)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=55, body=existing_body
+        )
         mock_upsert.return_value = True
         with patch.dict(
             os.environ, self._env(GITHUB_RUN_NUMBER="42", GITHUB_RUN_ID="999"), clear=True
@@ -436,7 +447,9 @@ class TestMergeLogic(unittest.TestCase):
             "(https://github.com/owner/repo/actions/runs/999#summary-111)\n"
         )
         mock_requests.get.return_value = self._job_resp("success")
-        mock_find_existing.return_value = (55, existing_body)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=55, body=existing_body
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER="42"), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -457,7 +470,9 @@ class TestMergeLogic(unittest.TestCase):
         )
         existing_body = f"{link.MARKER}\n### CI test summary\n\n{existing_lines}\n"
         mock_requests.get.return_value = self._job_resp("success")
-        mock_find_existing.return_value = (55, existing_body)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=55, body=existing_body
+        )
         mock_upsert.return_value = True
         new_run = str(link.MAX_ITEMS + 1)
         with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER=new_run), clear=True):
@@ -512,7 +527,9 @@ class TestMain(unittest.TestCase):
         self, mock_requests, mock_upsert, mock_find_existing
     ):
         mock_requests.get.return_value = self._job_resp(111, "success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -526,7 +543,9 @@ class TestMain(unittest.TestCase):
         self, mock_requests, mock_upsert, mock_find_existing
     ):
         mock_requests.get.return_value = self._job_resp(111, "success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -540,7 +559,9 @@ class TestMain(unittest.TestCase):
         self, mock_requests, mock_upsert, mock_find_existing
     ):
         mock_requests.get.return_value = self._job_resp(111, "failure")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -556,7 +577,9 @@ class TestMain(unittest.TestCase):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"jobs": []}
         mock_requests.get.return_value = mock_resp
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -570,7 +593,9 @@ class TestMain(unittest.TestCase):
     def test_docs_only_pr_shows_skip_result(self, mock_requests, mock_upsert, mock_find_existing):
         """Docs-only PRs (SUMMARY_WRITTEN=false) show 'skip' as the result."""
         mock_requests.get.return_value = self._job_resp(111, "success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(SUMMARY_WRITTEN="false"), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -585,7 +610,9 @@ class TestMain(unittest.TestCase):
         self, mock_requests, mock_upsert, mock_find_existing
     ):
         mock_requests.get.return_value = self._job_resp(111, "success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         env = self._env()
         del env["SUMMARY_WRITTEN"]
@@ -601,7 +628,9 @@ class TestMain(unittest.TestCase):
     def test_reads_github_run_number(self, mock_requests, mock_upsert, mock_find_existing):
         """The run number should appear as the second token in the list item."""
         mock_requests.get.return_value = self._job_resp(111, "success")
-        mock_find_existing.return_value = (None, None)
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=None, body=None
+        )
         mock_upsert.return_value = True
         with patch.dict(os.environ, self._env(GITHUB_RUN_NUMBER="1337"), clear=True):
             self.assertEqual(link.main([]), 0)
@@ -611,19 +640,18 @@ class TestMain(unittest.TestCase):
     @patch("post_pr_ci_summary_link.find_existing_comment")
     @patch("post_pr_ci_summary_link.upsert_comment")
     def test_does_not_clobber_history_when_fetch_fails(self, mock_upsert, mock_find_existing):
-        """When find_existing_comment fails (returns (None, None)) and no prior
-        comment is known, a fresh POST is made rather than a PATCH that would
-        overwrite unknown prior content."""
-        mock_find_existing.return_value = (None, None)
-        mock_upsert.return_value = True
+        """When find_existing_comment returns fetch_ok=False (API error), main
+        must not call upsert_comment at all.
+        Posting a fresh comment when the prior one may exist would orphan the
+        prior history."""
+        mock_find_existing.return_value = link.CommentLookup(
+            fetch_ok=False, comment_id=None, body=None
+        )
         with patch("post_pr_ci_summary_link.find_job") as mock_find_job:
             mock_find_job.return_value = {"id": 111, "conclusion": "success"}
             with patch.dict(os.environ, self._env(), clear=True):
                 self.assertEqual(link.main([]), 0)
-        # upsert_comment should be called with existing_id=None (POST, not PATCH).
-        call_args = mock_upsert.call_args
-        existing_id = call_args[0][4] if len(call_args[0]) > 4 else call_args[1].get("existing_id")
-        self.assertIsNone(existing_id)
+        mock_upsert.assert_not_called()
 
     @patch("post_pr_ci_summary_link.upsert_comment")
     def test_skips_when_not_a_pull_request_run(self, mock_upsert):


### PR DESCRIPTION
Fixes #528.

## What changed

The sticky CI-summary comment on PRs now accumulates a chronological list of CI run results rather than replacing a single link on each push.
Each line shows the job name, human-facing run number, and a clear pass/fail/skip label:

```
### CI test summary

- [build-and-test 1234 pass](https://github.com/.../actions/runs/...#summary-...)
- [build-and-test 1235 fail](https://github.com/.../actions/runs/...#summary-...)
```

An Author scanning the comment immediately sees the latest result and can review the history of prior runs without hunting through the Checks tab.

### Changes in `scripts/post_pr_ci_summary_link.py`

- **`find_job_id` -> `find_job`**: returns the full job dict (id + conclusion) from a single API call.
  A thin `find_job_id` wrapper is kept for backward compatibility.
- **`result_label(conclusion)`**: maps job conclusion to `"pass"`, `"fail"`, `"skip"`, or `"unknown"`.
  `failure`, `timed_out`, and `cancelled` all map to `"fail"` so Authors are not lulled by a non-green result.
  Docs-only PRs (`SUMMARY_WRITTEN=false`) always show `"skip"` to convey no full build ran.
- **`parse_existing_items(body)`**: regex-extracts prior list lines from the comment body and returns `CIItem` tuples, enabling in-place replacement and the cap logic.
- **`build_comment_body(items)`**: replaces the old single-link signature; renders the marker, heading, and a `-`-prefixed list line per item.
- **Merge/append in `main`**: reads `GITHUB_RUN_NUMBER`, fetches the job's conclusion (always, not only when `SUMMARY_WRITTEN=true`), builds `CIItem`, parses prior items, replaces-in-place or appends, caps to 20 entries, and upserts.
- Dedup: same `(job_name, run_number)` replaces in place, making the script safe to re-run within the same workflow run.
- Cap: oldest entries are dropped when the list exceeds 20 items.

### Changes in `.github/workflows/build.yml`

- Added `GITHUB_RUN_NUMBER: ${{ github.run_number }}` to the `env:` block of the "Post CI summary link on PR" step.

### Tests (`scripts/test_post_pr_ci_summary_link.py`)

Added 25 new tests covering:
- `result_label` for all conclusion values
- `parse_existing_items`: empty body, single and multiple items, ignores non-list lines, trailing whitespace, bare run URLs
- `build_comment_body`: marker, heading, list item format, ordering, fail/skip results
- `TestMergeLogic` (via `main`): first run, second push appends, same run number replaces, cap to MAX_ITEMS
- `TestMain`: pass/fail results, run number in output, docs-only skip, history-safe on fetch failure

Total: 55 tests, all passing.
