### PR TITLE
Refresh SecureViewer reactively when the secure session populates

### DIFF
--- a/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
@@ -48,6 +48,16 @@ class SecureViewerActivity : ComponentActivity() {
 
     private val sessionTracker get() = SessionTracker.instance
 
+    // Issue #537: react to session media populating after onCreate()'s one-shot read.
+    // The viewer can open in the brief window before the OverlayService's ContentObserver
+    // has added the captured photo to the session; without this observer the activity would
+    // render a black "no photos" state and never recover. Listener callbacks may arrive on a
+    // background thread, so the refresh is marshaled onto the UI thread.
+    private val sessionListener =
+        SessionTracker.SessionListener {
+            runOnUiThread { refreshMedia() }
+        }
+
     // L4: BroadcastReceiver to finish the activity when the device unlocks (SF-15)
     private val userPresentReceiver =
         object : BroadcastReceiver() {
@@ -87,13 +97,19 @@ class SecureViewerActivity : ComponentActivity() {
         setTurnScreenOn(true)
 
         setupLayout()
-        refreshMedia()
+        // Issue #537: the initial read happens in onStart(), which always runs right after
+        // onCreate() and also registers the session observer; refreshing here too would be
+        // redundant.
     }
 
     override fun onStart() {
         super.onStart()
         // L4: Register receiver for device-unlock events
         registerReceiver(userPresentReceiver, IntentFilter(Intent.ACTION_USER_PRESENT))
+        // Issue #537: observe the session so a late-arriving photo refreshes the viewer.
+        // Refresh once on registration to pick up any change between onCreate() and now.
+        sessionTracker.addListener(sessionListener)
+        refreshMedia()
     }
 
     override fun onStop() {
@@ -104,6 +120,8 @@ class SecureViewerActivity : ComponentActivity() {
         } catch (e: IllegalArgumentException) {
             DebugLog.log("userPresentReceiver was not registered: ${e.message}")
         }
+        // Issue #537: stop observing the session while the viewer is not started.
+        sessionTracker.removeListener(sessionListener)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
@@ -19,6 +19,45 @@ class SessionTracker {
     private val mediaItems = mutableListOf<MediaItem>()
 
     /**
+     * Observers notified whenever the session's media set changes (start, end, add, remove).
+     *
+     * Issue #537: [SecureViewerActivity] reads the session once in `onCreate()`. When the
+     * activity opens in the brief window before the OverlayService's ContentObserver has
+     * populated the session, that one-shot read sees an empty session and renders a black
+     * "no photos" state. A reactive observer lets the viewer auto-refresh as soon as media
+     * arrives, rather than relying solely on the startup read.
+     *
+     * Backed by a [CopyOnWriteArraySet] so registration/deregistration and notification are
+     * thread-safe without holding [lock] while invoking listeners (which would risk a
+     * re-entrant deadlock if a listener called back into the tracker).
+     */
+    private val listeners = java.util.concurrent.CopyOnWriteArraySet<SessionListener>()
+
+    /** Listener for session media changes. See [addListener]. */
+    fun interface SessionListener {
+        fun onSessionMediaChanged()
+    }
+
+    /**
+     * Register a listener for session media changes. Re-registering the same instance is a no-op.
+     * Listeners are invoked on the thread that mutates the session; UI consumers must marshal
+     * any view updates onto the main thread themselves.
+     */
+    fun addListener(listener: SessionListener) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: SessionListener) {
+        listeners.remove(listener)
+    }
+
+    private fun notifyListeners() {
+        for (listener in listeners) {
+            listener.onSessionMediaChanged()
+        }
+    }
+
+    /**
      * SF-01: Begin a new session, recording the start timestamp (SF-02).
      */
     fun startSession() {
@@ -27,6 +66,7 @@ class SessionTracker {
             sessionStartTimestamp = System.currentTimeMillis()
             mediaItems.clear()
         }
+        notifyListeners()
     }
 
     /**
@@ -37,21 +77,29 @@ class SessionTracker {
             isSessionActive = false
             mediaItems.clear()
         }
+        notifyListeners()
     }
 
     fun addMedia(item: MediaItem) {
-        synchronized(lock) {
-            if (!isSessionActive) return
-            if (mediaItems.none { it.uri == item.uri }) {
-                mediaItems.add(item)
+        val changed =
+            synchronized(lock) {
+                if (!isSessionActive) return
+                if (mediaItems.none { it.uri == item.uri }) {
+                    mediaItems.add(item)
+                    true
+                } else {
+                    false
+                }
             }
-        }
+        if (changed) notifyListeners()
     }
 
     fun removeMedia(uri: String) {
-        synchronized(lock) {
-            mediaItems.removeAll { it.uri == uri }
-        }
+        val changed =
+            synchronized(lock) {
+                mediaItems.removeAll { it.uri == uri }
+            }
+        if (changed) notifyListeners()
     }
 
     /**

--- a/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
@@ -47,6 +47,10 @@ class SessionTracker {
         listeners.add(listener)
     }
 
+    /**
+     * Deregister a previously registered listener.
+     * Thread-safe; no-op if the listener is not currently registered.
+     */
     fun removeListener(listener: SessionListener) {
         listeners.remove(listener)
     }
@@ -71,13 +75,17 @@ class SessionTracker {
 
     /**
      * SF-01: End the session, clearing all media (SF-05).
+     * No-op (and no notification) if the session is already inactive.
      */
     fun endSession() {
-        synchronized(lock) {
-            isSessionActive = false
-            mediaItems.clear()
-        }
-        notifyListeners()
+        val changed =
+            synchronized(lock) {
+                if (!isSessionActive) return
+                isSessionActive = false
+                mediaItems.clear()
+                true
+            }
+        if (changed) notifyListeners()
     }
 
     fun addMedia(item: MediaItem) {

--- a/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
+++ b/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
@@ -123,6 +123,83 @@ class SessionTrackerTest {
         assertEquals("content://media/2", tracker.getSessionMedia()[0].uri)
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #537: session-change observer
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `addMedia notifies listener so a late photo can refresh the viewer`() {
+        tracker.startSession()
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+
+        assertEquals(1, notifications)
+    }
+
+    @Test
+    fun `startSession and endSession notify listener`() {
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.startSession()
+        tracker.endSession()
+
+        assertEquals(2, notifications)
+    }
+
+    @Test
+    fun `removeMedia notifies only when an item is actually removed`() {
+        tracker.startSession()
+        tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.removeMedia("content://media/1")
+        assertEquals(1, notifications)
+
+        // Removing a URI that is not present must not notify.
+        tracker.removeMedia("content://media/absent")
+        assertEquals(1, notifications)
+    }
+
+    @Test
+    fun `addMedia does not notify when no active session`() {
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+
+        assertEquals(0, notifications)
+    }
+
+    @Test
+    fun `addMedia does not notify for a duplicate URI`() {
+        tracker.startSession()
+        val item = MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false)
+        tracker.addMedia(item)
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.addMedia(item)
+
+        assertEquals(0, notifications)
+    }
+
+    @Test
+    fun `removed listener is no longer notified`() {
+        tracker.startSession()
+        var notifications = 0
+        val listener = SessionTracker.SessionListener { notifications++ }
+        tracker.addListener(listener)
+        tracker.removeListener(listener)
+
+        tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+
+        assertEquals(0, notifications)
+    }
+
     @Test
     fun `getSessionMedia returns most recent first per SF-07`() {
         tracker.startSession()

--- a/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
+++ b/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
@@ -150,6 +150,17 @@ class SessionTrackerTest {
     }
 
     @Test
+    fun `endSession does not notify when session is already inactive`() {
+        // endSession on a tracker that was never started must not fire listeners.
+        var notifications = 0
+        tracker.addListener { notifications++ }
+
+        tracker.endSession()
+
+        assertEquals(0, notifications)
+    }
+
+    @Test
     fun `removeMedia notifies only when an item is actually removed`() {
         tracker.startSession()
         tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))


### PR DESCRIPTION
Claimed to fix, but also not really prevent the bugs in 537.

## Problem

`SecureViewerActivity` reads the secure session exactly once, in `onCreate()`'s `refreshMedia()` call. When the viewer opens in the brief window before the `OverlayService` ContentObserver has added the captured photo to `SessionTracker`, that one-shot read sees an empty session and renders a black "no photos" state that never recovers. In CI this makes `GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen` fail intermittently, because `waitForGreenBand` polls a black screen for 15s and times out.

This is the same class of race that `waitForSessionMedia()` guards against on the tap side, but nothing covered the viewer's own startup read.

## Fix

Implements the issue's preferred option (a reactive session observer):

1. `SessionTracker` gains a thread-safe `SessionListener` registry. Mutators (`startSession`, `endSession`, `addMedia`, `removeMedia`) notify listeners when the media set changes. Listeners are held in a `CopyOnWriteArraySet` and invoked outside the tracker lock to avoid re-entrant deadlock; `addMedia`/`removeMedia` notify only when the set actually changes.
2. `SecureViewerActivity` registers a listener in `onStart()` and unregisters it in `onStop()`. The callback marshals `refreshMedia()` onto the UI thread, so a photo added to the session shortly after the viewer opens now updates the view instead of leaving a black screen.

The one-shot `refreshMedia()` call moved out of `onCreate()` into `onStart()` (which always runs right after `onCreate()` and now performs the initial read when it registers the observer), so the previous `onCreate()` call would be redundant.

## Tests

Added unit tests to `SessionTrackerTest` covering observer notification on add/remove/start/end, no-notify on duplicate add, no-notify when the session is inactive, no-notify when `removeMedia` removes nothing, and that a removed listener stops receiving callbacks. The full `:app:testDebugUnitTest` suite passes and the debug variant compiles. The end-to-end fix is exercised by the existing `test5a` E2E test on the emulator in CI.

