### PR TITLE
Declare READ_EXTERNAL_STORAGE and READ_MEDIA_IMAGES so MediaStore sees Pixel Camera photos

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,13 @@
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
 
+    <!-- Media read permissions for querying photos taken by Pixel Camera via MediaStore -->
+    <!-- READ_EXTERNAL_STORAGE covers Android 10-12 (API 29-32) -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <!-- READ_MEDIA_IMAGES covers Android 13+ (API 33+) -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
     <!-- Runtime permission (API 33+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,10 +15,8 @@
         tools:ignore="ProtectedPermissions" />
 
     <!-- Media read permissions for querying photos taken by Pixel Camera via MediaStore -->
-    <!-- READ_EXTERNAL_STORAGE covers Android 10-12 (API 29-32) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <!-- READ_MEDIA_IMAGES covers Android 13+ (API 33+) -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <!-- Runtime permission (API 33+) -->


### PR DESCRIPTION
Fixes #509

## Root cause

On Android 10+ (API 29+), MediaStore queries are scoped to an app's own
media unless a read permission is granted.
The production manifest declared no media-read permission, so
`queryLatestMedia` / `queryAllFromMediaStore` in `OverlayService` always
received an empty cursor when looking for photos taken by Pixel Camera.
`MediaObserverRetry` fired correctly but the query could never succeed,
leaving the gallery thumbnail permanently stale after a photo was taken.

The bug was invisible in E2E tests because `build.gradle.kts` grants
`READ_MEDIA_IMAGES` to the test package via `pm grant`--but that grant
never applied to the production app itself.

## Fix

Added to `app/src/main/AndroidManifest.xml`:

- `READ_EXTERNAL_STORAGE` with `maxSdkVersion="32"` -- covers Android 10-12 (API 29-32)
- `READ_MEDIA_IMAGES` -- covers Android 13+ (API 33+)

No logic changes are needed; the existing retry loop works correctly once
the permission lets the cursor return results.

## Test plan

- [ ] Install a production (non-test) build on an Android 13+ device, grant the permission at runtime, take a photo in Pixel Camera, and confirm the gallery thumbnail updates.
