### PR TITLE
Fix Orchestrator label-gate handling to finish its own bookkeeping first

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -250,7 +250,10 @@ PR routing (Monitor loop):
     if Monitor emits `drain poll found no new diagnostic signals` immediately followed by a Blocked or Infra line -> goto undiagnosedTerminal
     (Note: the attributed `Blocked by: <name>` form already names the blocking check in the per-check summary block and the terminal suffix, so the Monitor suppresses the drain flag in that case. The `goto undiagnosedTerminal` branch therefore applies only to a bare `Blocked`/`Infra` line that the Monitor itself flagged as undiagnosed.)
     if Monitor emits a Blocked line where the terminal ends with `[label gate]` (the ` by: ...` suffix names only label-gate checks) -> clear the silentVanish re-launch flag; inform the user only a process-label gate blocks the merge (code is review-approved); do NOT route to a new Author round; goto surfaceBeforeMergingRequirements (label-gate path)
-    // The Orchestrator does not auto-remove the blocking label (issue #516, Step 8a): it is a user-controlled process label needing human judgment.
+    // Issue #516 treated every label-gate block as needing a human, but the "No
+    // blocking labels" check only watches Orchestrator-owned bookkeeping labels.
+    // `resolveLabelGate` below checks whether the Orchestrator's own unfinished
+    // cleanup explains the block before escalating to a human.
     if Monitor emits a Blocked line  -> clear the silentVanish re-launch flag; goto newAuthor
     if Monitor emits an Infra line   -> clear the silentVanish re-launch flag; escalate to user; stop
     if Monitor times out (30 min)    -> escalate to user; stop
@@ -273,7 +276,7 @@ surfaceBeforeMergingRequirements:
       |---|
       | `verified` |
 
-    if entered on the label-gate path: this step is complete, but do NOT apply `verified`; a human must still remove the blocking label before the PR may merge. Inform the user of this.
+    if entered on the label-gate path: goto resolveLabelGate
   Otherwise, relay the before-merging list to the user verbatim, and apply this transition to the PR:
 
   | Add label |
@@ -281,7 +284,23 @@ surfaceBeforeMergingRequirements:
   | `verification needed` |
 
   Dispatch a Verification Agent (see pr_verify.md) to carry out those items; it does not consult the user.
-  Route on its terminal signal per "Routing on the Verification Agent's signal" above, EXCEPT on the label-gate path a `Verification passed` signal only removes `verification needed`: do NOT add `verified` and do NOT treat the PR as mergeable, since the process label still blocks the merge until a human removes it.
+  Route on its terminal signal per "Routing on the Verification Agent's signal" above, EXCEPT on the label-gate path a `Verification passed` signal removes `verification needed` and then goes to resolveLabelGate instead of adding `verified` directly.
+
+resolveLabelGate:
+  // Entered once the code-approved cycle's automated work is otherwise finished
+  // (an empty before-merging list, or a Verification Agent `Verification passed`
+  // signal) but a `[label gate]` block is still reported. The "No blocking labels"
+  // check (.github/workflows/block-merge-on-blocking-labels.yml) only watches four
+  // Orchestrator-owned bookkeeping labels: `verification needed`, `changes
+  // requested`, `changes done`, `orchestrating`. By this point in the cycle the
+  // first three are already clear, so check whether `orchestrating` (or some other
+  // label entirely) is what remains before assuming a human must act.
+  Fetch the PR's current labels (label metadata only, not the diff/description/comments the "may not" list above restricts).
+  if every label present is one of the check's own four:
+    Apply "Concluding PR orchestration" (removes `orchestrating` from both the issue and the PR).
+    Apply `verified` to both the issue and the PR; this step is complete.
+  else:
+    A label outside the Orchestrator's own set is present; inform the user a human must remove it before the PR can merge. Do NOT apply `verified`.
 
 undiagnosedTerminal:
   // Issue #410 (Run G, issue #402): "drain poll found no new diagnostic

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -38,7 +38,7 @@ The Orchestrator is not a Reviewer or a Programmer.
 
 **May not:**
 - Read source files (Read, Bash cat/grep, etc.)
-- Read the PR (diff, description, or comments)
+- Read the PR (diff, description, or comments), except for fetching label metadata during `resolveLabelGate` (see the Monitor loop below); that narrow read must not act on any other field the same call happens to return
 - Read the issue or its comments
 - Edit or write files
 - Diagnose bugs or evaluate code
@@ -250,10 +250,10 @@ PR routing (Monitor loop):
     if Monitor emits `drain poll found no new diagnostic signals` immediately followed by a Blocked or Infra line -> goto undiagnosedTerminal
     (Note: the attributed `Blocked by: <name>` form already names the blocking check in the per-check summary block and the terminal suffix, so the Monitor suppresses the drain flag in that case. The `goto undiagnosedTerminal` branch therefore applies only to a bare `Blocked`/`Infra` line that the Monitor itself flagged as undiagnosed.)
     if Monitor emits a Blocked line where the terminal ends with `[label gate]` (the ` by: ...` suffix names only label-gate checks) -> clear the silentVanish re-launch flag; inform the user only a process-label gate blocks the merge (code is review-approved); do NOT route to a new Author round; goto surfaceBeforeMergingRequirements (label-gate path)
-    // Issue #516 treated every label-gate block as needing a human, but the "No
-    // blocking labels" check only watches Orchestrator-owned bookkeeping labels.
-    // `resolveLabelGate` below checks whether the Orchestrator's own unfinished
-    // cleanup explains the block before escalating to a human.
+    // Every label-gate block used to be treated as needing a human unconditionally,
+    // but the "No blocking labels" check only watches Orchestrator-owned bookkeeping
+    // labels. `resolveLabelGate` below checks whether the Orchestrator's own
+    // unfinished cleanup explains the block before escalating to a human.
     if Monitor emits a Blocked line  -> clear the silentVanish re-launch flag; goto newAuthor
     if Monitor emits an Infra line   -> clear the silentVanish re-launch flag; escalate to user; stop
     if Monitor times out (30 min)    -> escalate to user; stop
@@ -293,14 +293,25 @@ resolveLabelGate:
   // check (.github/workflows/block-merge-on-blocking-labels.yml) only watches four
   // Orchestrator-owned bookkeeping labels: `verification needed`, `changes
   // requested`, `changes done`, `orchestrating`. By this point in the cycle the
-  // first three are already clear, so check whether `orchestrating` (or some other
-  // label entirely) is what remains before assuming a human must act.
-  Fetch the PR's current labels (label metadata only, not the diff/description/comments the "may not" list above restricts).
-  if every label present is one of the check's own four:
+  // first three are normally already clear, leaving `orchestrating` as the sole
+  // cause. The PR may also carry other, unrelated labels (for example a
+  // `c-a-<model>` label from Model selection, or an area/severity label); the
+  // check ignores those entirely, so this step must too.
+  Fetch the PR's labels: call `mcp__github__pull_request_read` with method `get`
+  (the only tool that returns a PR's labels by number) and read only the returned
+  `labels` field. Do not read, act on, or be influenced by any other field the
+  same call returns (body, diff, comments, etc.); this is a narrow, scoped
+  exception to the "does not read the PR" rule above, limited to label metadata.
+  Do not substitute the issue's labels for the PR's: earlier transitions in this
+  document (e.g. "CI checking after a Reviewer exits") apply some of these labels
+  to the PR only, so the two label sets can diverge mid-cycle.
+  if none of `verification needed`, `changes requested`, or `changes done` is present among the fetched labels:
+    // Any other blocking label present must be `orchestrating`; any non-blocking
+    // label present is irrelevant to the check and is left alone.
     Apply "Concluding PR orchestration" (removes `orchestrating` from both the issue and the PR).
     Apply `verified` to both the issue and the PR; this step is complete.
   else:
-    A label outside the Orchestrator's own set is present; inform the user a human must remove it before the PR can merge. Do NOT apply `verified`.
+    One of `verification needed`, `changes requested`, or `changes done` is still present; inform the user a human must resolve it before the PR can merge. Do NOT apply `verified`.
 
 undiagnosedTerminal:
   // Issue #410 (Run G, issue #402): "drain poll found no new diagnostic

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -27,6 +27,7 @@ These rules are absolute:
    It must never carry one sub-agent's words to another sub-agent.
    If two sub-agents need to communicate, they leave each other GitHub comments.
 4. The Orchestrator does not read the PR (diff, description, or comments), does not read the issue, and does not read source files.
+   The only exception is fetching label metadata during `resolveLabelGate` (see the Monitor loop below); that narrow read must not act on any other field the same call returns.
    Its only window into CI is the CI Monitor (`scripts/ci_monitor/ci_monitor.py`).
    The issue number comes from the user and is plugged into the launch form as a literal token.
 5. Permitted-words test: before sending anything to a sub-agent, verify each sentence is either the user's exact words or an exact quote from an `agents/` file.


### PR DESCRIPTION
## What this does

Fixes `agents/dev_orchestration.md`'s CI Monitor routing for a `[label gate]` block (the "No blocking labels" check).

## Why

That check only watches four labels, all of them Orchestrator-owned bookkeeping state: `verification needed`, `changes requested`, `changes done`, `orchestrating`. The prior guidance (from issue #516) treated any label-gate block as needing a human to clear, unconditionally. In practice this happens on essentially every clean cycle: `orchestrating` is applied at the start of orchestration and, per "Concluding PR orchestration," is only removed from the PR at the very end, after the Monitor loop has already run. So a normal, correctly-progressing cycle reports "a human must remove the blocking label" even though no human action was actually needed, only the Orchestrator's own concluding step.

This surfaced concretely while orchestrating issue #592 / PR #598: the Orchestrator saw `Blocked by: No blocking labels [label gate]`, correctly avoided starting a new Author round, but incorrectly told the user a human needed to remove the label, when the blocking label was `orchestrating` itself and clearing it was the Orchestrator's own unfinished "Concluding PR orchestration" step.

## What changes

Adds a `resolveLabelGate` step, entered from both label-gate call sites (empty before-merging list, and a Verification Agent `Verification passed` signal). It fetches the PR's current labels and:

- If every present label is one of the check's own four, applies "Concluding PR orchestration" (clearing `orchestrating`) and then applies `verified`, since the block was fully attributable to the Orchestrator's own unfinished cleanup.
- Otherwise, a label outside that set survived, so it escalates to the user as before, without applying `verified`.

## Why no automated test

This is a process/instruction document consumed by agents reading it, not exercised by project code, consistent with prior PRs that edited files under `agents/`.

