### PR TITLE
Set overlay default position to y=75%, size=15%

### DIFF
--- a/app/src/main/java/com/gb4pc/Constants.kt
+++ b/app/src/main/java/com/gb4pc/Constants.kt
@@ -5,8 +5,8 @@ object Constants {
 
     // Default overlay position (PS-02)
     const val DEFAULT_X_PERCENT = 20.0f
-    const val DEFAULT_Y_PERCENT = 69.0f
-    const val DEFAULT_SIZE_PERCENT = 16.0f
+    const val DEFAULT_Y_PERCENT = 75.0f
+    const val DEFAULT_SIZE_PERCENT = 15.0f
 
     // Overlay size bounds
     const val MIN_SIZE_PERCENT = 1.0f

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerTest.kt
@@ -136,11 +136,11 @@ class OverlayManagerTest {
         val xPx = calculateOverlayXPx(pos.xPercent, displayWidth, sizePx)
         val yPx = calculateOverlayYPx(pos.yPercent, displayHeight, sizePx)
 
-        // Size: 1080 * 16.0 / 100 = 172.8 → 173
-        assertEquals(173, sizePx)
-        // X: 1080 * 20.0 / 100 - 86 = 216 - 86 = 130
-        assertEquals(130, xPx)
-        // Y: 2400 * 69.0 / 100 - 86 = 1656 - 86 = 1570
-        assertEquals(1570, yPx)
+        // Size: 1080 * 15.0 / 100 = 162.0 → 162
+        assertEquals(162, sizePx)
+        // X: 1080 * 20.0 / 100 - 81 = 216 - 81 = 135
+        assertEquals(135, xPx)
+        // Y: 2400 * 75.0 / 100 - 81 = 1800 - 81 = 1719
+        assertEquals(1719, yPx)
     }
 }


### PR DESCRIPTION
Changes `DEFAULT_Y_PERCENT` from 69.0 to 75.0 and `DEFAULT_SIZE_PERCENT` from 16.0 to 15.0 in `Constants.kt`. The x default (20.0%) was already correct and is unchanged.

Updates the pixel-value spot-check in `OverlayManagerTest` to match the new defaults (sizePx 173->162, xPx 130->135, yPx 1570->1719 for a 1080x2400 display).
