### PR TITLE
Make the Reviewer's third verdict reachable and drop the Author's status enum

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -187,7 +187,7 @@ Routing on the Verification Agent's signal:
 - Dispatch using the dispatch template above, with the Programmer role assignment statement and the literal issue number and branch name tokens.
 
 When the Author returns, apply this transition.
-Apply it to the PR if the Author opened one; apply it to the issue if the Author opened no PR, since that is where the work's labels live when there is no PR:
+Apply it to the PR if one exists; apply it to the issue otherwise, since that is where the work's labels live when there is no PR:
 
 | Remove label | Add label |
 |---|---|
@@ -197,7 +197,7 @@ Apply it to the PR if the Author opened one; apply it to the issue if the Author
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
 - Dispatch using the dispatch template above, with the Reviewer role assignment statement and the literal issue number token.
-- If the Author opened no PR, the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
+- If no PR exists, the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
   The dispatch template's issue token already points the Reviewer there; the Reviewer follows "Reviewing an Author who declined to open a PR" in `pr_participation.md`.
 
 ## Author disagreement
@@ -211,7 +211,7 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
 When the Reviewer returns, apply this transition.
-Apply it to the PR if one was opened; apply it to the issue on the no-PR path, since that is where the work's labels live when there is no PR:
+Apply it to the PR if one exists; apply it to the issue otherwise, since that is where the work's labels live when there is no PR:
 
 | Remove label |
 |---|
@@ -223,8 +223,8 @@ If the Reviewer requested changes, additionally apply this transition to the sam
 |---|
 | `changes requested` |
 
-Whether a PR was opened in the prior round decides which routing fence applies.
-If no PR was opened, there is no diff or CI to run, so follow the no-PR routing fence; if a PR was opened, follow the Monitor loop fence.
+Whether a PR exists decides which routing fence applies.
+If no PR exists, there is no diff or CI to run, so follow the no-PR routing fence; if a PR exists, follow the Monitor loop fence.
 
 No-PR routing:
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -384,7 +384,7 @@ If the stall cannot be explained by a known recoverable cause (e.g., a Monitor t
 
 Stop the automated cycle and escalate to the User in either of these cases:
 
-- A sub-agent emits `Cannot work` (see the routing fences above): escalate immediately, without waiting for further rounds.
+- A Reviewer emits `Cannot work` (see the routing fences above): escalate immediately, without waiting for further rounds.
   This covers a Programmer that gives up or an issue that cannot be solved as stated; the Reviewer confirms it by emitting `Cannot work`.
 - The Programmer / Reviewer loop runs **four rounds** without reaching consensus (unless the user gave a different threshold).
   This is the fallback for a loop that stalls in disagreement; once four rounds are reached the cap applies unconditionally, even when both parties are still actively disputing.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -131,7 +131,7 @@ Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
 - `LGTM`: the committed changes are correct and complete.
   If extra work outside the repo is required before merging, it should be explained clearly in a PR comment.
 - `Changes requested`: the Author is asked to take another turn, to correct or complete its prior work.
-- `Cannot implement`: the coding phase cannot be completed--the requirements are incomplete, unattainable, or self-contradictory, or no code change could address the issue.
+- `Cannot work`: the coding phase cannot be completed--the requirements are incomplete, unattainable, or self-contradictory, or no code change could address the issue.
   The Reviewer describes the specifics in a PR comment, or in an issue comment on the no-PR path (where there is no PR to comment on).
 
 Orchestrator-to-user terminal CI lines:
@@ -228,7 +228,7 @@ No-PR routing:
 
 ```text
   if Reviewer requested changes -> goto newAuthor
-  if Reviewer gave `Cannot implement` -> escalate to user; stop
+  if Reviewer gave `Cannot work` -> escalate to user; stop
   if Reviewer gave LGTM:
     The issue is resolved without a code change, and the Reviewer agreed.
     Do NOT launch the CI Monitor and do NOT dispatch a Verification Planner; both presuppose a PR.
@@ -241,7 +241,7 @@ PR routing (Monitor loop):
 
 ```text
   if Reviewer requested changes -> goto newAuthor
-  if Reviewer gave `Cannot implement` -> escalate to user; stop (do NOT route to a new Author round; leave the PR open for the user to close; the Reviewer's PR comment describes why)
+  if Reviewer gave `Cannot work` -> escalate to user; stop (do NOT route to a new Author round; leave the PR open for the user to close; the Reviewer's PR comment describes why)
   if Reviewer gave LGTM:
     Orchestrator launches a Monitor tool call running `python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER>` from the repo root (run_in_background: true, timeout_ms: 1800000). Record the task ID returned by the Monitor tool call for use in silentVanish recovery, and clear the silentVanish re-launch flag (this original launch is not a re-launch).
     Each stdout line arrives as a task-notification event; relay each line to the user verbatim.
@@ -382,8 +382,8 @@ If the stall cannot be explained by a known recoverable cause (e.g., a Monitor t
 
 Stop the automated cycle and escalate to the User in either of these cases:
 
-- A sub-agent emits `Cannot implement` (see the routing fences above): escalate immediately, without waiting for further rounds.
-  This covers a Programmer that gives up or an issue that cannot be solved as stated; the Reviewer confirms it by emitting `Cannot implement`.
+- A sub-agent emits `Cannot work` (see the routing fences above): escalate immediately, without waiting for further rounds.
+  This covers a Programmer that gives up or an issue that cannot be solved as stated; the Reviewer confirms it by emitting `Cannot work`.
 - The Programmer / Reviewer loop runs **four rounds** without reaching consensus (unless the user gave a different threshold).
   This is the fallback for a loop that stalls in disagreement; once four rounds are reached the cap applies unconditionally, even when both parties are still actively disputing.
 

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -113,18 +113,20 @@ Role assignment statements (copy the applicable line exactly):
 - Verification agent: "You are a Verification Agent: carry out the before-merging steps from the Verification Planner report on the linked PR, automating them where possible, and report results. You *must* start your turn by re-fetching the Verification Planner comment on the PR and each before-merging tracking issue it lists."
 
 The Programmer statement names the decline path so the dispatched Programmer receives it in the copied line, not only by reading `pr_participation.md`.
-An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and emitting `No PR; position posted on the issue` (see the Author status vocabulary below) instead of creating a PR.
+An Author that legitimately declines satisfies its exit obligation by posting the explanatory issue comment and reporting that it opened no PR, pointing to that comment (see the Author work-location report below), instead of creating a PR.
 
 ## Decision-signal templates
 
 When routing control signals, use these exact lines and no others.
 Fill only the tokens in braces.
 
-Author-to-Orchestrator status vocabulary (the Programmer emits one when it finishes a round, reporting only what it did):
-- `PR opened`: the Author opened a PR.
-- `No PR; position posted on the issue`: the Author opened no PR and posted its position as an explanatory comment on the issue (see "Declining to open a PR" in `pr_participation.md`).
+Author-to-Orchestrator work-location report (the Programmer states where its work product is when it finishes a round, reporting only what it did):
+- If it opened a PR, it gives the PR number.
+- If it opened no PR, it points to the explanatory comment it posted on the issue (see "Declining to open a PR" in `pr_participation.md`).
 
-When the Author emits `No PR; position posted on the issue`, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
+The Author is not making a branching decision, so it uses no fixed phrase; a plain location report suffices.
+The Orchestrator derives the branch from whether a PR number is present: a PR number selects the PR path, its absence the no-PR path.
+When no PR number is present, dispatch the Reviewer pointed at the **issue**, not a PR (see "Assigning a Reviewer").
 The Orchestrator does not read or judge the Author's explanation; it only notes which artifact the Reviewer must examine.
 
 Reviewer-to-Orchestrator outcome vocabulary (the Reviewer emits one):
@@ -185,7 +187,7 @@ Routing on the Verification Agent's signal:
 - Dispatch using the dispatch template above, with the Programmer role assignment statement and the literal issue number and branch name tokens.
 
 When the Author returns, apply this transition.
-Apply it to the PR if the Author emitted `PR opened`; apply it to the issue if the Author emitted `No PR; position posted on the issue`, since that is where the work's labels live when there is no PR:
+Apply it to the PR if the Author opened one; apply it to the issue if the Author opened no PR, since that is where the work's labels live when there is no PR:
 
 | Remove label | Add label |
 |---|---|
@@ -195,7 +197,7 @@ Apply it to the PR if the Author emitted `PR opened`; apply it to the issue if t
 
 - Create a sub-agent at the Reviewer model (see Model selection above)
 - Dispatch using the dispatch template above, with the Reviewer role assignment statement and the literal issue number token.
-- If the Author emitted `No PR; position posted on the issue` (no PR was opened), the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
+- If the Author opened no PR, the Reviewer examines the Author's explanatory comment on the **issue** rather than a PR.
   The dispatch template's issue token already points the Reviewer there; the Reviewer follows "Reviewing an Author who declined to open a PR" in `pr_participation.md`.
 
 ## Author disagreement
@@ -209,7 +211,7 @@ After the Reviewer exits and delivers its decision, the Orchestrator acts as fol
 Monitor output lines are relayed to the user verbatim; this is user-facing status reporting and is not governed by the say-nothing rule (which covers sub-agent messages only).
 
 When the Reviewer returns, apply this transition.
-Apply it to the PR if one was opened (the Author emitted `PR opened`); apply it to the issue on the no-PR path (the Author emitted `No PR; position posted on the issue`), since that is where the work's labels live when there is no PR:
+Apply it to the PR if one was opened; apply it to the issue on the no-PR path, since that is where the work's labels live when there is no PR:
 
 | Remove label |
 |---|
@@ -221,8 +223,8 @@ If the Reviewer requested changes, additionally apply this transition to the sam
 |---|
 | `changes requested` |
 
-The Author's status signal from the prior round decides which routing fence applies.
-If the Author emitted `No PR; position posted on the issue`, there is no diff or CI to run, so follow the no-PR routing fence; if it emitted `PR opened`, follow the Monitor loop fence.
+Whether a PR was opened in the prior round decides which routing fence applies.
+If no PR was opened, there is no diff or CI to run, so follow the no-PR routing fence; if a PR was opened, follow the Monitor loop fence.
 
 No-PR routing:
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -28,13 +28,14 @@
   post review: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```
 
-- After posting your review, tell the Orchestrator your decision using the fixed decision-signal vocabulary from `dev_orchestration.md`: one of `LGTM` or `Changes requested`.
+- After posting your review, tell the Orchestrator your decision using the fixed decision-signal vocabulary from `dev_orchestration.md`: one of `LGTM`, `Changes requested`, or `Cannot work`.
   The Orchestrator routes this signal verbatim; it does not relay your review prose to the Author.
   The Author reads your review from GitHub directly.
 
-- Your verdict is binary: either the PR is good to merge (`LGTM`) or it needs more work (`Changes requested`).
-  There is no middle option.
-  If you want any change made before merge, request changes so the full review cycle continues.
+- Your verdict is one of exactly three words, because it selects among three different Orchestrator actions:
+  - `LGTM`: the PR is good to merge. If you want any change made before merge, do not use this; request changes instead so the full review cycle continues.
+  - `Changes requested`: the PR needs more work, and another Author round can supply it. This sends the Author back to correct or complete its work.
+  - `Cannot work`: the coding phase cannot be completed by any further Author round, because the requirements are unattainable or self-contradictory, or a blocker is genuinely outside anyone's control (for example, the CI infrastructure itself is broken). This escalates to the user instead of looping. Explain the specifics in your review comment (or, on the no-PR path, in your issue comment). Do not reach for it merely because the PR is imperfect: use `Changes requested` whenever another round could help.
 
 ### CI checks during the development cycle
 
@@ -48,8 +49,8 @@ The artifact under review is then that issue comment and the Author's stated pos
 The Orchestrator will point you at the issue rather than a PR.
 
 Because there is no PR, post your review as an ordinary comment on the **issue** (begin it with the `🤖 Reviewer` line), not via the PR review tool.
-Your verdict vocabulary is unchanged: `LGTM` or `Changes requested`.
-Choose among three stances and map each to a verdict:
+Your verdict vocabulary is unchanged: `LGTM`, `Changes requested`, or `Cannot work`.
+Choose among these stances and map each to a verdict:
 
 - **Agree and approve.** You are convinced the Author is right that no PR is warranted (the issue needs no code change, cannot be fixed, or should not be acted upon).
   Say so plainly and emit `LGTM`.
@@ -59,6 +60,8 @@ Choose among three stances and map each to a verdict:
 - **Fundamentally disagree.** You believe the Author is wrong, the issue is valid, and a change is required and possible.
   Make the case that code is needed, citing what behavior is missing or broken, and emit `Changes requested`.
   This sends the Author back to either rebut your case in the issue comments or, if convinced, open a PR with the needed code.
+- **The issue is real but unworkable.** You agree a code change is needed, but conclude the issue as stated cannot be resolved by any Author, or a required blocker is genuinely outside anyone's control.
+  Explain why fully and emit `Cannot work`, which escalates to the user instead of looping.
 
 As always, do not hold back, and do not make the change yourself; convince the Author.
 
@@ -88,7 +91,7 @@ When declining to open a PR, the Author must:
   The Orchestrator then points a Reviewer at the issue.
 
 This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.
-The Reviewer still renders an `LGTM` or `Changes requested` verdict (see the Reviewer section), and the Author still defends its position or revises it across rounds.
+The Reviewer still renders an `LGTM`, `Changes requested`, or `Cannot work` verdict (see the Reviewer section), and the Author still defends its position or revises it across rounds.
 
 ### Changing position
 

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -35,7 +35,7 @@
 - Your verdict is one of exactly three words, because it selects among three different Orchestrator actions:
   - `LGTM`: the PR is good to merge. If you want any change made before merge, do not use this; request changes instead so the full review cycle continues.
   - `Changes requested`: the PR needs more work, and another Author round can supply it. This sends the Author back to correct or complete its work.
-  - `Cannot work`: the coding phase cannot be completed by any further Author round, because the requirements are unattainable or self-contradictory, or a blocker is genuinely outside anyone's control (for example, the CI infrastructure itself is broken). This escalates to the user instead of looping. Explain the specifics in your review comment (or, on the no-PR path, in your issue comment). Do not reach for it merely because the PR is imperfect: use `Changes requested` whenever another round could help.
+  - `Cannot work`: the coding phase cannot be completed by any further Author round, because the requirements are unattainable or self-contradictory, or a blocker is outside the Author's control (for example, the CI infrastructure itself is broken). This escalates to the user instead of looping. Explain the specifics in your review comment (or, on the no-PR path, in your issue comment). Do not reach for it merely because the PR is imperfect: use `Changes requested` whenever another round could help.
 
 ### CI checks during the development cycle
 
@@ -60,7 +60,7 @@ Choose among these stances and map each to a verdict:
 - **Fundamentally disagree.** You believe the Author is wrong, the issue is valid, and a change is required and possible.
   Make the case that code is needed, citing what behavior is missing or broken, and emit `Changes requested`.
   This sends the Author back to either rebut your case in the issue comments or, if convinced, open a PR with the needed code.
-- **The issue is real but unworkable.** You agree a code change is needed, but conclude the issue as stated cannot be resolved by any Author, or a required blocker is genuinely outside anyone's control.
+- **The issue is unworkable.** You conclude the issue as stated cannot be resolved by any Author, or a required blocker is genuinely outside Author control.
   Explain why fully and emit `Cannot work`, which escalates to the user instead of looping.
 
 As always, do not hold back, and do not make the change yourself; convince the Author.

--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -87,7 +87,7 @@ When declining to open a PR, the Author must:
 - Post a comment on the **issue** (not on a PR, since none exists) that explains its position.
   Begin the comment with the `🤖 Author` attribution line, then state which of the three circumstances applies and the reasoning behind it.
   If circumstance 1 applies and the issue is resolved by an action outside the repo (for example, a setting change) or by an answer (for example, the issue is really asking a question), describe that action or give that answer in the comment.
-- Tell the Orchestrator that it opened no PR and posted its position as an **issue comment** instead, using the status vocabulary in `dev_orchestration.md`.
+- Tell the Orchestrator that it opened no PR and point to the **issue comment** it posted instead, using the work-location report in `dev_orchestration.md`.
   The Orchestrator then points a Reviewer at the issue.
 
 This no-PR path changes only the artifact under review; the rest of the review cycle is unchanged.


### PR DESCRIPTION
Fixes #626.

## Reviewer's third verdict is now reachable

`dev_orchestration.md` already routed a third Reviewer verdict (on both the PR and no-PR paths, escalate to the user and stop), but `pr_participation.md`, the doc that actually instructs the Reviewer, told it the verdict was binary (`LGTM` or `Changes requested`, "no middle option"). Because the Reviewer was explicitly told a third option did not exist, it never emitted one, so the escalation branch was unreachable. That is why loops ran to the four-round cap even when the work genuinely cannot proceed (for example, when CI infrastructure itself is broken).

- `pr_participation.md` now tells the Reviewer a third verdict exists and when to use it: when the requirements are unattainable or self-contradictory, or a blocker is genuinely outside anyone's control. This is covered on both the PR path and the no-PR path (a new "issue is real but unworkable" stance).
- Renamed `Cannot implement` to `Cannot work` throughout for wording consistency with the Author-facing language.
- The Reviewer vocabulary stays at exactly three words, since each selects a different Orchestrator action: `Cannot work` escalates to the user, `LGTM` goes to the verification planner, `Changes requested` goes back to the Author.

## Author's status enum replaced with a plain location report

Every place `dev_orchestration.md` branched on the Author's exact status phrase (`PR opened` vs `No PR; position posted on the issue`) used it only as a proxy for whether a PR exists. The Author is not making a branching decision, so it no longer needs a controlled vocabulary: it simply reports where its work product is (a PR number, or a pointer to the issue comment it posted), and the Orchestrator derives the PR-path versus no-PR-path branching from whether a PR number is present, the same as before.

## Notes

Docs-only change; no automated test surface. Verified no remaining references to `Cannot implement`, `PR opened`, or `No PR; position posted on the issue` anywhere in the repo.

🦀
