### PR TITLE
Fail safe in CI's non-docs-changes check when no merge base exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,7 @@ jobs:
           else
             BASE_REF="${{ github.base_ref }}"
             git fetch origin "$BASE_REF" --depth=1
-            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD | grep -v '\.md$' || true)
-            echo "needs_full_build=$([ -n "$CHANGED" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+            echo "needs_full_build=$(scripts/check_non_docs_changes.sh "origin/$BASE_REF")" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up JDK 17

--- a/scripts/check_non_docs_changes.sh
+++ b/scripts/check_non_docs_changes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check_non_docs_changes.sh -- decide whether CI's full build/test phase is
+# check_non_docs_changes.sh: decide whether CI's full build/test phase is
 # needed for a pull request, based on whether it touches anything besides
 # Markdown files.
 #

--- a/scripts/check_non_docs_changes.sh
+++ b/scripts/check_non_docs_changes.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# check_non_docs_changes.sh -- decide whether CI's full build/test phase is
+# needed for a pull request, based on whether it touches anything besides
+# Markdown files.
+#
+# Background: this used to be inlined in .github/workflows/build.yml as
+#   CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD | grep -v '\.md$' || true)
+# The triple-dot diff requires a merge base between the base ref and HEAD.
+# When the base branch's history has been rewritten out from under a PR (a
+# force-push or a rebase server-side), no merge base exists and `git diff`
+# fails with "no merge base" and prints nothing to stdout. The trailing
+# `|| true` swallowed that failure, leaving $CHANGED empty -- indistinguishable
+# from "no changes" -- so the full test suite was silently skipped even though
+# the diff was simply undeterminable, not empty. Observed live in CI run
+# https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/27517745981/job/84790634265.
+#
+# This script fixes that by finding the merge base explicitly first, and
+# failing safe (printing "true") when one cannot be found, rather than
+# silently treating "unknown" as "no changes".
+#
+# Usage:
+#   scripts/check_non_docs_changes.sh <base-ref> [<head-ref>]
+#     base-ref  a ref/commit already available locally (e.g. origin/main)
+#     head-ref  defaults to HEAD
+#
+# Prints "true" or "false" to stdout. Always exits 0.
+
+set -uo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || -z "${1:-}" ]]; then
+  grep '^#' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+fi
+
+BASE_REF="$1"
+HEAD_REF="${2:-HEAD}"
+
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null)"
+if [[ -z "$MERGE_BASE" ]]; then
+  echo "::warning::Could not find a merge base with $BASE_REF (its history may have been rewritten); running the full build as a safe default." >&2
+  echo "true"
+  exit 0
+fi
+
+CHANGED="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF" | grep -v '\.md$' || true)"
+if [[ -n "$CHANGED" ]]; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/scripts/check_non_docs_changes.sh
+++ b/scripts/check_non_docs_changes.sh
@@ -28,21 +28,34 @@
 set -uo pipefail
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || -z "${1:-}" ]]; then
-  grep '^#' "$0" | sed 's/^# \{0,1\}//'
+  # Skip line 1 (the shebang): it also matches '^#' but isn't part of the
+  # usage text, and the sed below only strips a bare '#', not '#!'.
+  tail -n +2 "$0" | grep '^#' | sed 's/^# \{0,1\}//'
   exit 1
 fi
 
 BASE_REF="$1"
 HEAD_REF="${2:-HEAD}"
 
-MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null)"
+MERGE_BASE_ERR_FILE="$(mktemp)"
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>"$MERGE_BASE_ERR_FILE")"
+MERGE_BASE_ERR="$(cat "$MERGE_BASE_ERR_FILE")"
+rm -f "$MERGE_BASE_ERR_FILE"
 if [[ -z "$MERGE_BASE" ]]; then
-  echo "::warning::Could not find a merge base with $BASE_REF (its history may have been rewritten); running the full build as a safe default." >&2
+  echo "::warning::Could not find a merge base between $BASE_REF and $HEAD_REF (${MERGE_BASE_ERR:-no diagnostic output from git}); running the full build as a safe default." >&2
   echo "true"
   exit 0
 fi
 
-CHANGED="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF" | grep -v '\.md$' || true)"
+DIFF_OUTPUT="$(git diff --name-only "$MERGE_BASE" "$HEAD_REF")"
+DIFF_RC=$?
+if [[ $DIFF_RC -ne 0 ]]; then
+  echo "::warning::git diff between $MERGE_BASE and $HEAD_REF failed unexpectedly (exit $DIFF_RC); running the full build as a safe default." >&2
+  echo "true"
+  exit 0
+fi
+
+CHANGED="$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '\.md$' || true)"
 if [[ -n "$CHANGED" ]]; then
   echo "true"
 else

--- a/scripts/test_check_non_docs_changes.sh
+++ b/scripts/test_check_non_docs_changes.sh
@@ -16,7 +16,7 @@
 #
 # Always exits 0 on success, non-zero on failure.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK="$SCRIPT_DIR/check_non_docs_changes.sh"

--- a/scripts/test_check_non_docs_changes.sh
+++ b/scripts/test_check_non_docs_changes.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test_check_non_docs_changes.sh -- Shell-based tests for check_non_docs_changes.sh.
+#
+# Builds small throwaway git repos in a temp dir so each test controls the
+# exact commit graph (and, for the no-merge-base case, forces the two graphs
+# to be genuinely disjoint) rather than depending on this repo's real history.
+#
+# Covers:
+#   (a) Base and head identical -> "false"
+#   (b) Only a .md file changed -> "false"
+#   (c) A non-.md file changed -> "true"
+#   (d) A mix of .md and non-.md changes -> "true"
+#   (e) No merge base (disjoint histories, e.g. a rewritten base branch) ->
+#       "true", with a ::warning on stderr
+#   (f) HEAD_REF defaults to HEAD when omitted
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$SCRIPT_DIR/check_non_docs_changes.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Isolate git from the ambient environment: a fixed identity means the tests
+# do not depend on global git config being present on the runner.
+export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@example.com"
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" commit -q --allow-empty -m "base commit"
+BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+# ── (a) Base and head identical -> "false" ───────────────────────────────────
+echo ""
+echo "=== (a) base and head identical -> false ==="
+OUT="$(cd "$REPO" && "$CHECK" "$BASE_SHA" HEAD)"
+if [[ "$OUT" == "false" ]]; then pass "identical refs -> false"; else fail "expected false, got '$OUT'"; fi
+
+# ── (b) Only a .md file changed -> "false" ────────────────────────────────────
+echo ""
+echo "=== (b) only a .md file changed -> false ==="
+echo "hello" > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -q -m "docs only"
+OUT="$(cd "$REPO" && "$CHECK" "$BASE_SHA" HEAD)"
+if [[ "$OUT" == "false" ]]; then pass "docs-only change -> false"; else fail "expected false, got '$OUT'"; fi
+
+# ── (c) A non-.md file changed -> "true" ──────────────────────────────────────
+echo ""
+echo "=== (c) a non-.md file changed -> true ==="
+echo "content" > "$REPO/app.txt"
+git -C "$REPO" add app.txt
+git -C "$REPO" commit -q -m "code change"
+OUT="$(cd "$REPO" && "$CHECK" "$BASE_SHA" HEAD)"
+if [[ "$OUT" == "true" ]]; then pass "non-docs change -> true"; else fail "expected true, got '$OUT'"; fi
+
+# ── (d) A mix of .md and non-.md changes -> "true" ────────────────────────────
+echo ""
+echo "=== (d) a mix of .md and non-.md changes -> true ==="
+echo "more docs" >> "$REPO/README.md"
+echo "more code" >> "$REPO/app.txt"
+git -C "$REPO" add README.md app.txt
+git -C "$REPO" commit -q -m "mixed change"
+OUT="$(cd "$REPO" && "$CHECK" "$BASE_SHA" HEAD)"
+if [[ "$OUT" == "true" ]]; then pass "mixed change -> true"; else fail "expected true, got '$OUT'"; fi
+
+# ── (e) No merge base -> "true", with a ::warning ─────────────────────────────
+echo ""
+echo "=== (e) no merge base (disjoint histories) -> true, with a warning ==="
+ORPHAN="$TMP/orphan"
+mkdir -p "$ORPHAN"
+git -C "$ORPHAN" init -q -b main
+echo "unrelated code" > "$ORPHAN/other.txt"
+git -C "$ORPHAN" add other.txt
+git -C "$ORPHAN" commit -q -m "disjoint history"
+ORPHAN_SHA="$(git -C "$ORPHAN" rev-parse HEAD)"
+# Import the orphan's objects into the main repo without linking histories, so
+# the two SHAs genuinely share no common ancestor within one repo.
+git -C "$REPO" fetch -q "$ORPHAN" main:refs/heads/orphan-main
+STDERR_FILE="$TMP/stderr.txt"
+OUT="$(cd "$REPO" && "$CHECK" "$ORPHAN_SHA" HEAD 2> "$STDERR_FILE")"
+if [[ "$OUT" == "true" ]]; then pass "no merge base -> true (fail safe)"; else fail "expected true, got '$OUT'"; fi
+if grep -q '::warning::' "$STDERR_FILE"; then
+  pass "no merge base emits a ::warning::"
+else
+  fail "expected a ::warning:: on stderr, got: $(cat "$STDERR_FILE")"
+fi
+
+# ── (f) HEAD_REF defaults to HEAD when omitted ────────────────────────────────
+echo ""
+echo "=== (f) head-ref argument is optional, defaults to HEAD ==="
+OUT="$(cd "$REPO" && "$CHECK" "$BASE_SHA")"
+if [[ "$OUT" == "true" ]]; then pass "omitted head-ref defaults to HEAD"; else fail "expected true, got '$OUT'"; fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/test_check_non_docs_changes.sh
+++ b/scripts/test_check_non_docs_changes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test_check_non_docs_changes.sh -- Shell-based tests for check_non_docs_changes.sh.
+# test_check_non_docs_changes.sh: Shell-based tests for check_non_docs_changes.sh.
 #
 # Builds small throwaway git repos in a temp dir so each test controls the
 # exact commit graph (and, for the no-merge-base case, forces the two graphs


### PR DESCRIPTION
## Summary

- The "Check for non-docs changes" step in `.github/workflows/build.yml` used `git diff --name-only origin/$BASE_REF...HEAD`, which requires a merge base between the base branch and HEAD. When the base branch's history is rewritten out from under a PR (e.g. a force-push/reset on `main`), `git diff` fails with `fatal: origin/main...HEAD: no merge base` and prints nothing to stdout. The trailing `|| true` swallowed that failure, leaving the computed diff indistinguishable from "no changes" — so `needs_full_build` silently came out `false` and the full test suite was skipped even though real, significant changes existed.
- Reproduced live in [run 27517745981, job 84790634265](https://github.com/aunger/gallery-button-for-pixel-camera/actions/runs/27517745981/job/84790634265), which shows exactly this `fatal: origin/main...HEAD: no merge base` error.
- Extracted the logic into `scripts/check_non_docs_changes.sh`, which looks up the merge base explicitly before diffing and fails safe to `needs_full_build=true` (with a `::warning::`) when no merge base is found, instead of silently defaulting to skip.

## Test plan

- `scripts/test_check_non_docs_changes.sh` (new) covers: identical refs, docs-only changes, non-docs changes, mixed changes, and the no-merge-base fail-safe path (constructed via genuinely disjoint git histories). Runs automatically as part of the existing "Run shell script unit tests" CI step.
- Manually reproduced the exact bug in a scratch repo (shallow-fetched a rewritten base branch) and confirmed the old inline logic produced `needs_full_build=false` while the new script correctly produces `needs_full_build=true`.

