### PR TITLE
Restore FLAG_LAYOUT_NO_LIMITS on the non-focusable overlay window

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -636,6 +636,43 @@ class E2EFixture(
     }
 
     /**
+     * Polls screenshots until at least one pixel matches [color], or [timeoutMs] elapses.
+     * Returns the last captured screenshot regardless of whether the color appeared, so the
+     * caller's own assertion (built from that screenshot) still produces a meaningful diagnostic
+     * on a genuine failure.
+     *
+     * Issue #556: [waitForOverlayActive] only observes [OverlayService.isOverlayActive], an
+     * internal UsageStats-based flag that can flip true before the corresponding frame (camera
+     * feed plus overlay) is actually composited by the WindowManager -- especially on a
+     * cold-started activity, which briefly shows Android's mandatory splash-screen frame first.
+     * A fixed post-activation pause is a guess at how long compositing takes and silently stops
+     * being enough as CI load changes (e.g. issue #520's concurrent `screenrecord`). Polling for
+     * the actual pixel evidence removes that guess: `ScreenshotTestRule.failed()` proved the
+     * content was correct just moments after a fixed-pause capture went stale (it takes its own
+     * screenshot after the assertion throws and consistently shows the overlay rendered exactly
+     * at the configured position), so the content was never wrong -- only the single early
+     * capture was.
+     *
+     * @param color      The [Rgb] color to poll for.
+     * @param timeoutMs  Maximum wait time in milliseconds.
+     * @param intervalMs Sleep between successive capture attempts.
+     */
+    fun waitForColorVisible(
+        color: Rgb,
+        timeoutMs: Long = 5_000L,
+        intervalMs: Long = 200L,
+    ): android.graphics.Bitmap {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (true) {
+            val screen = Screenshot.captureScreen()
+            if (ColorMatch.mask(screen, color).pixelCount > 0 || System.currentTimeMillis() >= deadline) {
+                return screen
+            }
+            Thread.sleep(intervalMs)
+        }
+    }
+
+    /**
      * Polls screenshots until the GREEN (#00C853) region forms a *letterboxed* band: its bounding
      * box spans at least [minWidthFraction] of the screen width while occupying at most
      * [maxHeightFraction] of the screen height. Returns true if such a band appeared before

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.media.MediaScannerConnection
 import android.os.Build
 import android.os.Environment
@@ -636,10 +637,9 @@ class E2EFixture(
     }
 
     /**
-     * Polls screenshots until at least one pixel matches [color], or [timeoutMs] elapses.
-     * Returns the last captured screenshot regardless of whether the color appeared, so the
-     * caller's own assertion (built from that screenshot) still produces a meaningful diagnostic
-     * on a genuine failure.
+     * Polls screenshots until at least one pixel matches [color], or [timeoutMs] elapses, and
+     * returns the screenshot it last captured -- so the caller asserts against the exact same
+     * image that proved (or failed to prove) the color's presence, not a separately-captured one.
      *
      * Issue #556: [waitForOverlayActive] only observes [OverlayService.isOverlayActive], an
      * internal UsageStats-based flag that can flip true before the corresponding frame (camera
@@ -657,11 +657,11 @@ class E2EFixture(
      * @param timeoutMs  Maximum wait time in milliseconds.
      * @param intervalMs Sleep between successive capture attempts.
      */
-    fun waitForColorVisible(
+    fun captureScreenUntilColorVisible(
         color: Rgb,
         timeoutMs: Long = 5_000L,
         intervalMs: Long = 200L,
-    ): android.graphics.Bitmap {
+    ): Bitmap {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (true) {
             val screen = Screenshot.captureScreen()

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -109,12 +109,13 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay, then
-        // allow one additional frame for the WM to composite the overlay window on screen.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then poll
+        // screenshots until BLUE pixels actually appear on screen (Issue #556). A fixed pause
+        // is only a guess at how long WM compositing takes after activation, and a cold-started
+        // activity briefly shows Android's mandatory splash-screen frame first; a single capture
+        // taken too early sees that stale frame instead of the real content.
         fixture.waitForOverlayActive()
-        fixture.pause(500)
-
-        val screen = Screenshot.captureScreen()
+        val screen = fixture.waitForColorVisible(Rgb.BLUE)
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
         Screenshot.saveForArtifact(screen, "1a-screen.png")
         Screenshot.saveForArtifact(maskToBitmap(blue), "1a-blue-mask.png")
@@ -155,12 +156,11 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay, then
-        // allow one additional frame for the WM to composite the overlay window on screen.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then poll
+        // screenshots until BLUE pixels actually appear on screen (Issue #556). See test1a's
+        // comment for why a fixed post-activation pause is not reliable here.
         fixture.waitForOverlayActive()
-        fixture.pause(500)
-
-        val screen = Screenshot.captureScreen()
+        val screen = fixture.waitForColorVisible(Rgb.BLUE)
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
         Screenshot.saveForArtifact(screen, "1b-screen.png")
         Screenshot.saveForArtifact(maskToBitmap(blue), "1b-blue-mask.png")
@@ -181,12 +181,12 @@ class GalleryButtonVisualE2ETest {
         fixture.seedGalleryPrefs(MOCK_GALLERY_PACKAGE)
         fixture.clearCameraRoll()
         fixture.launchPixelCamera()
-        // Wait for UsageStats-based foreground detection to activate the overlay, then
-        // allow one additional frame for the WM to composite the overlay window on screen.
+        // Wait for UsageStats-based foreground detection to activate the overlay, then poll
+        // screenshots until BLUE pixels actually appear on screen (Issue #556). See test1a's
+        // comment for why a fixed post-activation pause is not reliable here. YELLOW is part of
+        // the same overlay icon draw, so BLUE's appearance is a reliable proxy for it too.
         fixture.waitForOverlayActive()
-        fixture.pause(500)
-
-        val screen = Screenshot.captureScreen()
+        val screen = fixture.waitForColorVisible(Rgb.BLUE)
         val outer =
             ColorMatch.union(
                 ColorMatch.mask(screen, Rgb.BLUE),

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -115,7 +115,7 @@ class GalleryButtonVisualE2ETest {
         // activity briefly shows Android's mandatory splash-screen frame first; a single capture
         // taken too early sees that stale frame instead of the real content.
         fixture.waitForOverlayActive()
-        val screen = fixture.waitForColorVisible(Rgb.BLUE)
+        val screen = fixture.captureScreenUntilColorVisible(Rgb.BLUE)
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
         Screenshot.saveForArtifact(screen, "1a-screen.png")
         Screenshot.saveForArtifact(maskToBitmap(blue), "1a-blue-mask.png")
@@ -160,7 +160,7 @@ class GalleryButtonVisualE2ETest {
         // screenshots until BLUE pixels actually appear on screen (Issue #556). See test1a's
         // comment for why a fixed post-activation pause is not reliable here.
         fixture.waitForOverlayActive()
-        val screen = fixture.waitForColorVisible(Rgb.BLUE)
+        val screen = fixture.captureScreenUntilColorVisible(Rgb.BLUE)
         val blue = ColorMatch.mask(screen, Rgb.BLUE)
         Screenshot.saveForArtifact(screen, "1b-screen.png")
         Screenshot.saveForArtifact(maskToBitmap(blue), "1b-blue-mask.png")
@@ -186,7 +186,7 @@ class GalleryButtonVisualE2ETest {
         // comment for why a fixed post-activation pause is not reliable here. YELLOW is part of
         // the same overlay icon draw, so BLUE's appearance is a reliable proxy for it too.
         fixture.waitForOverlayActive()
-        val screen = fixture.waitForColorVisible(Rgb.BLUE)
+        val screen = fixture.captureScreenUntilColorVisible(Rgb.BLUE)
         val outer =
             ColorMatch.union(
                 ColorMatch.mask(screen, Rgb.BLUE),

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -450,32 +450,25 @@ class OverlayManager(
         // above relative to the full display size) land the overlay too far down the screen
         // (Issue #229 — the overlay rendered ~128 px lower than the configured yPercent).
         // This flag makes (x, y) relative to the true physical-screen origin (0, 0), matching
-        // calculateOverlayXPx/calculateOverlayYPx's assumptions, and on its own is sufficient to
-        // place the surface correctly (test1a confirms this; it does not require
-        // FLAG_LAYOUT_NO_LIMITS). The focusable branch additionally keeps FLAG_LAYOUT_NO_LIMITS,
-        // but only because that path is not exercised by the failing default-prefs test, not
-        // because positioning needs it.
+        // calculateOverlayXPx/calculateOverlayYPx's assumptions.
         //
         // FLAG_NOT_TOUCH_MODAL (both branches): the overlay is a small (sizePx x sizePx)
         // window. This flag forwards pointer events that fall *outside* the window bounds to the
         // windows behind it (so the surrounding camera-app touches pass through), while in-bounds
         // touches go to this window's clickable ImageView.
         //
-        // FLAG_LAYOUT_NO_LIMITS is not set on the non-focusable branch. The overlay icon is small
-        // and positioned well inside the display (default 20% / 69%, ~16% of the min dimension), so
-        // it never needs to extend past the screen limits; keeping the frame within screen limits
-        // aligns its touchable region with the FLAG_LAYOUT_IN_SCREEN-placed surface.
-        //
-        // Historical note (Issue #230 / #397): earlier rounds dropped FLAG_LAYOUT_NO_LIMITS here on
-        // the theory that test2a_emptyGalleryNoGreenAfterTap's tap was not reaching this window. CI
-        // logcat (after the diagnostics below were made to emit) disproved that theory: the tap DOES
-        // fire handleTap() and DOES launch the gallery. test2a's ~87% green was actually the gallery
-        // activity crashing on launch and the green camera being restored to the foreground; the
-        // real fix was in the mock gallery's MediaStore query, not these flags. The flag set is kept
-        // because test1a confirms the surface position is correct under it.
-        //
-        // The focusable branch keeps FLAG_LAYOUT_NO_LIMITS unchanged (it is not exercised by the
-        // failing default-prefs test path).
+        // FLAG_LAYOUT_NO_LIMITS (both branches, Issue #556): combined with FLAG_LAYOUT_IN_SCREEN,
+        // this keeps the window's surface unclipped by display insets (status/nav bars, cutouts),
+        // so it renders at the exact physical-screen coordinates calculateOverlayXPx/
+        // calculateOverlayYPx computed. PR #398 (commit ce20d71) dropped this flag from the
+        // non-focusable branch on the theory that keeping the frame within screen limits would
+        // align the touchable region with the surface for test2a, and justified keeping it dropped
+        // by citing test1a as still passing under that flag set. Neither claim held up: test2a's
+        // real fix was unrelated (the LastPhotoActivity MediaStore query crash, not these flags),
+        // and test1a in fact regressed to a more severe failure (pixelCount=0 — the overlay wasn't
+        // rendering on screen at all, apparently clipped by display insets without this flag) on
+        // every CI run since (see issue #556). Restoring FLAG_LAYOUT_NO_LIMITS here matches the
+        // focusable branch, which kept it the whole time.
         val windowFlags =
             if (prefsManager.focusableOverlay) {
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
@@ -485,6 +478,7 @@ class OverlayManager(
             } else {
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                     WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
                     WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                     showWhenLockedFlag
             }

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -457,17 +457,7 @@ class OverlayManager(
         // windows behind it (so the surrounding camera-app touches pass through), while in-bounds
         // touches go to this window's clickable ImageView.
         //
-        // FLAG_LAYOUT_NO_LIMITS is not set on the non-focusable branch. Issue #556 originally
-        // suspected that PR #398 (commit ce20d71) dropping this flag here caused test1a's
-        // pixelCount=0 regression, and an earlier round of this fix restored it on that theory.
-        // Direct CI evidence (see issue #556 / PR #557) disproved that: with the flag restored,
-        // test1a still failed with the exact same signature as without it, and the actual
-        // screenshot evidence (a JUnit TestWatcher's post-failure screenshot, taken moments after
-        // the assertion's own screenshot) showed the overlay rendering correctly regardless --
-        // the real bug was a screenshot-timing race in the E2E test harness (fixed in
-        // E2EFixture.captureScreenUntilColorVisible), unrelated to this flag. No evidence
-        // supports setting this flag on the non-focusable branch, so it is left unset, matching
-        // the flag set that has shipped since PR #398.
+        // FLAG_LAYOUT_NO_LIMITS is not set on the non-focusable branch (see PRs #398 & #557).
         val windowFlags =
             if (prefsManager.focusableOverlay) {
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or

--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -457,18 +457,17 @@ class OverlayManager(
         // windows behind it (so the surrounding camera-app touches pass through), while in-bounds
         // touches go to this window's clickable ImageView.
         //
-        // FLAG_LAYOUT_NO_LIMITS (both branches, Issue #556): combined with FLAG_LAYOUT_IN_SCREEN,
-        // this keeps the window's surface unclipped by display insets (status/nav bars, cutouts),
-        // so it renders at the exact physical-screen coordinates calculateOverlayXPx/
-        // calculateOverlayYPx computed. PR #398 (commit ce20d71) dropped this flag from the
-        // non-focusable branch on the theory that keeping the frame within screen limits would
-        // align the touchable region with the surface for test2a, and justified keeping it dropped
-        // by citing test1a as still passing under that flag set. Neither claim held up: test2a's
-        // real fix was unrelated (the LastPhotoActivity MediaStore query crash, not these flags),
-        // and test1a in fact regressed to a more severe failure (pixelCount=0 — the overlay wasn't
-        // rendering on screen at all, apparently clipped by display insets without this flag) on
-        // every CI run since (see issue #556). Restoring FLAG_LAYOUT_NO_LIMITS here matches the
-        // focusable branch, which kept it the whole time.
+        // FLAG_LAYOUT_NO_LIMITS is not set on the non-focusable branch. Issue #556 originally
+        // suspected that PR #398 (commit ce20d71) dropping this flag here caused test1a's
+        // pixelCount=0 regression, and an earlier round of this fix restored it on that theory.
+        // Direct CI evidence (see issue #556 / PR #557) disproved that: with the flag restored,
+        // test1a still failed with the exact same signature as without it, and the actual
+        // screenshot evidence (a JUnit TestWatcher's post-failure screenshot, taken moments after
+        // the assertion's own screenshot) showed the overlay rendering correctly regardless --
+        // the real bug was a screenshot-timing race in the E2E test harness (fixed in
+        // E2EFixture.captureScreenUntilColorVisible), unrelated to this flag. No evidence
+        // supports setting this flag on the non-focusable branch, so it is left unset, matching
+        // the flag set that has shipped since PR #398.
         val windowFlags =
             if (prefsManager.focusableOverlay) {
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
@@ -478,7 +477,6 @@ class OverlayManager(
             } else {
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                     WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
-                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
                     WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                     showWhenLockedFlag
             }

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -294,27 +294,23 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issue #556: overlay surface must not be clipped by display insets ────
+    // ── Issue #556: FLAG_LAYOUT_NO_LIMITS is not the non-focusable window's problem ──
 
     /**
      * Regression guard for Issue #556 (`test1a_overlayShowsBlueAtConfiguredPosition`): the
-     * small, non-focusable overlay window must set `FLAG_LAYOUT_NO_LIMITS`.
+     * small, non-focusable overlay window must NOT set `FLAG_LAYOUT_NO_LIMITS`.
      *
-     * PR #398 (commit ce20d71) dropped this flag from the non-focusable branch on the theory
-     * that keeping the window's frame within screen limits would align its touchable region
-     * with the `FLAG_LAYOUT_IN_SCREEN`-placed surface for `test2a_emptyGalleryNoGreenAfterTap`,
-     * and justified the drop by citing `test1a` as still passing under the resulting flag set.
-     * Neither claim held up: `test2a`'s real fix was unrelated (a `LastPhotoActivity` MediaStore
-     * query crash, not these flags), and `test1a` in fact regressed on every CI run since,
-     * to a more severe failure mode (`pixelCount=0`: the overlay was not rendering on screen at
-     * all, consistent with the window being clipped by display insets without this flag).
-     *
-     * This test previously asserted the opposite (that this flag must NOT be set); that
-     * assertion encoded the disproven theory above and is inverted here to match the corrected
-     * understanding (Issue #556).
+     * Issue #556 originally suspected that PR #398 (commit ce20d71) dropping this flag here
+     * caused test1a's `pixelCount=0` regression, and an earlier round of the #556 fix restored
+     * it on that theory (also inverting this test's assertion to match). Direct CI evidence
+     * (see PR #557) disproved the theory: with the flag restored, test1a still failed with the
+     * exact same failure signature as without it. The real bug was a screenshot-timing race in
+     * the E2E test harness, unrelated to this flag (fixed via
+     * `E2EFixture.captureScreenUntilColorVisible`). This test is restored to its original
+     * assertion, since no evidence supports setting this flag on the non-focusable branch.
      */
     @Test
-    fun `non-focusable overlay window sets FLAG_LAYOUT_NO_LIMITS`() {
+    fun `non-focusable overlay window does not set FLAG_LAYOUT_NO_LIMITS`() {
         val context: Application = ApplicationProvider.getApplicationContext()
         val prefsManager: PrefsManager =
             mock {
@@ -332,10 +328,9 @@ class OverlayManagerRobolectricTest {
         val params = overlayView.layoutParams as WindowManager.LayoutParams
 
         assertTrue(
-            "Non-focusable overlay window must set FLAG_LAYOUT_NO_LIMITS, combined with " +
-                "FLAG_LAYOUT_IN_SCREEN, so the surface is not clipped by display insets and " +
-                "renders at the configured position (Issue #556).",
-            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0,
+            "Non-focusable overlay window must NOT set FLAG_LAYOUT_NO_LIMITS (Issue #556: " +
+                "restoring it did not fix test1a in CI, and no evidence supports setting it).",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) == 0,
         )
     }
 

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -294,46 +294,6 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issue #556: FLAG_LAYOUT_NO_LIMITS is not the non-focusable window's problem ──
-
-    /**
-     * Regression guard for Issue #556 (`test1a_overlayShowsBlueAtConfiguredPosition`): the
-     * small, non-focusable overlay window must NOT set `FLAG_LAYOUT_NO_LIMITS`.
-     *
-     * Issue #556 originally suspected that PR #398 (commit ce20d71) dropping this flag here
-     * caused test1a's `pixelCount=0` regression, and an earlier round of the #556 fix restored
-     * it on that theory (also inverting this test's assertion to match). Direct CI evidence
-     * (see PR #557) disproved the theory: with the flag restored, test1a still failed with the
-     * exact same failure signature as without it. The real bug was a screenshot-timing race in
-     * the E2E test harness, unrelated to this flag (fixed via
-     * `E2EFixture.captureScreenUntilColorVisible`). This test is restored to its original
-     * assertion, since no evidence supports setting this flag on the non-focusable branch.
-     */
-    @Test
-    fun `non-focusable overlay window does not set FLAG_LAYOUT_NO_LIMITS`() {
-        val context: Application = ApplicationProvider.getApplicationContext()
-        val prefsManager: PrefsManager =
-            mock {
-                on { galleryPackage } doReturn null
-                on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
-                on { focusableOverlay } doReturn false
-            }
-
-        val overlayManager = OverlayManager(context, prefsManager)
-        overlayManager.show()
-
-        val windowManager = context.getSystemService(WindowManager::class.java)
-        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-        val overlayView = shadowWm.views[0]
-        val params = overlayView.layoutParams as WindowManager.LayoutParams
-
-        assertTrue(
-            "Non-focusable overlay window must NOT set FLAG_LAYOUT_NO_LIMITS (Issue #556: " +
-                "restoring it did not fix test1a in CI, and no evidence supports setting it).",
-            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) == 0,
-        )
-    }
-
     // ── Issue #230 / #397: tap on the overlay reaches its clickable ImageView ─
 
     /**

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -294,24 +294,27 @@ class OverlayManagerRobolectricTest {
         )
     }
 
-    // ── Issue #230 / #397: small window keeps its touchable region on-screen ──
+    // ── Issue #556: overlay surface must not be clipped by display insets ────
 
     /**
-     * Regression guard for Issue #230 / #397
-     * (`test2a_emptyGalleryNoGreenAfterTap`): the small, non-focusable overlay window must NOT set
-     * `FLAG_LAYOUT_NO_LIMITS`.
+     * Regression guard for Issue #556 (`test1a_overlayShowsBlueAtConfiguredPosition`): the
+     * small, non-focusable overlay window must set `FLAG_LAYOUT_NO_LIMITS`.
      *
-     * The icon is small and positioned well inside the display (default 20% / 69%, ~16% of the
-     * min dimension), so it never needs to extend past the screen limits. With
-     * `FLAG_LAYOUT_NO_LIMITS` the frame the WindowManager uses to derive the touchable input
-     * region can diverge from the on-screen surface for such a small window, so an in-bounds tap
-     * is not routed to the window and `handleTap()` never fires. CI observed exactly that: even
-     * with `FLAG_NOT_TOUCH_MODAL` set, the tap stayed a no-op (~87% green) while the surface
-     * position was correct (test1a passed). Dropping `FLAG_LAYOUT_NO_LIMITS` keeps the frame
-     * within screen limits so the touchable region matches the surface.
+     * PR #398 (commit ce20d71) dropped this flag from the non-focusable branch on the theory
+     * that keeping the window's frame within screen limits would align its touchable region
+     * with the `FLAG_LAYOUT_IN_SCREEN`-placed surface for `test2a_emptyGalleryNoGreenAfterTap`,
+     * and justified the drop by citing `test1a` as still passing under the resulting flag set.
+     * Neither claim held up: `test2a`'s real fix was unrelated (a `LastPhotoActivity` MediaStore
+     * query crash, not these flags), and `test1a` in fact regressed on every CI run since,
+     * to a more severe failure mode (`pixelCount=0`: the overlay was not rendering on screen at
+     * all, consistent with the window being clipped by display insets without this flag).
+     *
+     * This test previously asserted the opposite (that this flag must NOT be set); that
+     * assertion encoded the disproven theory above and is inverted here to match the corrected
+     * understanding (Issue #556).
      */
     @Test
-    fun `non-focusable overlay window does not set FLAG_LAYOUT_NO_LIMITS`() {
+    fun `non-focusable overlay window sets FLAG_LAYOUT_NO_LIMITS`() {
         val context: Application = ApplicationProvider.getApplicationContext()
         val prefsManager: PrefsManager =
             mock {
@@ -329,11 +332,10 @@ class OverlayManagerRobolectricTest {
         val params = overlayView.layoutParams as WindowManager.LayoutParams
 
         assertTrue(
-            "Non-focusable overlay window must NOT set FLAG_LAYOUT_NO_LIMITS so its small " +
-                "touchable input region stays within screen limits and matches the " +
-                "FLAG_LAYOUT_IN_SCREEN-placed surface, letting in-bounds taps reach the icon " +
-                "(Issue #230 / #397).",
-            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) == 0,
+            "Non-focusable overlay window must set FLAG_LAYOUT_NO_LIMITS, combined with " +
+                "FLAG_LAYOUT_IN_SCREEN, so the surface is not clipped by display insets and " +
+                "renders at the configured position (Issue #556).",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0,
         )
     }
 


### PR DESCRIPTION
Fixes #556.

## Diagnosis: this was a screenshot-timing race, not a window-flag bug

Issue #556 suspected PR #398 (commit `ce20d71`) dropping `FLAG_LAYOUT_NO_LIMITS` from the non-focusable branch of `OverlayManager.createLayoutParams()` caused `test1a`'s `pixelCount=0` regression. Restoring that flag did not fix `test1a` in CI; the failure signature was identical with or without it. Screenshot evidence settled it directly:

- The screenshot `test1a` asserts against (captured inside the test body): a generic Android splash/launcher-icon frame, not `MockCameraActivity`'s content.
- `ScreenshotTestRule.failed()`'s own screenshot (taken moments later, after the assertion already threw): the green camera feed with the gallery-button overlay rendered exactly at the configured position.

The overlay was never mispositioned or unrendered. `test1a`/`test1b`/`test1c` captured their single assertion screenshot before the cold-started `MockCameraActivity` finished transitioning off Android's mandatory splash screen. `waitForOverlayActive()` only polls `OverlayService.isOverlayActive` (an internal UsageStats-based flag), and the fixed `pause(500)` after it was a guess at WM-compositing time that silently stopped being enough, plausibly from added CI load (issue #520's concurrent `screenrecord`, issue #532's extra permission checks).

The `FLAG_LAYOUT_NO_LIMITS` restoration was reverted entirely: `OverlayManager.kt`'s production code is now unchanged from `main`. This was confirmed by isolating it in its own CI run (`0b585fd`, no code change from `2df6018` besides retriggering CI): pre-flight passed, `GalleryButtonVisualE2ETest` ran and passed, `Gate on test failures` passed. That is direct, isolated evidence the flag was never the cause of the live CI failures.

## The fix

Added `E2EFixture.captureScreenUntilColorVisible(color, timeoutMs, intervalMs)`, which polls screenshots (mirroring the existing `waitForGreenCoverage`/`waitForGreenBand` pattern) until the target color actually appears, and returns that exact screenshot for the caller's assertion — no gap between "screenshot that proved readiness" and "screenshot being asserted against". Wired into `test1a`, `test1b`, `test1c` in place of the fixed `pause(500)`.

`test5a_secureCameraLockedPopulatedGalleryShowsGreen` shows the same all-zero symptom but is already tracked separately (allowlisted, issue #243); not touched here.

## Test deletion

Deleted the Robolectric test `non-focusable overlay window does not set FLAG_LAYOUT_NO_LIMITS` (originally added by PR #398). Its rationale (a touch-region theory) was never rigorously established, and this investigation showed the flag doesn't explain test1a's regression either. Neither direction (flag set or unset) is backed by a demonstrated behavioral requirement, so an assertion pinning one direction as required overstated the available evidence. The other flag-contract tests in that file (`FLAG_LAYOUT_IN_SCREEN`, `FLAG_NOT_TOUCH_MODAL`) are kept; those do have direct evidence behind them.

## Tests

`./gradlew testDebugUnitTest` passes across all modules. `:app:compileDebugAndroidTestKotlin` succeeds. The instrumented `test1a`/`test1b`/`test1c`/`test2a` run in CI's instrumented suite and are confirmed green in run 28602463679 (commit `0b585fd`), an isolated run with only the timing fix in play.

## Follow-up suggestion (out of scope here)

While tracing the original (superseded) flag theory, found that commit `ce20d71` also silently dropped a `setFitInsetsTypes(0)` call (added in commit `06fcb34` for issue #230, to align the window's touchable input region with its rendered surface) with no mention in that commit's message. Not addressed here: it affects touch-input alignment, not the rendering/timing issue this PR fixes, and `test2a` (the touch-routing test) is not currently failing in CI. Worth a follow-up issue if touch-alignment problems resurface.