### PR TITLE
Add YAML rule reminding agents about Action version consistency

### DIFF
--- a/.claude/rules/yaml-action-reminders.md
+++ b/.claude/rules/yaml-action-reminders.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "**/*.{yaml,yml}"
+---
+# GitHub Actions version reminders
+
+When editing YAML files, keep these priorities in mind:
+
+1. Be consistent with Action versions across this project.
+   Match the versions used by other workflows and *particularly* this same workflow.
+2. If introducing an Action to this project, start with the current version (not just the most recent version you're aware of).
+3. Avoid using Actions developed by third-parties (not GitHub or Microsoft).
+   This isn't a hard rule, but prefer writing your own action script if it's not complex.


### PR DESCRIPTION
Fixes #592.

## What this does

Adds `.claude/rules/yaml-action-reminders.md`, a rule file (following the same pattern as `.claude/rules/prose-style.md` and `.claude/rules/github-mcp-authenticate.md`) with `paths: ["**/*.{yaml,yml}"]` frontmatter so it surfaces whenever an agent touches a YAML file, including GitHub Actions workflows.

The rule reminds agents of the three priorities from the issue, verbatim:

1. Be consistent with Action versions across this project. Match the versions used by other workflows and particularly this same workflow.
2. If introducing an Action to this project, start with the current version (not just the most recent version you're aware of).
3. Avoid using Actions developed by third-parties (not GitHub or Microsoft). This isn't a hard rule, but prefer writing your own action script if it's not complex.

(The issue text contained doubly-HTML-escaped `&amp;` and `&#39;` sequences; those are rendered as plain `&` and `'` here since they're artifacts of how the issue body was pasted, not part of the intended wording.)

## Why no automated test

Like the two prior rule-file additions (#306, #421), this is a prompt-instruction file consumed by the Claude Code harness itself, not by project code, so there's nothing in the repo to exercise with an automated test.

