### PR TITLE
Align adb-pull step titles with per-suite naming convention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
           "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
             bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
-      - name: Pull and upload overlay E2E video on failure
+      - name: Pull PixelCameraOverlayE2ETest E2E video on failure
         # Only pull and upload the recording when the overlay E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
@@ -521,7 +521,7 @@ jobs:
           done
           wait "$RECPID_GALLERY" 2>/dev/null || true
 
-      - name: Pull and upload gallery E2E video on failure
+      - name: Pull GalleryButtonVisualE2ETest E2E video on failure
         # Only pull and upload the recording when the gallery E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_gallery_e2e.outputs.outcome == 'failure'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
           "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
             bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
-      - name: Pull PixelCameraOverlayE2ETest E2E video on failure
+      - name: Pull PixelCameraOverlayE2ETest video on failure
         # Only pull and upload the recording when the overlay E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
@@ -457,7 +457,7 @@ jobs:
           "$ADB" pull /sdcard/e2e-overlay.mp4 /tmp/e2e-videos/e2e-overlay.mp4 || \
             echo "WARNING: could not pull e2e-overlay.mp4"
 
-      - name: Upload PixelCameraOverlayE2ETest E2E video
+      - name: Upload PixelCameraOverlayE2ETest video
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
@@ -521,7 +521,7 @@ jobs:
           done
           wait "$RECPID_GALLERY" 2>/dev/null || true
 
-      - name: Pull GalleryButtonVisualE2ETest E2E video on failure
+      - name: Pull GalleryButtonVisualE2ETest video on failure
         # Only pull and upload the recording when the gallery E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_gallery_e2e.outputs.outcome == 'failure'
@@ -531,7 +531,7 @@ jobs:
           "$ADB" pull /sdcard/e2e-gallery.mp4 /tmp/e2e-videos/e2e-gallery.mp4 || \
             echo "WARNING: could not pull e2e-gallery.mp4"
 
-      - name: Upload GalleryButtonVisualE2ETest E2E video
+      - name: Upload GalleryButtonVisualE2ETest video
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_gallery_e2e.outputs.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
           "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
             bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
-      - name: Pull PixelCameraOverlayE2ETest E2E video on failure
+      - name: Pull PixelCameraOverlayE2ETest video on failure
         # Only pull and upload the recording when the overlay E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
@@ -521,7 +521,7 @@ jobs:
           done
           wait "$RECPID_GALLERY" 2>/dev/null || true
 
-      - name: Pull GalleryButtonVisualE2ETest E2E video on failure
+      - name: Pull GalleryButtonVisualE2ETest video on failure
         # Only pull and upload the recording when the gallery E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_gallery_e2e.outputs.outcome == 'failure'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
           "$ADB" logcat -d -T "$LOGCAT_SINCE" | \
             bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
-      - name: Pull PixelCameraOverlayE2ETest video on failure
+      - name: Pull PixelCameraOverlayE2ETest E2E video on failure
         # Only pull and upload the recording when the overlay E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
@@ -521,7 +521,7 @@ jobs:
           done
           wait "$RECPID_GALLERY" 2>/dev/null || true
 
-      - name: Pull GalleryButtonVisualE2ETest video on failure
+      - name: Pull GalleryButtonVisualE2ETest E2E video on failure
         # Only pull and upload the recording when the gallery E2E suite failed (issue #520).
         # On a green run the file is left on the device and discarded when the emulator exits.
         if: always() && steps.diff_check.outputs.needs_full_build == 'true' && steps.run_gallery_e2e.outputs.outcome == 'failure'


### PR DESCRIPTION
Fixes #632.

`build.yml:450` and `:524` (the adb-pull `run:` steps for the overlay and gallery E2E suites) still used the older suite-descriptor step-title style ("Pull and upload overlay/gallery E2E video on failure"), rather than the per-suite naming convention that PR #630 applied to the artifact-producing `upload-artifact` steps ("Upload PixelCameraOverlayE2ETest E2E video", etc).

This renames the two adb-pull steps to:
- "Pull PixelCameraOverlayE2ETest video on failure"
- "Pull GalleryButtonVisualE2ETest video on failure"

Per owner feedback during review, the redundant "E2E" (the class name already ends in `E2ETest`) is also dropped from the sibling `upload-artifact` step titles, so both the Pull and Upload steps for each suite stay in sync:
- "Upload PixelCameraOverlayE2ETest video"
- "Upload GalleryButtonVisualE2ETest video"

No behavior change — step titles only.

## Test plan

- [ ] None outside the repo; this is a CI workflow step-title rename with no runtime behavior change.