### PR TITLE
Add test5a_secureCameraLockedPopulatedGalleryShowsGreen to flaky test allowlist

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -20,4 +20,5 @@
 # issue #309 removed it.  Each already has a tracking issue and must be
 # removed from this list as it is fixed.
 
-# (No entries.)
+# Tracking issue: #243
+com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen


### PR DESCRIPTION
Fixes #538

`test5a_secureCameraLockedPopulatedGalleryShowsGreen` has been failing on CI repeatedly since May 2026 (tracked in #243).
Adding it to `.github/allowed-test-failures.txt` prevents these known-flaky failures from blocking unrelated PRs.

**Prior fix attempts and why flakiness persists:**

- PR #527 (merged 2026-06-28) added a `waitForSessionMedia()` poll to address a MediaStore-row-timeout race.
  This changed the failure mode: pre-#527 failures reported a MediaStore timeout in `captureOnePhoto()`; post-#527 failures report a pixel-geometry assertion (green region 0% width, 0% coverage in `SecureViewerActivity`).
  The test is still flaky after #527.

- PR #532 (merged 2026-06-28) fixed a missing `READ_MEDIA_IMAGES`/`READ_EXTERNAL_STORAGE` permission in the production manifest.
  However, #532's own commit message notes that this bug was "invisible in E2E tests because `build.gradle.kts` grants `READ_MEDIA_IMAGES` to the test package via `pm grant`."
  The E2E failures are therefore unaffected by #532; the pixel-geometry flakiness remains.

The remaining root cause (why the overlay tap over the keyguard occasionally fails to composite or is not tappable) is still unresolved and continues to be tracked in #243.

**Allowlist entry format:**

The entry uses the method-level `ClassName#methodName` format, so only this one test is tolerated, not the whole class.
The tracking issue (#243) is cited in an inline comment per the file's own conventions.
This entry should be removed from the allowlist once #243 is resolved.

🤖 Author