### PR TITLE
Run Python and shell script unit tests before JDK/Android SDK setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,25 @@ jobs:
             echo "needs_full_build=$(scripts/check_non_docs_changes.sh "origin/$BASE_REF")" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install Python script dependencies
+        if: steps.diff_check.outputs.needs_full_build == 'true'
+        run: pip install -r scripts/requirements.txt
+
+      - name: Run Python script unit tests
+        if: steps.diff_check.outputs.needs_full_build == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 -m unittest discover -s scripts -p "test_*.py" -v
+
+      - name: Run shell script unit tests
+        if: steps.diff_check.outputs.needs_full_build == 'true'
+        run: |
+          for test_script in scripts/test_*.sh; do
+            echo "==> Running $test_script"
+            bash "$test_script"
+          done
+
       - name: Set up JDK 17
         if: steps.diff_check.outputs.needs_full_build == 'true'
         uses: actions/setup-java@v5
@@ -114,25 +133,6 @@ jobs:
 
           echo "==> emulator -list-avds:"
           ANDROID_AVD_HOME="$AVD_HOME" $ANDROID_HOME/emulator/emulator -list-avds
-
-      - name: Install Python script dependencies
-        if: steps.diff_check.outputs.needs_full_build == 'true'
-        run: pip install -r scripts/requirements.txt
-
-      - name: Run Python script unit tests
-        if: steps.diff_check.outputs.needs_full_build == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: python3 -m unittest discover -s scripts -p "test_*.py" -v
-
-      - name: Run shell script unit tests
-        if: steps.diff_check.outputs.needs_full_build == 'true'
-        run: |
-          for test_script in scripts/test_*.sh; do
-            echo "==> Running $test_script"
-            bash "$test_script"
-          done
 
       - name: Grant execute permission for gradlew
         if: steps.diff_check.outputs.needs_full_build == 'true'


### PR DESCRIPTION
## Summary

- Moves the `Install Python script dependencies`, `Run Python script unit tests`, and `Run shell script unit tests` steps in `build.yml` to run right after `Check for non-docs changes`, ahead of `Set up JDK 17` and `Set up Android SDK`.
- These three steps only need Python and bash, so they do not need to wait behind the JVM/Android SDK setup.

## Why

Investigating a failed CI run (see linked issue) showed that when `Set up Android SDK` fails, every later plain `if: needs_full_build == 'true'` step is skipped by GitHub Actions' default `success()` gate, including `Install Python script dependencies`. The `Write test-result summary` and `Gate on test failures` steps are `if: always() && ...`, so they still run, but they import `defusedxml`, which was never installed, so they fail with `ModuleNotFoundError: No module named 'defusedxml'` instead of surfacing the real Android SDK error.

Running the Python/shell steps before the JDK/Android SDK setup means the pip install always completes (or fails on its own, cleanly) before any Android-specific step has a chance to fail, so the later summary/gate steps can no longer be starved of `defusedxml` by an unrelated upstream failure. It also gives faster feedback on Python/shell test failures, since they no longer wait behind the slower JDK/Android SDK setup.

## Test plan

- [ ] Confirm `Build & Test` still passes on this PR (Python/shell steps run first, then JDK/Android SDK/build/E2E as before).
- [ ] Confirm a docs-only PR still skips all of these steps (unchanged `needs_full_build` gating).

