### PR TITLE
Post a placeholder CI-summary comment when a PR opens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -669,6 +669,28 @@ jobs:
             downloaded-artifacts/e2e-test-results \
               --suite-label "E2E Tests"
 
+  # Reserve the first PR comment for CI status updates (issue #561): as soon
+  # as the PR is opened, post a placeholder comment carrying the same hidden
+  # marker link-pr-to-ci-summary looks for. That job's find-or-update logic
+  # then edits this placeholder in place once real results are ready, instead
+  # of creating a late comment (the build-and-test job can take a long time)
+  # that lands after human review comments have already piled up.
+  reserve-ci-summary-comment:
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Post placeholder CI summary comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_PR_URL: ${{ github.event.pull_request.html_url }}
+        run: python3 scripts/post_pr_ci_placeholder_comment.py
+
   # Surface the build-and-test job's pass/fail summary directly on the PR
   # (issue #331): post or update a sticky comment linking to the job's
   # "Summary" section, e.g. .../actions/runs/<run_id>#summary-<job_id>.

--- a/scripts/post_pr_ci_placeholder_comment.py
+++ b/scripts/post_pr_ci_placeholder_comment.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""post_pr_ci_placeholder_comment.py--Reserve the first PR comment for CI status.
+
+Issue #561: the sticky CI-summary comment (see `post_pr_ci_summary_link.py`)
+is not posted until the `build-and-test` job finishes, which can take a long
+time (full E2E suite). Until then, nothing marks where CI status will show
+up, so the sticky comment often lands after human review comments instead of
+being the first comment on the PR.
+
+This script runs as soon as a PR is opened and posts a placeholder comment
+carrying the same hidden marker `post_pr_ci_summary_link.py` looks for. That
+script's `find_existing_comment` / `upsert_comment` logic then edits this
+placeholder in place once real results are available, rather than creating a
+new comment later.
+
+Usage:
+    python3 scripts/post_pr_ci_placeholder_comment.py
+
+Environment:
+    GITHUB_TOKEN          GitHub token for REST calls (required).
+    GITHUB_REPOSITORY     "owner/repo" (required).
+    WORKFLOW_RUN_PR_URL   The triggering PR's html_url (required).
+
+Exit code is always 0 (display only; a missing placeholder must never fail
+the build).
+"""
+
+import os
+import sys
+
+# Reuse the marker constant and GitHub-comment helpers rather than
+# duplicating them (they must stay in lockstep with post_pr_ci_summary_link.py,
+# which later finds and edits this same comment).
+from post_pr_ci_summary_link import (
+    MARKER,
+    find_existing_comment,
+    pr_number_from_url,
+    upsert_comment,
+)
+
+PLACEHOLDER_BODY = f"{MARKER}\n### CI test summary\n\nCI has not reported results yet.\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # No CLI arguments; configuration comes entirely from the environment.
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_url = os.environ.get("WORKFLOW_RUN_PR_URL", "")
+
+    if not token or not repository:
+        print(
+            "Note: GITHUB_TOKEN/GITHUB_REPOSITORY not set--skipping placeholder comment.",
+            file=sys.stderr,
+        )
+        return 0
+    if not pr_url:
+        print("Note: not a pull_request run--skipping placeholder comment.", file=sys.stderr)
+        return 0
+
+    pr_number = pr_number_from_url(pr_url)
+    if pr_number is None:
+        print(f"Note: could not parse PR number from '{pr_url}'--skipping.", file=sys.stderr)
+        return 0
+
+    lookup = find_existing_comment(token, repository, pr_number)
+    if not lookup.fetch_ok:
+        print(
+            "Warning: skipping placeholder comment: could not fetch existing comments.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if lookup.comment_id is not None:
+        # A sticky CI comment is already there (e.g. a duplicate "opened"
+        # delivery); leave it alone rather than clobbering real results.
+        print(f"Note: PR #{pr_number} already has a CI summary comment; skipping placeholder.")
+        return 0
+
+    if upsert_comment(token, repository, pr_number, PLACEHOLDER_BODY):
+        print(f"Posted placeholder CI summary comment to PR #{pr_number}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_post_pr_ci_placeholder_comment.py
+++ b/scripts/test_post_pr_ci_placeholder_comment.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Unit tests for post_pr_ci_placeholder_comment.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import post_pr_ci_placeholder_comment as placeholder  # noqa: E402
+import post_pr_ci_summary_link as link  # noqa: E402
+
+
+class TestPlaceholderBody(unittest.TestCase):
+    def test_contains_marker(self):
+        self.assertIn(link.MARKER, placeholder.PLACEHOLDER_BODY)
+
+    def test_is_parseable_by_find_existing_comment_marker_check(self):
+        # The body must contain the same MARKER post_pr_ci_summary_link.py
+        # scans for, so the later real-results run edits this comment in
+        # place instead of creating a second one.
+        self.assertTrue(placeholder.PLACEHOLDER_BODY.startswith(link.MARKER))
+
+
+class TestMain(unittest.TestCase):
+    def _env(self, **overrides):
+        env = {
+            "GITHUB_TOKEN": "token",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "WORKFLOW_RUN_PR_URL": "https://github.com/owner/repo/pull/42",
+        }
+        env.update(overrides)
+        return env
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    @patch("post_pr_ci_placeholder_comment.find_existing_comment")
+    def test_posts_placeholder_when_no_comment_exists(self, mock_find, mock_upsert):
+        mock_find.return_value = link.CommentLookup(fetch_ok=True, comment_id=None, body=None)
+        mock_upsert.return_value = True
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_called_once_with(
+            "token", "owner/repo", "42", placeholder.PLACEHOLDER_BODY
+        )
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    @patch("post_pr_ci_placeholder_comment.find_existing_comment")
+    def test_does_not_overwrite_existing_sticky_comment(self, mock_find, mock_upsert):
+        mock_find.return_value = link.CommentLookup(
+            fetch_ok=True, comment_id=7, body=f"{link.MARKER}\nreal results"
+        )
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    @patch("post_pr_ci_placeholder_comment.find_existing_comment")
+    def test_does_not_post_when_fetch_fails(self, mock_find, mock_upsert):
+        mock_find.return_value = link.CommentLookup(fetch_ok=False, comment_id=None, body=None)
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    def test_skips_when_token_missing(self, mock_upsert):
+        with patch.dict(os.environ, self._env(GITHUB_TOKEN=""), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    def test_skips_when_repository_missing(self, mock_upsert):
+        with patch.dict(os.environ, self._env(GITHUB_REPOSITORY=""), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    def test_skips_when_pr_url_missing(self, mock_upsert):
+        with patch.dict(os.environ, self._env(WORKFLOW_RUN_PR_URL=""), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+    @patch("post_pr_ci_placeholder_comment.upsert_comment")
+    def test_skips_when_pr_url_unparseable(self, mock_upsert):
+        with patch.dict(os.environ, self._env(WORKFLOW_RUN_PR_URL="not-a-url"), clear=True):
+            self.assertEqual(placeholder.main([]), 0)
+        mock_upsert.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #561.

`link-pr-to-ci-summary` only posts its sticky CI-summary comment after the `build-and-test` job finishes, which can take a long time (full E2E suite). Until then nothing marks where CI status will show up, so the comment often lands after human review comments instead of being the first comment on the PR.

This adds a `reserve-ci-summary-comment` job that runs as soon as a PR is opened (`github.event.action == 'opened'`) and posts a placeholder comment via the new `scripts/post_pr_ci_placeholder_comment.py`. The placeholder carries the same hidden `<!-- gb4pc-ci-summary-link -->` marker `post_pr_ci_summary_link.py` scans for, so that script's existing find-or-update logic edits this placeholder in place once real results are ready, rather than creating a second, later comment.

`post_pr_ci_placeholder_comment.py` reuses `MARKER`, `find_existing_comment`, `pr_number_from_url`, and `upsert_comment` from `post_pr_ci_summary_link.py` instead of duplicating that GitHub API logic, and skips posting if a sticky comment already exists (for example on a duplicate "opened" delivery) so it never clobbers real results.

Test plan:
- [x] Unit tests added in `scripts/test_post_pr_ci_placeholder_comment.py` cover: posting the placeholder, skipping when a sticky comment already exists, skipping on a fetch error, and skipping when required environment variables are missing.
- [ ] Manually confirm on a live PR that the placeholder comment appears immediately on open, and that `link-pr-to-ci-summary` later edits that same comment in place (no duplicate comment) once `build-and-test` completes.

