### PR TITLE
Stop PR agents if they agree, despite CI

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -193,6 +193,8 @@ Apply it to the PR if one exists after this round (the Author emitted `PR opened
 |---|---|
 | `changes requested` | `changes done` |
 
+If this Author round was dispatched because a prior Reviewer round gave `LGTM` or `Cannot implement` (for example, via the Monitor loop's Blocked-after-LGTM branch, or a user-directed resumption after a `Cannot implement` escalation), and the Author's return signal this round is `No work to do: explanation posted on the existing PR or issue`, apply the no-work/LGTM pairing rule (see "When to abort"): do not dispatch a Reviewer; escalate to the user instead.
+
 ## Assigning a Reviewer
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
@@ -228,9 +230,12 @@ The Author's status signal from the prior round decides which routing fence appl
 If the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open, there is no diff or CI to run, so follow the no-PR routing fence.
 If the Author emitted `PR opened or fixed`, or emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR, follow the Monitor loop fence.
 
+Before following either fence, check the no-work/LGTM pairing rule (see "When to abort"): if the Author's signal this round was `No work to do: explanation posted on the existing PR or issue` and the Reviewer's verdict this round is `LGTM` or `Cannot implement`, do not follow either fence below; instead escalate to the user per that rule.
+
 No-PR routing:
 
 ```text
+  if the Author's signal this round was `No work to do: explanation posted on the existing PR or issue` and Reviewer gave `LGTM` or `Cannot implement` -> escalate to user (see "When to abort"); stop
   if Reviewer requested changes -> goto newAuthor
   if Reviewer gave `Cannot implement` -> escalate to user; stop
   if Reviewer gave LGTM:
@@ -244,6 +249,7 @@ No-PR routing:
 PR routing (Monitor loop):
 
 ```text
+  if the Author's signal this round was `No work to do: explanation posted on the existing PR or issue` and Reviewer gave `LGTM` or `Cannot implement` -> escalate to user (see "When to abort"); stop
   if Reviewer requested changes -> goto newAuthor
   if Reviewer gave `Cannot implement` -> escalate to user; stop (do NOT route to a new Author round; leave the PR open for the user to close; the Reviewer's PR comment describes why)
   if Reviewer gave LGTM:
@@ -256,6 +262,10 @@ PR routing (Monitor loop):
     if Monitor emits a Blocked line where the terminal ends with `[label gate]` (the ` by: ...` suffix names only label-gate checks) -> clear the silentVanish re-launch flag; inform the user only a process-label gate blocks the merge (code is review-approved); do NOT route to a new Author round; goto surfaceBeforeMergingRequirements (label-gate path)
     // The Orchestrator does not auto-remove the blocking label (issue #516, Step 8a): it is a user-controlled process label needing human judgment.
     if Monitor emits a Blocked line  -> clear the silentVanish re-launch flag; goto newAuthor
+    // This newAuthor round follows a Reviewer LGTM (the branch we are in). If that new Author
+    // round's own return signal is `No work to do: explanation posted on the existing PR or issue`,
+    // the no-work/LGTM pairing rule (see "When to abort") applies: escalate to the user instead of
+    // dispatching the next Reviewer round.
     if Monitor emits an Infra line   -> clear the silentVanish re-launch flag; escalate to user; stop
     if Monitor times out (30 min)    -> escalate to user; stop
     if a user message wakes the session before Monitor delivers any terminal line -> goto silentVanish
@@ -390,6 +400,9 @@ Stop the automated cycle and escalate to the User in either of these cases:
   This covers a Programmer that gives up or an issue that cannot be solved as stated; the Reviewer confirms it by emitting `Cannot implement`.
 - The Programmer / Reviewer loop runs **four rounds** without reaching consensus (unless the user gave a different threshold).
   This is the fallback for a loop that stalls in disagreement; once four rounds are reached the cap applies unconditionally, even when both parties are still actively disputing.
+- The no-work/LGTM pairing rule: the Author emits `No work to do: explanation posted on the existing PR or issue` immediately adjacent, in either order across two consecutive turns, to a Reviewer verdict of `LGTM` or `Cannot implement`.
+  That is: the Author's `No work to do` turn is immediately followed by a Reviewer `LGTM`/`Cannot implement` verdict on that same round, OR a Reviewer `LGTM`/`Cannot implement` verdict is immediately followed by the Author's next turn emitting `No work to do`.
+  This pairing means one side found nothing actionable right next to the other side declaring the work fine or impossible; pause and escalate regardless of what CI reports, instead of following the normal routing fences.
 
 ## Concluding PR orchestration
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -113,7 +113,7 @@ Role assignment statements (copy the applicable line exactly):
 - Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
-An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.
+An Author that legitimately declines satisfies its exit obligation by posting the explanatory comment and emitting the applicable status signal (see the Author status vocabulary below) instead of creating a PR.
 
 ## Decision-signal templates
 
@@ -121,10 +121,12 @@ When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
 Author-to-Orchestrator status vocabulary (the Programmer emits one when it finishes a round, reporting only what it did):
-- `PR opened`: the Author opened a PR.
-- `No PR; position posted on the issue`: the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+- `PR opened or fixed`: the Author opened a fresh PR, or pushed a fix to an existing PR.
+- `Work completed but no PR: updated issue with requested information`: the Author took a concrete action (answered a question, described an out-of-repo fix, supplied missing information) and recorded it by updating the issue, without opening a PR (see "Declining to open a PR" in `pr_participation.md`).
+- `No work to do: explanation posted on the existing PR or issue`: the Author found nothing actionable this round and left an explanation, either on the issue (no PR exists) or on an existing PR (see "Declining to open a PR" in `pr_participation.md`).
 
-When the Author emits `No PR; position posted on the issue`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
+When the Author emits `Work completed but no PR: updated issue with requested information`, dispatch the Reviewer pointed at the **issue** (see "Assigning a Reviewer").
+When the Author emits `No work to do: explanation posted on the existing PR or issue`, dispatch the Reviewer pointed at whichever artifact carries the explanation: the **issue** if no PR exists, or the existing **PR** if one does.
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
@@ -185,7 +187,7 @@ Routing on the Verification Agent's signal:
 - Dispatch using the dispatch template above, with the Programmer role assignment statement and the literal issue number and branch name tokens.
 
 When the Author returns, apply this transition.
-Apply it to the PR if the Author emitted `PR opened`; apply it to the issue if the Author emitted `No PR; position posted on the issue`, since that is where the work's labels live when there is no PR:
+Apply it to the PR if one exists after this round (the Author emitted `PR opened or fixed`, or emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR); otherwise apply it to the issue (the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open), since that is where the work's labels live when there is no PR:
 
 | Remove label | Add label |
 |---|---|
@@ -195,8 +197,9 @@ Apply it to the PR if the Author emitted `PR opened`; apply it to the issue if t
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
 - Dispatch using the dispatch template above, with the Reviewer role assignment statement and the literal issue number token.
-- If the Author emitted `No PR; position posted on the issue` (no PR was opened), the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
+- If the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open, the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
   The dispatch template's issue token already points the Reviewer there; the Reviewer follows "Reviewing an Author who declined to open a PR" in `pr_participation.md`.
+- If the Author emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR, the Reviewer examines the Author's explanatory comment on that **PR** as usual.
 
 ## Author disagreement
 
@@ -209,7 +212,7 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
 When the Reviewer returns, apply this transition.
-Apply it to the PR if one was opened (the Author emitted `PR opened`); apply it to the issue on the no-PR path (the Author emitted `No PR; position posted on the issue`), since that is where the work's labels live when there is no PR:
+Apply it to the PR if one exists (the Author emitted `PR opened or fixed`, or emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR); apply it to the issue on the no-PR path (the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open), since that is where the work's labels live when there is no PR:
 
 | Remove label |
 |---|
@@ -222,7 +225,8 @@ If the Reviewer requested changes, additionally apply this transition to the sam
 | `changes requested` |
 
 The Author's status signal from the prior round decides which routing fence applies.
-If the Author emitted `No PR; position posted on the issue`, there is no diff or CI to run, so follow the no-PR routing fence; if it emitted `PR opened`, follow the Monitor loop fence.
+If the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open, there is no diff or CI to run, so follow the no-PR routing fence.
+If the Author emitted `PR opened or fixed`, or emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR, follow the Monitor loop fence.
 
 No-PR routing:
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -169,6 +169,8 @@ Routing on the Verification Agent's signal:
   |---|---|
   | `verification needed` | `changes requested` |
 
+  This newAuthor round is not immediately adjacent to the Reviewer's earlier `LGTM` (the Verification Planner and Verification Agent turns intervene), so the no-work/LGTM pairing rule (see "When to abort") does not apply here, even if the Author's return signal is `No work to do: explanation posted on the existing PR or issue`.
+
 - `Verification incomplete`: no item failed, but one or more before-merging items could not be automated and remain open for a human to verify.
   Do not treat the PR as cleared and do not start a new Author round.
   Inform the user that manual verification is still required, and that the PR may be merged once every open before-merging tracking issue is resolved.
@@ -193,7 +195,8 @@ Apply it to the PR if one exists after this round (the Author emitted `PR opened
 |---|---|
 | `changes requested` | `changes done` |
 
-If this Author round was dispatched because a prior Reviewer round gave `LGTM` or `Cannot implement` (for example, via the Monitor loop's Blocked-after-LGTM branch, or a user-directed resumption after a `Cannot implement` escalation), and the Author's return signal this round is `No work to do: explanation posted on the existing PR or issue`, apply the no-work/LGTM pairing rule (see "When to abort"): do not dispatch a Reviewer; escalate to the user instead.
+If this Author round was dispatched immediately after a Reviewer round gave `LGTM` or `Cannot implement`, with no other agent turn in between (that is: via the Monitor loop's Blocked-after-LGTM branch, or a user-directed resumption immediately after a `Cannot implement` escalation), and the Author's return signal this round is `No work to do: explanation posted on the existing PR or issue`, apply the no-work/LGTM pairing rule (see "When to abort"): do not dispatch a Reviewer; escalate to the user instead.
+This scoping matters: a newAuthor round dispatched via `Verification revealed an error` (see "Routing on the Verification Agent's signal") does NOT qualify, since the Verification Planner and Verification Agent turns intervene between the Reviewer's earlier `LGTM` and this Author round, breaking immediate adjacency.
 
 ## Assigning a Reviewer
 
@@ -230,7 +233,7 @@ The Author's status signal from the prior round decides which routing fence appl
 If the Author emitted `Work completed but no PR: updated issue with requested information`, or emitted `No work to do: explanation posted on the existing PR or issue` with no PR open, there is no diff or CI to run, so follow the no-PR routing fence.
 If the Author emitted `PR opened or fixed`, or emitted `No work to do: explanation posted on the existing PR or issue` about an existing PR, follow the Monitor loop fence.
 
-Before following either fence, check the no-work/LGTM pairing rule (see "When to abort"): if the Author's signal this round was `No work to do: explanation posted on the existing PR or issue` and the Reviewer's verdict this round is `LGTM` or `Cannot implement`, do not follow either fence below; instead escalate to the user per that rule.
+Each fence's first line checks the no-work/LGTM pairing rule (see "When to abort") before anything else.
 
 No-PR routing:
 
@@ -401,7 +404,8 @@ Stop the automated cycle and escalate to the User in either of these cases:
 - The Programmer / Reviewer loop runs **four rounds** without reaching consensus (unless the user gave a different threshold).
   This is the fallback for a loop that stalls in disagreement; once four rounds are reached the cap applies unconditionally, even when both parties are still actively disputing.
 - The no-work/LGTM pairing rule: the Author emits `No work to do: explanation posted on the existing PR or issue` immediately adjacent, in either order across two consecutive turns, to a Reviewer verdict of `LGTM` or `Cannot implement`.
-  That is: the Author's `No work to do` turn is immediately followed by a Reviewer `LGTM`/`Cannot implement` verdict on that same round, OR a Reviewer `LGTM`/`Cannot implement` verdict is immediately followed by the Author's next turn emitting `No work to do`.
+  That is: the Author's `No work to do` turn is immediately followed by a Reviewer `LGTM`/`Cannot implement` verdict on that same round, OR a Reviewer `LGTM`/`Cannot implement` verdict is immediately followed by the Author's next turn emitting `No work to do`, with no other agent turn (Verification Planner, Verification Agent, or otherwise) intervening between the two.
+  A newAuthor round reached via `Verification revealed an error` does not qualify for the second form: the Verification Planner and Verification Agent turns intervene, so the Author's turn there is not immediately adjacent to the earlier Reviewer verdict.
   This pairing means one side found nothing actionable right next to the other side declaring the work fine or impossible; pause and escalate regardless of what CI reports, instead of following the normal routing fences.
 
 ## Concluding PR orchestration

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -43,7 +43,7 @@ Some required checks, such as "No blocking labels", validate the post-cycle stat
 
 ### Reviewing an Author who declined to open a PR
 
-Sometimes the Author opens no PR and instead posts its position as an **issue comment** (see "Declining to open a PR" in the Author section).
+Sometimes the Author opens no PR and instead posts its position as an **issue comment**, emitting `Work completed but no PR: updated issue with requested information` or `No work to do: explanation posted on the existing PR or issue` (see "Declining to open a PR" in the Author section).
 The artifact under review is then that issue comment and the Author's stated position, not a diff.
 The Orchestrator will point you at the issue rather than a PR.
 
@@ -79,13 +79,12 @@ In any of the following three circumstances, the Author should *not* open a PR:
 2. The Author believes it cannot fix the issue.
 3. The issue is flawed, invalid, or otherwise should not be acted upon.
 
-When declining to open a PR, the Author must:
+When declining to open a PR, the Author must post a comment on the **issue** (not on a PR, since none exists) that explains its position, begin the comment with the `🤖 Author` attribution line, and then tell the Orchestrator the matching status signal from `dev_orchestration.md`:
 
-- Post a comment on the **issue** (not on a PR, since none exists) that explains its position.
-  Begin the comment with the `🤖 Author` attribution line, then state which of the three circumstances applies and the reasoning behind it.
-  If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, the issue is really asking a question), describe that action or give that answer in the comment.
-- Tell the Orchestrator that it opened no PR and posted its position as an **issue comment** instead, using the status vocabulary in `dev_orchestration.md`.
-  The Orchestrator then points a Reviewer at the issue.
+- If circumstance 1 applies and the "no code change" resolution is itself an affirmative answer or action (for example, the issue is resolved by an action outside the repo such as a setting change, or the issue is really a question the Author can answer), describe that action or give that answer in the comment, and emit `Work completed but no PR: updated issue with requested information`.
+- Otherwise (circumstance 1 without an affirmative answer or action, or circumstance 2, or circumstance 3), state which circumstance applies and the reasoning behind it, and emit `No work to do: explanation posted on the existing PR or issue`.
+
+The Orchestrator then points a Reviewer at the issue.
 
 This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.
 The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Reviewer section), and the Author still defends its position or revises it across rounds.
@@ -94,10 +93,10 @@ The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Rev
 
 An Author may change its position between rounds, in either direction:
 
-- An Author that opened a PR may, after a review, conclude that no code change is warranted or that the issue should not be acted upon.
-  In that case it should close its PR and switch to the declining-to-open-a-PR path above, explaining the change on the issue.
+- An Author that opened a PR may, after a review, conclude that no further code change is warranted (for example, a CI failure turns out not to need a fix, or the issue should not be acted upon after all).
+  In that case it leaves the PR open, posts a comment on the **PR** explaining its conclusion (begin it with the `🤖 Author` attribution line), and emits `No work to do: explanation posted on the existing PR or issue` instead of pushing a fix.
 - An Author that declined to open a PR may later become convinced and switch to authoring a PR.
-  It opens the PR as usual (see `pr_creation.md`), and the review then proceeds against the PR.
+  It opens the PR as usual (see `pr_creation.md`), emitting `PR opened or fixed`, and the review then proceeds against the PR.
 
 Because each round begins by re-reading the issue, the PR (if any), and all comments, an Author is free to adopt whichever position the evidence supports; it is not bound by a position it took in an earlier round.
 The Author should not flip-flop merely to appease the Reviewer: change position only when genuinely convinced (see the skepticism guidance above).


### PR DESCRIPTION
Fixes #622.

## Changes

**A. Split `No PR; position posted on the issue` into two signals** (`agents/dev_orchestration.md`, `agents/pr_participation.md`):
- `Work completed but no PR: updated issue with requested information`: the Author took a concrete action (answered a question, described an out-of-repo fix, supplied missing information) and recorded it on the issue.
- `No work to do: explanation posted on the existing PR or issue`: the Author found nothing actionable and left an explanation, either on the issue (no PR exists) or on an existing PR. This also now covers an Author returning to an existing PR with nothing further to change (for example, after concluding a CI failure needs no fix); the PR stays open and the Author's explanation goes there instead of always closing the PR and moving to the issue.

**B. Reworded `PR opened` to `PR opened or fixed`** to cover both opening a fresh PR and pushing a fix to an existing PR in a later round.

**C. New Orchestrator escalation rule** (the "no-work/LGTM pairing rule", added to "When to abort" in `agents/dev_orchestration.md`): pause and escalate to the user, regardless of CI's result, whenever an Author's `No work to do` turn is immediately adjacent (in either order, across two consecutive turns) to a Reviewer verdict of `LGTM` or `Cannot implement`. This is wired into both routing fences (no-PR and Monitor loop), the Blocked-after-LGTM branch that dispatches a new Author round, and the Author-return handling in "Assigning a Programmer" so it fires whether the pairing happens within one round or across a CI-triggered new round.

## Why

The old single no-PR signal conflated three different circumstances (no code change needed, cannot fix, issue invalid) and had no way to describe an Author returning to an *existing* PR with nothing new to report. The new escalation rule catches a specific contradictory pattern: one side says "nothing to do here" right next to the other side saying "this is fine" or "this is impossible", which is worth a human look independent of whatever CI is doing.

## Scope

This is a documentation-only change to `agents/dev_orchestration.md` and `agents/pr_participation.md` (agent orchestration protocol, consumed by LLM sub-agents, not executable code). No other file in the repo parses these signal strings programmatically (verified via grep), so no code or tests needed updating.

## Test plan

- [ ] Manually exercise the new signals end-to-end in a live orchestration cycle (no-PR "work completed" path, no-PR "no work to do" path, existing-PR "no work to do" path, and the no-work/LGTM pairing escalation) to confirm the Orchestrator routes as documented, since these are LLM-followed prose instructions with no automated test harness.

