### PR TITLE
Add workflow_dispatch trigger to build-and-test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,11 @@ jobs:
       - name: Check for non-docs changes
         id: diff_check
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            # Always build on direct pushes to main (e.g. merge commits).
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Always build on direct pushes to main (e.g. merge commits) and on
+            # manual ad hoc runs. github.base_ref is empty for workflow_dispatch,
+            # so falling through to the pull_request branch below would pass an
+            # empty ref to git fetch/check_non_docs_changes.sh--see #577.
             echo "needs_full_build=true" >> $GITHUB_OUTPUT
           else
             BASE_REF="${{ github.base_ref }}"


### PR DESCRIPTION
Fixes #577

## Summary

Adds the `workflow_dispatch` event as a trigger to the Build & Test workflow, enabling ad hoc (manual) runs from the GitHub Actions interface without requiring a push or pull request.

## Changes

- Added `workflow_dispatch:` to the `on:` section of `.github/workflows/build.yml`

This allows users to manually trigger the build-and-test workflow from the GitHub Actions tab, which is useful for testing ad hoc scenarios or re-running tests on a specific commit.
