### PR TITLE
Fail enforce_mutually_exclusive_labels.py loudly on real errors

### DIFF
--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -23,8 +23,9 @@ Exit code:
        removed successfully (a 404 on removal means it was already gone,
        e.g. via a race with another process, and does not count as a
        failure).
-    1  the issue/PR's current labels could not be fetched, or removing a
-       conflicting label failed for a reason other than 404.
+    1  ISSUE_NUMBER is not a valid integer, the issue/PR's current labels
+       could not be fetched, or removing a conflicting label failed for a
+       reason other than 404.
 
 Required environment variables:
     GITHUB_TOKEN        Personal access token or Actions secret with
@@ -218,7 +219,7 @@ def main() -> int:
             f"Error: ISSUE_NUMBER is not a valid integer: {issue_number_str!r}",
             file=sys.stderr,
         )
-        return 0
+        return 1
 
     label_set = find_conflicting_set(added_label)
     conflicting_prefix = find_conflicting_prefix(added_label)

--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -19,7 +19,12 @@ Usage:
     python3 scripts/enforce_mutually_exclusive_labels.py
 
 Exit code:
-    0  always--API failures are logged but do not fail the CI run.
+    0  no conflicting labels were found, or every conflicting label was
+       removed successfully (a 404 on removal means it was already gone,
+       e.g. via a race with another process, and does not count as a
+       failure).
+    1  the issue/PR's current labels could not be fetched, or removing a
+       conflicting label failed for a reason other than 404.
 
 Required environment variables:
     GITHUB_TOKEN        Personal access token or Actions secret with
@@ -145,8 +150,13 @@ def remove_labels(
     to_remove: list[str],
     repo: str,
     token: str,
-) -> None:
-    """Remove each label in *to_remove* from the issue/PR, logging each removal."""
+) -> bool:
+    """Remove each label in *to_remove* from the issue/PR, logging each removal.
+
+    Returns True if every removal succeeded or was already absent (404),
+    False if any removal failed with a non-404 HTTPError or a URLError.
+    """
+    all_succeeded = True
     for label in to_remove:
         encoded = urllib.request.quote(label, safe="")
         try:
@@ -167,11 +177,14 @@ def remove_labels(
                     f"Error removing label '{label}' from #{issue_number}: {exc}",
                     file=sys.stderr,
                 )
+                all_succeeded = False
         except urllib.error.URLError as exc:
             print(
                 f"Network error removing label '{label}' from #{issue_number}: {exc}",
                 file=sys.stderr,
             )
+            all_succeeded = False
+    return all_succeeded
 
 
 # ---------------------------------------------------------------------------
@@ -218,14 +231,14 @@ def main() -> int:
         issue = gh_api(f"repos/{repo}/issues/{issue_number}", token=token)
     except Exception as exc:  # noqa: BLE001
         print(f"Error fetching issue #{issue_number}: {exc}", file=sys.stderr)
-        return 0
+        return 1
 
     if not isinstance(issue, dict):
         print(
             f"Error: unexpected response fetching issue #{issue_number}: {issue!r}",
             file=sys.stderr,
         )
-        return 0
+        return 1
 
     current_labels = [lbl["name"] for lbl in issue.get("labels", [])]
 
@@ -241,7 +254,8 @@ def main() -> int:
         print(f"No conflicting labels found for '{added_label}' on #{issue_number}--nothing to do.")
         return 0
 
-    remove_labels(issue_number, to_remove, repo, token)
+    if not remove_labels(issue_number, to_remove, repo, token):
+        return 1
     return 0
 
 

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -251,12 +251,13 @@ class TestLabelsToRemove(unittest.TestCase):
 class TestRemoveLabels(unittest.TestCase):
     def test_calls_delete_for_each_label(self):
         with patch.object(emxl, "gh_api") as mock_api:
-            emxl.remove_labels(42, ["p2", "p3"], "owner/repo", "tok")
+            result = emxl.remove_labels(42, ["p2", "p3"], "owner/repo", "tok")
 
         self.assertEqual(mock_api.call_count, 2)
         paths = [c[0][0] for c in mock_api.call_args_list]
         self.assertTrue(any("p2" in p for p in paths))
         self.assertTrue(any("p3" in p for p in paths))
+        self.assertTrue(result)
 
     def test_uses_delete_method(self):
         with patch.object(emxl, "gh_api") as mock_api:
@@ -266,27 +267,34 @@ class TestRemoveLabels(unittest.TestCase):
 
     def test_no_calls_when_list_empty(self):
         with patch.object(emxl, "gh_api") as mock_api:
-            emxl.remove_labels(1, [], "owner/repo", "tok")
+            result = emxl.remove_labels(1, [], "owner/repo", "tok")
 
         mock_api.assert_not_called()
+        self.assertTrue(result)
 
     def test_handles_404_gracefully(self):
         error = urllib.error.HTTPError(url=None, code=404, msg="Not Found", hdrs=None, fp=None)
         with patch.object(emxl, "gh_api", side_effect=error):
-            # Should not raise.
-            emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
+            # Should not raise, and a 404 (already removed) does not count as a failure.
+            result = emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
 
-    def test_handles_other_http_error_gracefully(self):
+        self.assertTrue(result)
+
+    def test_continues_after_http_error_but_reports_failure(self):
         error = urllib.error.HTTPError(
             url=None, code=422, msg="Unprocessable Entity", hdrs=None, fp=None
         )
         with patch.object(emxl, "gh_api", side_effect=error):
-            emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
+            result = emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
 
-    def test_handles_url_error_gracefully(self):
+        self.assertFalse(result)
+
+    def test_continues_after_url_error_but_reports_failure(self):
         error = urllib.error.URLError("network error")
         with patch.object(emxl, "gh_api", side_effect=error):
-            emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
+            result = emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
+
+        self.assertFalse(result)
 
     def test_continues_after_one_failure(self):
         """An error on the first label does not prevent the second from being removed."""
@@ -300,9 +308,22 @@ class TestRemoveLabels(unittest.TestCase):
                 )
 
         with patch.object(emxl, "gh_api", side_effect=fake_api):
-            emxl.remove_labels(1, ["p2", "p3"], "owner/repo", "tok")
+            result = emxl.remove_labels(1, ["p2", "p3"], "owner/repo", "tok")
 
         self.assertTrue(any("p3" in p for p in call_paths))
+        self.assertFalse(result)
+
+    def test_one_failure_among_several_still_reports_failure(self):
+        def fake_api(path, token, method="GET", body=None):
+            if "p2" in path:
+                raise urllib.error.HTTPError(
+                    url=None, code=500, msg="Server Error", hdrs=None, fp=None
+                )
+
+        with patch.object(emxl, "gh_api", side_effect=fake_api):
+            result = emxl.remove_labels(1, ["p1", "p2", "p3"], "owner/repo", "tok")
+
+        self.assertFalse(result)
 
     def test_url_encodes_label_with_spaces(self):
         call_paths = []
@@ -311,9 +332,10 @@ class TestRemoveLabels(unittest.TestCase):
             call_paths.append(path)
 
         with patch.object(emxl, "gh_api", side_effect=fake_api):
-            emxl.remove_labels(5, ["verification needed"], "owner/repo", "tok")
+            result = emxl.remove_labels(5, ["verification needed"], "owner/repo", "tok")
 
         self.assertTrue(any("verification%20needed" in p for p in call_paths))
+        self.assertTrue(result)
 
 
 # ---------------------------------------------------------------------------
@@ -451,19 +473,49 @@ class TestMain(unittest.TestCase):
         delete_call = mock_api.call_args_list[1]
         self.assertIn("orchestrate", delete_call[0][0])
 
-    def test_exit_0_when_fetch_raises(self):
+    def test_exit_1_when_fetch_raises(self):
         with patch.object(emxl, "gh_api", side_effect=Exception("network error")):
             result = emxl.main()
-        self.assertEqual(result, 0)
+        self.assertEqual(result, 1)
 
-    def test_exit_0_when_fetch_returns_non_dict(self):
+    def test_exit_1_when_fetch_returns_non_dict(self):
         # gh_api returns None for an empty body; main() must not crash on it.
         with patch.object(emxl, "gh_api") as mock_api:
             mock_api.return_value = None
             result = emxl.main()
-        self.assertEqual(result, 0)
+        self.assertEqual(result, 1)
         # Only the GET was attempted; no DELETE follows a bad response.
         self.assertEqual(mock_api.call_count, 1)
+
+    def test_exit_1_when_remove_labels_fails(self):
+        error = urllib.error.HTTPError(url=None, code=500, msg="Server Error", hdrs=None, fp=None)
+        with patch.dict(os.environ, {"ADDED_LABEL": "p1"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["p2", "ci"]),
+                    error,  # DELETE p2 fails
+                ],
+            ):
+                result = emxl.main()
+
+        self.assertEqual(result, 1)
+
+    def test_exit_0_when_removal_404_is_benign(self):
+        error = urllib.error.HTTPError(url=None, code=404, msg="Not Found", hdrs=None, fp=None)
+        with patch.dict(os.environ, {"ADDED_LABEL": "p1"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["p2", "ci"]),
+                    error,  # DELETE p2 races with another process removing it first
+                ],
+            ):
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
 
     # ------------------------------------------------------------------
     # Prefix group tests

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -382,10 +382,10 @@ class TestMain(unittest.TestCase):
             result = emxl.main()
         self.assertEqual(result, 0)
 
-    def test_exit_0_when_issue_number_non_integer(self):
+    def test_exit_1_when_issue_number_non_integer(self):
         with patch.dict(os.environ, {"ISSUE_NUMBER": "abc"}):
             result = emxl.main()
-        self.assertEqual(result, 0)
+        self.assertEqual(result, 1)
 
     def test_exit_0_when_label_not_in_any_set(self):
         with patch.dict(os.environ, {"ADDED_LABEL": "bug"}):


### PR DESCRIPTION
Fixes #614

`scripts/enforce_mutually_exclusive_labels.py`'s `main()` always returned 0, even when:

- the `gh_api` call that fetches the issue/PR's current labels raised (or returned an unexpected non-dict response), or
- `remove_labels()` swallowed an `HTTPError`/`URLError` from a label removal, or
- `ISSUE_NUMBER` failed to parse as an integer.

This kept the "Enforce mutually exclusive labels" check green even when it silently failed to reconcile a mutually-exclusive label set.

## Changes

- `remove_labels()` now returns `bool`: `True` if every removal succeeded or was already absent (404, treated as benign per the existing "already removed?" distinction), `False` if any removal failed with a non-404 `HTTPError` or a `URLError`.
- `main()` returns 1 when the initial label fetch raises or returns something other than a dict, when `remove_labels()` reports a failure, and when `ISSUE_NUMBER` is not a valid integer (matching the identical check in `label_by_title.py`). It still returns 0 for "nothing to do" paths (label not in any set, no conflicts found) and for the pre-existing missing-configuration warnings, which are unchanged.
- Docstring's exit-code section updated to describe the new 0/1 semantics.

This follows the same pattern already applied to `label_by_title.py`/`backfill_labels_by_title.py` in PR #613 (an `apply_labels()`/`remove_labels()`-style function reports overall success, and `main()` propagates it).

This workflow isn't wired into any merge gate (unlike `block-merge-on-blocking-labels.yml`), so a nonzero exit only shows as a red X on the check run in the Actions tab, not a blocked merge.

## Test plan

- [x] None outside the automated suite; `python3 -m unittest scripts.test_enforce_mutually_exclusive_labels` covers the new failure/success paths (67 tests, all passing).