### PR TITLE
Bound the E2E instrumentation call with a timeout so CI can't hang for hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,10 @@ jobs:
     # full 360 minutes before GitHub auto-canceled it. A full green run normally finishes in
     # 10-14 minutes, so 60 minutes is a generous bound that still cuts a would-be multi-hour
     # hang down to about an hour, with results/artifacts/issue-filing preserved for whatever ran
-    # before the cutoff. The `connectedE2EAndroidTest` Gradle task's own `am instrument` call
+    # before the cutoff--GitHub re-evaluates `if` conditions on cancellation, so `if: always()`
+    # steps still queued when the timeout fires keep running, but only for up to 5 more minutes
+    # (GitHub's own cancellation grace period); anything not done by then is force-terminated
+    # regardless. The `connectedE2EAndroidTest` Gradle task's own `am instrument` call
     # (app/build.gradle.kts) now bounds itself too, so most hangs there fail within that task's
     # own timeout well before this job-level backstop is needed; this remains as defense in depth
     # for a hang anywhere else in the job (e.g. the AGP-driven "Run instrumented tests" step).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,18 @@ jobs:
     # ubuntu-latest has KVM hardware acceleration (available since April 2024).
     runs-on: ubuntu-latest
 
+    # Issue #611: with no job-level timeout, a hang anywhere in this job falls back to GitHub's
+    # own 360-minute (6-hour) default. That has happened twice: this issue's referenced run sat
+    # hung for over three hours before a human canceled it, and a separate run on main ran the
+    # full 360 minutes before GitHub auto-canceled it. A full green run normally finishes in
+    # 10-14 minutes, so 60 minutes is a generous bound that still cuts a would-be multi-hour
+    # hang down to about an hour, with results/artifacts/issue-filing preserved for whatever ran
+    # before the cutoff. The `connectedE2EAndroidTest` Gradle task's own `am instrument` call
+    # (app/build.gradle.kts) now bounds itself too, so most hangs there fail within that task's
+    # own timeout well before this job-level backstop is needed; this remains as defense in depth
+    # for a hang anywhere else in the job (e.g. the AGP-driven "Run instrumented tests" step).
+    timeout-minutes: 60
+
     outputs:
       # Surfaced so link-pr-to-ci-summary (issue #331) can tell whether the
       # "Write test-result summary" step actually ran--on docs-only PRs it is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ import java.io.File
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
 
 plugins {
     id("com.android.application")
@@ -327,8 +328,21 @@ tasks.register("connectedE2EAndroidTest") {
         val xmlSuiteName = e2eClass ?: "com.gb4pc.e2e"
 
         val instrumentOut = ByteArrayOutputStream()
-        exec {
-            commandLine(
+        // Issue #611: `am instrument -w` blocks until the on-device instrumentation reports
+        // completion, and has no timeout of its own. A prior CI run's "Run SetupActivityDeniedE2ETest"
+        // step went completely silent right after this exec started (no INSTRUMENTATION_STATUS
+        // output at all) for over three hours before a human had to cancel it; a separate run on
+        // main hit GitHub's own 360-minute (6-hour) job default and was cancelled automatically.
+        // Both burned CI compute and blocked the pipeline for hours with no automatic recovery.
+        // Run `am instrument` via a plain ProcessBuilder (rather than Gradle's `exec {}`, which has
+        // no built-in timeout either) and bound it ourselves with Process.waitFor(timeout, unit) +
+        // destroyForcibly(), so a hung instrumentation run fails this task quickly instead of
+        // hanging indefinitely. A JVM-level timeout (vs. shelling out to the `timeout` coreutil, as
+        // build.yml already does for the emulator-readiness wait) keeps this task portable to
+        // developers running `./gradlew connectedE2EAndroidTest` locally on any OS.
+        val e2eInstrumentTimeoutMinutes = 10L
+        val instrumentProcess =
+            ProcessBuilder(
                 e2eAdb,
                 "shell",
                 "am",
@@ -337,12 +351,24 @@ tasks.register("connectedE2EAndroidTest") {
                 "-w",
                 *classArgs.toTypedArray(),
                 "com.gb4pc.test/androidx.test.runner.AndroidJUnitRunner",
-            )
-            standardOutput = instrumentOut
-            // Don't throw on non-zero exit: am instrument exits 1 on test failure,
-            // but we must write the JUnit XML before surfacing the error ourselves.
-            isIgnoreExitValue = true
+            ).redirectErrorStream(true)
+                .start()
+        // Drain stdout on a separate thread while we wait: the pipe's OS buffer is bounded, and a
+        // verbose test run could otherwise deadlock the child process (blocked writing) against
+        // this task (not yet reading) before the timeout below is ever reached.
+        val drainThread =
+            Thread {
+                instrumentProcess.inputStream.copyTo(instrumentOut)
+            }.apply {
+                isDaemon = true
+                start()
+            }
+        val finishedInTime = instrumentProcess.waitFor(e2eInstrumentTimeoutMinutes, TimeUnit.MINUTES)
+        val timedOut = !finishedInTime
+        if (timedOut) {
+            instrumentProcess.destroyForcibly()
         }
+        drainThread.join(TimeUnit.MINUTES.toMillis(1))
         val output = instrumentOut.toString()
         print(output)
 
@@ -465,6 +491,17 @@ tasks.register("connectedE2EAndroidTest") {
             },
         )
 
+        // Timeout guard (issue #611): checked first and unconditionally, since a hung run that
+        // happened to complete a few tests before being killed would otherwise slip past the
+        // empty-results guard (cases non-empty) and the failure guard (those completed cases
+        // may all have passed), reporting a false-green partial run instead of the hang it was.
+        if (timedOut) {
+            throw GradleException(
+                "E2E: 'am instrument' for $xmlSuiteName did not finish within " +
+                    "${e2eInstrumentTimeoutMinutes}m and was killed (device or test likely hung; " +
+                    "check logcat); ${cases.size} test(s) completed before the timeout",
+            )
+        }
         // Crash guard: these strings appear in -r output on hard abort/crash.
         if (output.contains("Process crashed") || output.contains("INSTRUMENTATION_ABORTED")) {
             throw GradleException("E2E instrumentation process crashed — check device logs")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -367,6 +367,25 @@ tasks.register("connectedE2EAndroidTest") {
         val timedOut = !finishedInTime
         if (timedOut) {
             instrumentProcess.destroyForcibly()
+            // PR #628 review: destroyForcibly() above only kills the local `adb shell am
+            // instrument` client process; it does not by itself confirm the on-device
+            // instrumentation (com.gb4pc, am instrument's targetPackage) actually stopped. If it
+            // lingered, every later connectedE2EAndroidTest step in the same CI job (overlay,
+            // gallery, permissions granted/denied, setup-activity granted/denied/permission-dialog,
+            // partial-access-photo-picker) targets that same process and could each need their own
+            // e2eInstrumentTimeoutMinutes wait, eroding most of this fix's benefit. Force-stop both
+            // the target and test packages explicitly (`am force-stop` acts at the ActivityManager
+            // level and does not itself wait on app cooperation, so this is not a source of a
+            // second hang) so the device is guaranteed clean for whichever step runs next,
+            // regardless of whether the local client's death alone would have propagated.
+            exec {
+                commandLine(e2eAdb, "shell", "am", "force-stop", "com.gb4pc")
+                isIgnoreExitValue = true
+            }
+            exec {
+                commandLine(e2eAdb, "shell", "am", "force-stop", "com.gb4pc.test")
+                isIgnoreExitValue = true
+            }
         }
         drainThread.join(TimeUnit.MINUTES.toMillis(1))
         val output = instrumentOut.toString()


### PR DESCRIPTION
Fixes #611.

### Where this run hung

The linked run's job log shows the `Run SetupActivityDeniedE2ETest` step (step 38) start `connectedE2EAndroidTest`'s `doLast` block, print the four expected `Performing Streamed Install` / `Success` lines from the APK installs, then go completely silent for over three hours until the user canceled it. No `INSTRUMENTATION_STATUS` output, nothing. Right after those installs, the task's `doLast` block calls `adb shell am instrument -r -w ...` via Gradle's `exec {}` and blocks until that returns. `am instrument -w` has no timeout of its own, and neither did anything wrapping it (the Gradle task, the CI step, or the job), so a hang anywhere inside the instrumented process (this exact test class's own doc already documents a history of keyguard/PIN races) could block indefinitely.

This is not a one-off: a separate run on `main` (run 28798023858) ran the full 360 minutes (GitHub's default job timeout) before being auto-canceled, and normal green runs consistently finish in 10-14 minutes. So this class of hang has recurred and can silently burn hours of CI compute with no automatic recovery.

### Fix

1. **`app/build.gradle.kts`**: `connectedE2EAndroidTest` now runs `am instrument` via a plain `ProcessBuilder` (rather than Gradle's `exec {}`, which has no built-in timeout either), bounded with `Process.waitFor(timeout, unit)` + `destroyForcibly()` on expiry, draining stdout on a side thread so a verbose run can't deadlock on a full pipe buffer while waiting. A timeout now fails the task with a clear message and is checked *before* the existing empty-results/failure guards, so a run that completed a few (all-passing) tests before being killed is still reported as the timeout it was, not a false-green partial run. Used a JVM-level timeout rather than shelling out to the `timeout` coreutil (as `build.yml` already does for the emulator-readiness wait) so `./gradlew connectedE2EAndroidTest` stays portable for local dev on any OS. After a timeout, also explicitly force-stops `com.gb4pc` and `com.gb4pc.test` on the device (review feedback), since killing the local adb client alone doesn't guarantee the on-device instrumentation stopped too.

2. **`.github/workflows/build.yml`**: added `timeout-minutes: 60` to `build-and-test` as a defense-in-depth backstop, since the fix above only covers this custom task; the AGP-driven `Run instrumented tests` step (and anything else in the job) still has no bound of its own.

### Test plan

- [x] `python3 -m unittest discover -s scripts -p "test_*.py"` and `scripts/test_*.sh` all still pass (unaffected by this change, run as a general health check).
- [x] YAML validated with `yaml.safe_load`; confirmed no ktlint/detekt gate exists to run locally.
- [x] The timeout firing path is no longer just a code-review-only claim: this PR's own CI (run 29072233989) reproduced the exact hang issue #611 describes, live, in `Run SetupActivityDeniedE2ETest`. The new timeout caught it at the 10-minute mark and failed loudly with `did not finish within 10m and was killed`, instead of blocking for hours. Every other E2E step in that same run passed normally (12s-2min each), confirming this was the pre-existing intermittent hang, not a regression from this change. Filed #629 to track the underlying test flakiness separately; a re-run of this branch is expected to go green since the failure is intermittent.
