### PR TITLE
Render SecureViewerActivity reactively from a session-media StateFlow

### DIFF
--- a/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
@@ -87,7 +87,7 @@ class SecureViewerActivity : ComponentActivity() {
         setTurnScreenOn(true)
 
         setupLayout()
-        refreshMedia()
+        renderMedia(sessionTracker.getSessionMedia())
     }
 
     override fun onStart() {
@@ -114,7 +114,7 @@ class SecureViewerActivity : ComponentActivity() {
             finish()
             return
         }
-        refreshMedia()
+        renderMedia(sessionTracker.getSessionMedia())
     }
 
     // H4: ContentObserver registration/unregistration has been removed.
@@ -222,7 +222,7 @@ class SecureViewerActivity : ComponentActivity() {
     ) {
         // Remove from session immediately
         sessionTracker.removeMedia(media.uri)
-        refreshMedia()
+        renderMedia(sessionTracker.getSessionMedia())
 
         // SF-10: Show undo snackbar
         val rootView = findViewById<View>(android.R.id.content)
@@ -234,7 +234,7 @@ class SecureViewerActivity : ComponentActivity() {
             ).setAction(R.string.viewer_undo) {
                 // Undo: re-add to session
                 sessionTracker.addMedia(media)
-                refreshMedia()
+                renderMedia(sessionTracker.getSessionMedia())
             }.addCallback(
                 object : Snackbar.Callback() {
                     override fun onDismissed(
@@ -281,8 +281,7 @@ class SecureViewerActivity : ComponentActivity() {
         )
     }
 
-    private fun refreshMedia() {
-        val media = sessionTracker.getSessionMedia()
+    private fun renderMedia(media: List<MediaItem>) {
         adapter.submitList(media)
         emptyMessage.visibility = if (media.isEmpty()) View.VISIBLE else View.GONE
         viewPager.visibility = if (media.isEmpty()) View.GONE else View.VISIBLE

--- a/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SecureViewerActivity.kt
@@ -20,7 +20,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.ListAdapter
@@ -87,7 +89,18 @@ class SecureViewerActivity : ComponentActivity() {
         setTurnScreenOn(true)
 
         setupLayout()
-        renderMedia(sessionTracker.getSessionMedia())
+
+        // #537: Render reactively from the session's StateFlow rather than a one-shot read.
+        // The replayed initial value covers the first render, and any later population
+        // (or repopulation after a transient reset) re-renders automatically, closing the
+        // race where the viewer opened before SessionTracker was populated.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                sessionTracker.sessionMedia.collect { media ->
+                    renderMedia(media)
+                }
+            }
+        }
     }
 
     override fun onStart() {
@@ -114,7 +127,8 @@ class SecureViewerActivity : ComponentActivity() {
             finish()
             return
         }
-        renderMedia(sessionTracker.getSessionMedia())
+        // #537: No explicit render here; the lifecycle-scoped collector started in
+        // onCreate() re-collects the StateFlow's current value on returning to STARTED.
     }
 
     // H4: ContentObserver registration/unregistration has been removed.
@@ -220,9 +234,8 @@ class SecureViewerActivity : ComponentActivity() {
         media: MediaItem,
         position: Int,
     ) {
-        // Remove from session immediately
+        // Remove from session immediately; the sessionMedia collector re-renders (#537).
         sessionTracker.removeMedia(media.uri)
-        renderMedia(sessionTracker.getSessionMedia())
 
         // SF-10: Show undo snackbar
         val rootView = findViewById<View>(android.R.id.content)
@@ -232,9 +245,8 @@ class SecureViewerActivity : ComponentActivity() {
                 com.gb4pc.Constants.UNDO_TIMEOUT_MS
                     .toInt(),
             ).setAction(R.string.viewer_undo) {
-                // Undo: re-add to session
+                // Undo: re-add to session; the sessionMedia collector re-renders (#537).
                 sessionTracker.addMedia(media)
-                renderMedia(sessionTracker.getSessionMedia())
             }.addCallback(
                 object : Snackbar.Callback() {
                     override fun onDismissed(

--- a/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
@@ -1,6 +1,9 @@
 package com.gb4pc.viewer
 
 import com.gb4pc.Constants
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Tracks the current secure camera session and its media items (§5.1).
@@ -18,6 +21,15 @@ class SessionTracker {
 
     private val mediaItems = mutableListOf<MediaItem>()
 
+    private val _sessionMedia = MutableStateFlow<List<MediaItem>>(emptyList())
+
+    /**
+     * SF-07: Observable, most-recent-first view of the current session media.
+     * Emits a fresh list on every mutation so collectors (e.g. SecureViewerActivity)
+     * re-render when the session is populated, reset, or edited (#537).
+     */
+    val sessionMedia: StateFlow<List<MediaItem>> = _sessionMedia.asStateFlow()
+
     /**
      * SF-01: Begin a new session, recording the start timestamp (SF-02).
      */
@@ -26,6 +38,7 @@ class SessionTracker {
             isSessionActive = true
             sessionStartTimestamp = System.currentTimeMillis()
             mediaItems.clear()
+            emitSnapshot()
         }
     }
 
@@ -36,6 +49,7 @@ class SessionTracker {
         synchronized(lock) {
             isSessionActive = false
             mediaItems.clear()
+            emitSnapshot()
         }
     }
 
@@ -44,13 +58,16 @@ class SessionTracker {
             if (!isSessionActive) return
             if (mediaItems.none { it.uri == item.uri }) {
                 mediaItems.add(item)
+                emitSnapshot()
             }
         }
     }
 
     fun removeMedia(uri: String) {
         synchronized(lock) {
-            mediaItems.removeAll { it.uri == uri }
+            if (mediaItems.removeAll { it.uri == uri }) {
+                emitSnapshot()
+            }
         }
     }
 
@@ -67,6 +84,16 @@ class SessionTracker {
      * Callers must already hold [lock].
      */
     private fun sortedSnapshot(): List<MediaItem> = mediaItems.sortedByDescending { it.dateTaken }
+
+    /**
+     * Publishes a fresh snapshot to [sessionMedia]. Callers must already hold [lock]
+     * so the emitted list is consistent with the state under the lock.
+     * A new list instance is emitted so StateFlow structural-equality de-duplication
+     * compares contents rather than the same mutable reference.
+     */
+    private fun emitSnapshot() {
+        _sessionMedia.value = sortedSnapshot()
+    }
 
     /**
      * SF-04: Check if a media item belongs to the current session.

--- a/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
+++ b/app/src/main/java/com/gb4pc/viewer/SessionTracker.kt
@@ -59,8 +59,14 @@ class SessionTracker {
      */
     fun getSessionMedia(): List<MediaItem> =
         synchronized(lock) {
-            mediaItems.sortedByDescending { it.dateTaken }
+            sortedSnapshot()
         }
+
+    /**
+     * SF-07: Builds a fresh, most-recent-first snapshot of the current media.
+     * Callers must already hold [lock].
+     */
+    private fun sortedSnapshot(): List<MediaItem> = mediaItems.sortedByDescending { it.dateTaken }
 
     /**
      * SF-04: Check if a media item belongs to the current session.

--- a/app/src/test/java/com/gb4pc/viewer/SecureViewerActivityRenderTest.kt
+++ b/app/src/test/java/com/gb4pc/viewer/SecureViewerActivityRenderTest.kt
@@ -1,0 +1,101 @@
+package com.gb4pc.viewer
+
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.viewpager2.widget.ViewPager2
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Robolectric regression test for the SecureViewerActivity race (#537).
+ *
+ * The viewer used to read SessionTracker exactly once in onCreate(). If the
+ * session was still empty at that instant (population lands asynchronously, or
+ * the session is briefly reset around tap time) the viewer showed the empty
+ * "no photos" state forever. The reactive sessionMedia collector must re-render
+ * when the session is populated after the activity has already started.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SecureViewerActivityRenderTest {
+    private val tracker get() = SessionTracker.instance
+
+    @Before
+    fun resetSession() {
+        // Start from a known, empty-but-active session on the process-wide singleton.
+        tracker.startSession()
+    }
+
+    @After
+    fun clearSession() {
+        tracker.endSession()
+    }
+
+    private fun emptyMessageOf(activity: SecureViewerActivity): TextView {
+        val root = activity.findViewById<View>(android.R.id.content)
+        // The empty-state TextView is the only TextView added to the viewer layout.
+        return findFirstTextView(root) ?: error("empty-state TextView not found")
+    }
+
+    private fun findFirstTextView(view: View): TextView? {
+        if (view is TextView) return view
+        if (view is android.view.ViewGroup) {
+            for (i in 0 until view.childCount) {
+                findFirstTextView(view.getChildAt(i))?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private fun viewPagerOf(activity: SecureViewerActivity): ViewPager2 {
+        val root = activity.findViewById<View>(android.R.id.content)
+        return findFirstViewPager(root) ?: error("ViewPager2 not found")
+    }
+
+    private fun findFirstViewPager(view: View): ViewPager2? {
+        if (view is ViewPager2) return view
+        if (view is android.view.ViewGroup) {
+            for (i in 0 until view.childCount) {
+                findFirstViewPager(view.getChildAt(i))?.let { return it }
+            }
+        }
+        return null
+    }
+
+    @Test
+    fun `viewer opened against empty session shows empty state`() {
+        ActivityScenario.launch(SecureViewerActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                shadowOf(activity.mainLooper).idle()
+                assertEquals(View.VISIBLE, emptyMessageOf(activity).visibility)
+                assertEquals(View.GONE, viewPagerOf(activity).visibility)
+            }
+        }
+    }
+
+    @Test
+    fun `late population re-renders viewer from empty to populated`() {
+        ActivityScenario.launch(SecureViewerActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                shadowOf(activity.mainLooper).idle()
+                // Regression precondition: viewer started with an empty session.
+                assertEquals(View.VISIBLE, emptyMessageOf(activity).visibility)
+
+                // Session is populated after the activity is already showing.
+                tracker.addMedia(
+                    MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false),
+                )
+                shadowOf(activity.mainLooper).idle()
+
+                // The reactive collector must have re-rendered to the populated state.
+                assertEquals(View.GONE, emptyMessageOf(activity).visibility)
+                assertEquals(View.VISIBLE, viewPagerOf(activity).visibility)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
+++ b/app/src/test/java/com/gb4pc/viewer/SessionTrackerTest.kt
@@ -1,6 +1,7 @@
 package com.gb4pc.viewer
 
 import com.gb4pc.Constants
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -122,6 +123,57 @@ class SessionTrackerTest {
         assertEquals(1, tracker.getSessionMedia().size)
         assertEquals("content://media/2", tracker.getSessionMedia()[0].uri)
     }
+
+    // ---------------------------------------------------------------------------
+    // sessionMedia StateFlow (#537): reactive observable surface
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `sessionMedia starts empty`() {
+        assertTrue(tracker.sessionMedia.value.isEmpty())
+    }
+
+    @Test
+    fun `sessionMedia emits added item`() =
+        runTest {
+            tracker.startSession()
+            val item = MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false)
+            tracker.addMedia(item)
+
+            assertEquals(listOf(item), tracker.sessionMedia.value)
+        }
+
+    @Test
+    fun `sessionMedia emits empty after endSession`() =
+        runTest {
+            tracker.startSession()
+            tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+            tracker.endSession()
+
+            assertTrue(tracker.sessionMedia.value.isEmpty())
+        }
+
+    @Test
+    fun `sessionMedia emits reduced list after removeMedia`() =
+        runTest {
+            tracker.startSession()
+            tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+            tracker.addMedia(MediaItem(uri = "content://media/2", dateTaken = 2000L, isVideo = false))
+            tracker.removeMedia("content://media/1")
+
+            assertEquals(listOf("content://media/2"), tracker.sessionMedia.value.map { it.uri })
+        }
+
+    @Test
+    fun `sessionMedia ordering matches getSessionMedia`() =
+        runTest {
+            tracker.startSession()
+            tracker.addMedia(MediaItem(uri = "content://media/1", dateTaken = 1000L, isVideo = false))
+            tracker.addMedia(MediaItem(uri = "content://media/2", dateTaken = 3000L, isVideo = false))
+            tracker.addMedia(MediaItem(uri = "content://media/3", dateTaken = 2000L, isVideo = false))
+
+            assertEquals(tracker.getSessionMedia(), tracker.sessionMedia.value)
+        }
 
     @Test
     fun `getSessionMedia returns most recent first per SF-07`() {

--- a/app/src/test/java/com/gb4pc/viewer/SessionTrackerThreadSafetyTest.kt
+++ b/app/src/test/java/com/gb4pc/viewer/SessionTrackerThreadSafetyTest.kt
@@ -52,6 +52,9 @@ class SessionTrackerThreadSafetyTest {
         // All items should have been added
         val media = tracker.getSessionMedia()
         assertEquals(threadCount * iterations, media.size)
+        // #537: the emitted StateFlow snapshot must agree with getSessionMedia()
+        // after concurrent mutations (and emission under lock must not deadlock).
+        assertEquals(media, tracker.sessionMedia.value)
     }
 
     @Test


### PR DESCRIPTION
Fixes #537.

## Problem

`SecureViewerActivity` read `SessionTracker` exactly once in `onCreate()` (and again in `onResume()`). If the secure session was still empty at that instant, the viewer rendered the empty "no photos" state and never recovered. Two things can leave the session empty at read time, both unrecoverable with a one-shot read:

1. Media population lands asynchronously (the `OverlayService` media observer adds media after the activity has started).
2. The session is briefly reset (`hideOverlayAndCleanup()` calls `endSession()`) around a camera-availability transition near tap time.

This made `test5a_secureCameraLockedPopulatedGalleryShowsGreen` flake (viewer stayed black, `waitForGreenBand` timed out) and, more importantly, could show a locked user an empty viewer even though the session had photos.

## Fix

Make the viewer render reactively from an observable session surface, so it re-renders on any later population or repopulation, removing the timing assumption entirely (issue's preferred option 1).

- **`SessionTracker`**: add a read-only `sessionMedia: StateFlow<List<MediaItem>>`. Every mutation (`startSession`/`endSession`/`addMedia`/`removeMedia`) emits a fresh, most-recent-first snapshot built by a shared `sortedSnapshot()` helper, so the flow and `getSessionMedia()` never disagree. Emission happens under the existing lock so the snapshot is consistent with the locked state.
- **`SecureViewerActivity`**: collect `sessionMedia` in a `lifecycleScope` + `repeatOnLifecycle(STARTED)` collector started in `onCreate()`. The replayed initial value renders once (no double render); later emissions re-render automatically. The one-shot read in `onCreate()`, the redundant `onResume()` render (keyguard check unchanged), and the explicit renders in the delete/undo handlers are dropped, since the mutations now drive the flow.

`getSessionMedia()` is unchanged and kept for existing callers; the flow is purely additive. No changes were needed to `OverlayService`/`OverlayServiceLogic`.

## Commits (split by concern)

1. Pure refactor: extract `sortedSnapshot()` in `SessionTracker`; extract `renderMedia(list)` from `refreshMedia()` in the viewer.
2. Feature: add the `sessionMedia` `StateFlow` and emit on every mutation, with unit tests.
3. Fix: wire the reactive collector, drop the one-shot/handler-side renders, add the Robolectric regression test.

## Tests

- `SessionTrackerTest`: flow starts empty, emits on add, empties on `endSession`, reduces on `removeMedia`, and ordering agrees with `getSessionMedia()`.
- `SessionTrackerThreadSafetyTest`: now also asserts the final emitted snapshot matches `getSessionMedia()` after concurrent mutations (guards against deadlock from emitting under the lock).
- `SecureViewerActivityRenderTest` (new, Robolectric): launches the viewer against an empty session and asserts it flips from the empty state to the populated state when media is added after the activity is already showing -- the unit-layer regression for the race.
- Full `:app:testDebugUnitTest` suite runs green locally.

`test5a` E2E assertions are unchanged; it is the end-to-end validation and should stop flaking now that the viewer re-renders on late population.

## Open questions from the issue's plan

- The separate "session reset around tap time" behavior (question 1) is masked by this reactive fix but may still be worth a follow-up issue if the session is genuinely ended/restarted around a valid tap.
- No `.github/allowed-test-failures.txt` stopgap was added (question 2): the fix lands directly.
- `StateFlow` was used as the observable primitive (question 3).
- `waitForSessionMedia()` in `E2EFixture.kt` was left in place (question 4).
