### PR TITLE
Exclude ci, testing, and agents labels from release notes (yml only)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ci
+      - testing
+      - agents


### PR DESCRIPTION
Adds .github/release.yml to configure GitHub's automatic release note generation to exclude PRs labeled ci, testing, or agents.

🦀

version of #609
fixes #607 
