### PR TITLE
Keep the secure session alive across secure-viewer launch

### DIFF
--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -85,6 +85,13 @@ class OverlayManager(
      * foreground, without waiting for the camera-available event.
      */
     private val onGalleryLaunched: () -> Unit = {},
+    /**
+     * Called immediately after the secure viewer is launched via a locked-screen overlay tap
+     * (Issue #608). Lets the service preserve the secure session across the overlay deactivation
+     * that follows (Pixel Camera closes behind the viewer), so the viewer keeps rendering its media
+     * instead of flashing to the empty state.
+     */
+    private val onSecureViewerLaunched: () -> Unit = {},
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
@@ -412,6 +419,7 @@ class OverlayManager(
             }
         context.startActivity(intent)
         DebugLog.log("Launched secure viewer")
+        onSecureViewerLaunched()
     }
 
     private fun createLayoutParams(): WindowManager.LayoutParams {

--- a/app/src/main/java/com/gb4pc/service/OverlayService.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayService.kt
@@ -86,6 +86,7 @@ class OverlayService : Service() {
                 onFocusLost = { logic.onOverlayFocusLost() },
                 onFocusGained = { logic.onOverlayFocusGained() },
                 onGalleryLaunched = { logic.onGalleryLaunched() },
+                onSecureViewerLaunched = { logic.onSecureViewerLaunched() },
             )
         cameraState = CameraState()
         val km = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager

--- a/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
+++ b/app/src/main/java/com/gb4pc/service/OverlayServiceLogic.kt
@@ -40,6 +40,16 @@ class OverlayServiceLogic(
 
     private var deactivateRunnable: Runnable? = null
 
+    // Issue #608: set when the secure viewer is launched from a locked-screen tap.
+    // Launching the viewer closes Pixel Camera, which releases the camera and drives the
+    // overlay's normal deactivation. That deactivation must hide the overlay WITHOUT ending
+    // the secure session, because the just-opened SecureViewerActivity renders that session's
+    // media reactively (#552); ending it would empty the flow and flip the viewer to the
+    // "no photos" state (the reported flash). The session instead ends on device unlock
+    // (OverlayService.onUserPresent), per SF-01(b). The flag is one-shot: it is consumed by the
+    // next hideOverlayAndCleanup() and cleared on any fresh activation.
+    private var secureViewerLaunched = false
+
     // DT-06a: Retry runnable for UsageStats lag--fires if foreground not detected on first check.
     // activationRetryPending gates re-scheduling: it is true exactly while a retry runnable is
     // posted to the handler, so a burst of evaluateForeground() calls (e.g. several camera events)
@@ -167,6 +177,9 @@ class OverlayServiceLogic(
         }
         val locked = isKeyguardLocked()
         DebugLog.log("Logic: showOverlay: showing overlay; keyguardLocked=$locked")
+        // Issue #608: a fresh activation starts a new session; clear any stale
+        // secure-viewer-launch preservation flag left over from a prior cycle.
+        secureViewerLaunched = false
         overlayManager.show()
         isOverlayActive = true
         onOverlayStateChanged(true)
@@ -214,11 +227,31 @@ class OverlayServiceLogic(
         isOverlayActive = false
         onOverlayStateChanged(false)
         onUnregisterThumbnailObserver() // unregister thumbnail observer on deactivation
+        if (secureViewerLaunched) {
+            // Issue #608: the overlay is being torn down only because launching the secure
+            // viewer closed Pixel Camera. Keep the secure session (and its media observer)
+            // alive so the open SecureViewerActivity keeps rendering the session's media
+            // instead of flashing to the empty state. The session ends on unlock (SF-01(b)).
+            DebugLog.log("Logic: overlay deactivated after secure-viewer launch; keeping secure session alive")
+            secureViewerLaunched = false
+            return
+        }
         if (sessionTracker.isSessionActive) {
             DebugLog.log("Logic: ending secure session on overlay deactivation")
             sessionTracker.endSession()
             onUnregisterMediaObserver()
         }
+    }
+
+    /**
+     * Issue #608: Called immediately after the secure viewer is launched from a locked-screen tap.
+     * Marks the next overlay deactivation (caused by Pixel Camera closing behind the viewer) so it
+     * preserves the secure session rather than ending it; see [hideOverlayAndCleanup].
+     */
+    fun onSecureViewerLaunched() {
+        if (!isOverlayActive) return
+        DebugLog.log("Logic: secure viewer launched; preserving session across the ensuing overlay deactivation")
+        secureViewerLaunched = true
     }
 
     fun cancelPendingDeactivation() {
@@ -277,6 +310,7 @@ class OverlayServiceLogic(
         cancelGalleryLaunchRecheck()
         onUnregisterThumbnailObserver()
         isOverlayActive = false
+        secureViewerLaunched = false
     }
 
     private fun cancelGalleryLaunchRecheck() {

--- a/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
+++ b/app/src/test/java/com/gb4pc/service/OverlayServiceLogicTest.kt
@@ -1223,4 +1223,118 @@ class OverlayServiceLogicTest {
 
         verify(handler).removeCallbacks(runnableCaptor.firstValue)
     }
+
+    // ── Issue #608: preserve the secure session across secure-viewer launch ──
+
+    /**
+     * When the secure viewer is launched from a locked tap, the ensuing overlay deactivation
+     * (Pixel Camera closes behind the viewer) must hide the overlay and drop the thumbnail
+     * observer, but must NOT end the secure session or unregister the media observer, so the
+     * open viewer keeps rendering the session's media instead of flashing to the empty state.
+     */
+    @Test
+    fun `issue-608 deactivation after secure-viewer launch keeps session and media observer alive`() {
+        // Activate the overlay with a live session (device locked at activation time)
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+        assertTrue("Pre-condition: thumbnail observer registered", thumbnailObserverRegistered)
+        assertTrue("Pre-condition: media observer registered", mediaObserverRegistered)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // User taps the overlay; the secure viewer is launched.
+        logic.onSecureViewerLaunched()
+
+        // Launching the viewer closed Pixel Camera → camera released → deactivation scheduled.
+        logic.onCameraAvailable("0")
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(0L))
+        runnableCaptor.firstValue.run()
+
+        // Overlay is hidden and its thumbnail observer torn down...
+        assertFalse("Overlay should be hidden after deactivation", logic.isOverlayActive)
+        verify(overlayManager).hide()
+        assertFalse("Thumbnail observer should be unregistered", thumbnailObserverRegistered)
+        // ...but the secure session and its media observer must survive for the open viewer.
+        verify(sessionTracker, never()).endSession()
+        assertTrue("Media observer should remain registered while the viewer is open", mediaObserverRegistered)
+    }
+
+    /**
+     * A camera-release deactivation with no preceding secure-viewer launch must still end the
+     * session and unregister the media observer (unchanged SF-01(a) behaviour).
+     */
+    @Test
+    fun `issue-608 deactivation without secure-viewer launch still ends session`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        assertTrue("Pre-condition: overlay should be active", logic.isOverlayActive)
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // Camera released with NO secure-viewer launch → normal teardown.
+        logic.onCameraAvailable("0")
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(runnableCaptor.capture(), eq(0L))
+        runnableCaptor.firstValue.run()
+
+        assertFalse("Overlay should be hidden after deactivation", logic.isOverlayActive)
+        verify(sessionTracker).endSession()
+        assertFalse("Media observer should be unregistered on normal deactivation", mediaObserverRegistered)
+    }
+
+    /**
+     * The preservation flag is one-shot: it is consumed by the deactivation that follows the
+     * secure-viewer launch and must not leak into a later, unrelated deactivation.
+     */
+    @Test
+    fun `issue-608 preservation flag is one-shot and does not leak into a later deactivation`() {
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        // First cycle: secure viewer launched → deactivation preserves the session.
+        logic.onSecureViewerLaunched()
+        logic.onCameraAvailable("0")
+        val captor1 = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(captor1.capture(), eq(0L))
+        captor1.firstValue.run()
+        verify(sessionTracker, never()).endSession()
+
+        // Second cycle: camera reopens (fresh activation), then closes normally with no viewer launch.
+        logic.onCameraUnavailable("0")
+        assertTrue("Overlay should reactivate on the next camera-open", logic.isOverlayActive)
+        logic.onCameraAvailable("0")
+        val captor2 = argumentCaptor<Runnable>()
+        verify(handler, atLeast(2)).postDelayed(captor2.capture(), eq(0L))
+        captor2.lastValue.run()
+
+        // This normal deactivation must end the session; the flag did not leak.
+        verify(sessionTracker).endSession()
+    }
+
+    /**
+     * onSecureViewerLaunched() is a no-op when the overlay is not active, so a stray call cannot
+     * arm the preservation flag and suppress a subsequent genuine session teardown.
+     */
+    @Test
+    fun `issue-608 onSecureViewerLaunched is no-op when overlay is not active`() {
+        assertFalse("Pre-condition: overlay should not be active", logic.isOverlayActive)
+        logic.onSecureViewerLaunched()
+
+        // A real activation and normal deactivation must still end the session.
+        keyguardLocked = true
+        cameraState.setCameraUnavailable("0")
+        logic.evaluateForeground()
+        whenever(sessionTracker.isSessionActive).thenReturn(true)
+
+        logic.onCameraAvailable("0")
+        val captor = argumentCaptor<Runnable>()
+        verify(handler).postDelayed(captor.capture(), eq(0L))
+        captor.firstValue.run()
+
+        verify(sessionTracker).endSession()
+    }
 }


### PR DESCRIPTION
Fixes #608.

## Problem

On the lock screen, tapping the overlay launches `SecureViewerActivity` to show the photos taken during the secure session. But launching the viewer closes Pixel Camera behind it, which releases the camera. That camera-release drives the overlay's normal deactivation, and `hideOverlayAndCleanup()` ended the secure session (SF-01(a)).

Since PR #552 made the viewer render the session's media reactively from a `StateFlow`, `endSession()` emits an empty snapshot that the just-opened viewer collects. The result is the reported bug: the photo flashes for a split second, then the viewer flips to the empty "take some photos" state.

This is the exact "session reset around tap time" behavior that #552 flagged as a possible follow-up.

The logs in the issue show it directly: `Launched secure viewer` is immediately followed by `Camera 0 available` -> `scheduling deactivation delay=10ms` -> `ending secure session on overlay deactivation` -> `ContentObserver unregistered`.

## Fix

The overlay deactivation that follows a secure-viewer launch should hide the overlay but must not end the session the viewer is displaying. The session's real end condition here is device unlock.

- **`OverlayManager`**: after `launchSecureViewer()` starts the activity, it calls a new `onSecureViewerLaunched` callback (mirroring the existing `onGalleryLaunched`).
- **`OverlayServiceLogic`**: `onSecureViewerLaunched()` arms a one-shot `secureViewerLaunched` flag (guarded to no-op when the overlay is inactive). The next `hideOverlayAndCleanup()` sees the flag, hides the overlay and drops the thumbnail observer as usual, but skips `endSession()` and keeps the media observer registered. The flag is consumed by that one deactivation and also cleared on any fresh activation (`showOverlay`) and in `reset()`, so an ordinary camera-close still ends the session (SF-01(a) unchanged).
- **`OverlayService`**: wires the new callback to the logic.

The session still ends on device unlock via `OverlayService.onUserPresent()` (SF-01(b)), where `SecureViewerActivity` also finishes itself (SF-15). Note this narrows SF-01(a): after a secure-viewer launch the session outlives the overlay until unlock, which is required for the viewer to keep rendering.

## Tests

`OverlayServiceLogicTest` gains four `issue-608` cases:

- Deactivation after a secure-viewer launch keeps the session and media observer alive (overlay hidden, thumbnail observer dropped).
- Deactivation without a secure-viewer launch still ends the session and unregisters the media observer (SF-01(a) unchanged).
- The preservation flag is one-shot and does not leak into a later, unrelated deactivation.
- `onSecureViewerLaunched()` is a no-op when the overlay is inactive.

Full `:app:testDebugUnitTest` suite runs green locally.

