### PR TITLE
Add --sha, --run-id, and --branch identifiers to CI Monitor

### DIFF
--- a/scripts/ci_monitor/README.md
+++ b/scripts/ci_monitor/README.md
@@ -1,23 +1,41 @@
 # CI Monitor
 
-`ci_monitor.py` polls a pull request's CI and streams a terminal outcome plus per-test signals.
+`ci_monitor.py` polls CI for a pull request, a bare commit, a specific Actions run, or a branch head, and streams a terminal outcome plus per-test signals.
 Each stdout line is the interface: terminal lines (`Clear`/`Blocked`/`Infra`) end the loop, while informational lines (`in_progress` heartbeat, per-step deltas, per-test `FAIL`/`SKIP`/`PASS`) keep it alive.
 
 For how the Orchestrator uses this script as part of the development cycle (the Monitor loop, routing decisions, and the Verification Planner dispatch), see [`agents/dev_orchestration.md`](../../agents/dev_orchestration.md).
 
 ## Running the monitor
 
-Run it from the repo root, passing the PR number via `--pr`:
+Run it from the repo root, passing **exactly one** identifier:
 
 ```bash
 python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER> [filter flags]
+python3 scripts/ci_monitor/ci_monitor.py --sha <SHA> [filter flags]
+python3 scripts/ci_monitor/ci_monitor.py --run-id <RUN_ID> [filter flags]
+python3 scripts/ci_monitor/ci_monitor.py --branch <BRANCH> [filter flags]
 ```
+
+| Flag | Tracks | Output prefix |
+|---|---|---|
+| `--pr <PR_NUMBER>` | A pull request's head commit. | `PR#<n>:` |
+| `--sha <SHA>` | A specific commit's check-runs directly, no PR involved. | `SHA#<first 7 chars>:` |
+| `--run-id <RUN_ID>` | One specific GitHub Actions run, scoped to that run only--not every check on its commit. | `RUN#<id>:` |
+| `--branch <BRANCH>` | The current head of a branch; its SHA is re-resolved every poll, so a new push is picked up. | `BRANCH#<name>:` |
+
+Supplying zero or more than one of these flags is a usage error (argparse exits with an error before any request is made).
+
+`--pr` mode is the only one with a pull request to consult, so it alone: (1) treats a merged or closed PR as an immediate terminal (`Merged`/`Closed`), and (2) gates the `Clear` terminal on `mergeable_state` (`clean`/`unstable`; `behind`/`dirty` maps to `Blocked`, `blocked` maps to `Infra`).
+`--sha`, `--run-id`, and `--branch` have no such state to consult: `Clear` fires directly off an all-passed check verdict, with no extra `/pulls/{n}` fetch.
+
+`--run-id` additionally does not fetch `/commits/{sha}/check-runs` at all--it resolves its verdict from the run object itself (`GET /actions/runs/{run_id}`, which carries `status`/`conclusion`/`head_sha` directly), and scopes step/artifact diagnostics to that one run's jobs. This keeps `--run-id` immune to an unrelated check on the same commit (e.g. this repo's `semgrep.yml`, which also runs on every commit) confusing its verdict--the problem `--pr`/`--sha`/`--branch` modes can in principle have if unrelated checks land on the same commit.
 
 `OWNER`/`REPO` default to this repo at the top of the script, and it reads `$GITHUB_TOKEN` from the environment (required).
 The script catches transient REST/parse failures per call so they cannot kill the resilient poll loop.
 
-The Monitor discovers which workflow run(s) and job(s) to track from the `/commits/{sha}/check-runs` payload, by parsing each GitHub Actions check run's `details_url` for its `(run_id, job_id)` (gated on `app.slug == "github-actions"`, with a `/actions/runs/` URL-pattern fallback when the `app` block is absent).
+In `--pr`/`--sha`/`--branch` modes, the Monitor discovers which workflow run(s) and job(s) to track from the `/commits/{sha}/check-runs` payload, by parsing each GitHub Actions check run's `details_url` for its `(run_id, job_id)` (gated on `app.slug == "github-actions"`, with a `/actions/runs/` URL-pattern fallback when the `app` block is absent).
 It does not name a workflow or job; the run/job to follow is derived from the same check-runs data that produces the verdict.
+In `--run-id` mode, the run to track is simply the one named on the command line--no check-runs payload is consulted for this purpose.
 
 ## Per-test outcome filters
 
@@ -73,6 +91,9 @@ The full marker is simply listed first as a readable convention.
 Switching the *emit* side to `##TEST##` (the Gradle/test reporters plus the `build.yml` greps) is a separate, larger change and out of scope here; the dual-marker config is the bridge, not an end state.
 
 ## Outcome vocabulary
+
+The table below is written for `--pr` mode's `PR#N:` prefix; `--sha`/`--run-id`/`--branch` modes emit the identical vocabulary under their own `SHA#<sha>:`/`RUN#<id>:`/`BRANCH#<name>:` prefix instead (see the flag table above).
+The `mergeable_state` gating on `Clear`/`Blocked`/`Infra` described below is `--pr`-only: the other three modes have no PR to consult, so `Clear` fires directly off an all-passed check verdict and `Blocked`/`Infra` fire directly off a failing/infra check conclusion, with no `mergeable_state` suffix.
 
 | Line emitted          | Meaning                                                                                               |
 |-----------------------|-------------------------------------------------------------------------------------------------------|

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -394,6 +394,11 @@ def parse_run_result(run_json):
     'Blocked', 'all_passed'. Unlike parse_check_result, there is no 'Clear'
     token here--a bare Actions run always exists once fetched, so the
     "no checks registered yet" case does not apply.
+
+    Any non-'completed' status (not just 'queued'/'in_progress') maps to
+    'in_progress': a single run object only has one status field, so there is
+    no multi-check "some still running" case to distinguish, unlike
+    parse_check_result's per-check-run list.
     """
     status = run_json.get("status", "")
     conclusion = run_json.get("conclusion") or ""
@@ -631,6 +636,30 @@ def _parse_outcome_filters(args):
     }
 
 
+def _select_mode(args):
+    """Return (mode, tag) for whichever identifier flag was supplied (issue #603).
+
+    `mode` is one of 'pr'/'sha'/'run'/'branch'; `tag` is the output-line
+    prefix. Only --pr has a PR to gate mergeable_state on or a merged/closed
+    short-circuit; the other three modes are simpler variants that fire
+    `Clear` directly off an all-passed check verdict.
+
+    Branches on "was this flag supplied" (argparse leaves an un-supplied dest
+    at its None default), not on truthiness: the mutually exclusive group
+    only guarantees exactly one dest is non-None, not that its value is
+    non-empty, so a truthiness check would misroute a literal empty-string
+    value for the flag actually used (e.g. `--sha ""`) to the next mode in
+    the chain instead of honoring --sha.
+    """
+    if args.pr is not None:
+        return "pr", "PR#%s" % args.pr
+    if args.sha is not None:
+        return "sha", "SHA#%s" % args.sha[:7]
+    if args.run_id is not None:
+        return "run", "RUN#%s" % args.run_id
+    return "branch", "BRANCH#%s" % args.branch
+
+
 class _DocstringParser(argparse.ArgumentParser):
     """ArgumentParser that prints the module docstring for --help/-h."""
 
@@ -697,22 +726,7 @@ def main(argv):
     token = os.environ.get("GITHUB_TOKEN", "")
     outcome_filters = _parse_outcome_filters(args)
 
-    # `mode` selects the identifier this run tracks; `tag` is the output-line
-    # prefix (issue #603). Only --pr has a PR to gate mergeable_state on or a
-    # merged/closed short-circuit; the other three modes are simpler variants
-    # that fire `Clear` directly off an all-passed check verdict.
-    if args.pr:
-        mode = "pr"
-        tag = "PR#%s" % args.pr
-    elif args.sha:
-        mode = "sha"
-        tag = "SHA#%s" % args.sha[:7]
-    elif args.run_id:
-        mode = "run"
-        tag = "RUN#%s" % args.run_id
-    else:
-        mode = "branch"
-        tag = "BRANCH#%s" % args.branch
+    mode, tag = _select_mode(args)
 
     # Configurable run/artifact/step/marker behavior (issue #500). Loaded once at
     # startup and threaded into the parsers below; a missing or invalid config

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -11,6 +11,15 @@ command-line arguments, per-outcome filter flags, and the outcome vocabulary.
 
 Usage:
     python3 scripts/ci_monitor/ci_monitor.py --pr <PR_NUMBER> [filter flags]
+    python3 scripts/ci_monitor/ci_monitor.py --sha <SHA> [filter flags]
+    python3 scripts/ci_monitor/ci_monitor.py --run-id <RUN_ID> [filter flags]
+    python3 scripts/ci_monitor/ci_monitor.py --branch <BRANCH> [filter flags]
+
+Exactly one of --pr/--sha/--run-id/--branch is required. --sha, --run-id, and
+--branch have no PR to consult, so their `Clear` terminal fires directly off
+an all-passed check verdict--no `mergeable_state` gating (that concept is
+--pr-only). See scripts/ci_monitor/README.md for the per-mode output prefixes
+(PR#/SHA#/RUN#/BRANCH#).
 
 Environment:
     GITHUB_TOKEN  GitHub token used for the REST calls (required).
@@ -137,6 +146,13 @@ SILENCE_SECONDS = 120
 # line.
 DRAIN_DELAY_SECONDS = 5
 DRAIN_MAX_ATTEMPTS = 3
+
+
+# Conclusion buckets shared by all three verdict classifiers (parse_check_result,
+# parse_check_summary's _BLOCKING_CONCLUSIONS, and parse_run_result). Hoisted to
+# module level (issue #603) so the third classifier does not re-duplicate them.
+_INFRA_CONCLUSIONS = frozenset(("cancelled", "timed_out", "stale", "startup_failure"))
+_BLOCKED_CONCLUSIONS = frozenset(("failure", "action_required"))
 
 
 # Parsers----------------------------------------------------------------------
@@ -280,9 +296,9 @@ def parse_check_result(check_json):
     if any(s in ("in_progress", "queued") for s in statuses):
         return "in_progress"
     if all(s == "completed" for s in statuses):
-        if any(c in ("cancelled", "timed_out", "stale", "startup_failure") for c in conclusions):
+        if any(c in _INFRA_CONCLUSIONS for c in conclusions):
             return "Infra"
-        if any(c in ("failure", "action_required") for c in conclusions):
+        if any(c in _BLOCKED_CONCLUSIONS for c in conclusions):
             return "Blocked"
         return "all_passed"
     return "in_progress"
@@ -302,9 +318,7 @@ def parse_check_summary(check_json, label_gate_check_regex=DEFAULT_LABEL_GATE_CH
     Returns [] when check_runs is absent or empty. Does not make any HTTP
     requests; reads only from the already-fetched check_json payload.
     """
-    _BLOCKING_CONCLUSIONS = frozenset(
-        ("failure", "action_required", "cancelled", "timed_out", "stale", "startup_failure")
-    )
+    _BLOCKING_CONCLUSIONS = _BLOCKED_CONCLUSIONS | _INFRA_CONCLUSIONS
     rows = []
     for r in check_json.get("check_runs", []):
         name = r.get("name") or "?"
@@ -369,6 +383,38 @@ def blocking_suffix(rows):
     if all(r["label_gate"] for r in blocking):
         suffix += " [label gate]"
     return suffix
+
+
+def parse_run_result(run_json):
+    """Map a /actions/runs/{run_id} response to an overall result token.
+
+    Mirrors parse_check_result's classification, but reads status/conclusion
+    directly off a single Actions run object (issue #603, --run-id mode)
+    instead of a list of check-runs. Returns one of: 'in_progress', 'Infra',
+    'Blocked', 'all_passed'. Unlike parse_check_result, there is no 'Clear'
+    token here--a bare Actions run always exists once fetched, so the
+    "no checks registered yet" case does not apply.
+    """
+    status = run_json.get("status", "")
+    conclusion = run_json.get("conclusion") or ""
+    if status != "completed":
+        return "in_progress"
+    if conclusion in _INFRA_CONCLUSIONS:
+        return "Infra"
+    if conclusion in _BLOCKED_CONCLUSIONS:
+        return "Blocked"
+    return "all_passed"
+
+
+def parse_commit_sha(commit_json):
+    """Return the top-level `sha` from a /commits/{ref} response, or '' if absent.
+
+    Used by --branch mode (issue #603) to re-resolve the branch's head SHA
+    every poll. Differs from parse_pr_sha, whose SHA is nested under
+    `head.sha`: a /commits/{ref} response (ref may be a branch or SHA) carries
+    the SHA at the top level.
+    """
+    return commit_json.get("sha", "")
 
 
 # Extract the run id (and optional job id) from an Actions check run's URL.
@@ -517,8 +563,8 @@ def _request(url, token, raw=False):
 _request.last_error = None
 
 
-def fetch_pr_with_retry(pr, token, attempts=3, base_delay=2):
-    """Fetch /pulls/{n} with bounded exponential backoff and rate-limit handling.
+def fetch_with_retry(url, token, attempts=3, base_delay=2):
+    """Fetch `url` with bounded exponential backoff and rate-limit handling.
 
     Tries up to `attempts` times. Between failed tries it sleeps with exponential
     backoff (base_delay, 2x, 4x, ...), unless the failure is a rate-limit
@@ -526,17 +572,31 @@ def fetch_pr_with_retry(pr, token, attempts=3, base_delay=2):
     hint, in which case it honors that delay instead. Returns the parsed JSON on
     success, or None if every attempt fails (the caller then handles the
     throttled "could not fetch SHA" line).
+
+    Generalized (issue #603) from the old PR-only `fetch_pr_with_retry` so the
+    same retry/backoff logic serves both the `--pr` fetch and the `--branch`
+    head-commit fetch, without duplicating it.
     """
-    url = "%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, pr)
     for attempt in range(attempts):
-        pr_json = _request(url, token)
-        if pr_json is not None:
-            return pr_json
+        result = _request(url, token)
+        if result is not None:
+            return result
         if attempt == attempts - 1:
             break
         hint = _retry_after_seconds(_request.last_error, time.time())
         time.sleep(hint if hint is not None else base_delay * (2**attempt))
     return None
+
+
+def fetch_pr_with_retry(pr, token, attempts=3, base_delay=2):
+    """Fetch /pulls/{n} with bounded exponential backoff and rate-limit handling.
+
+    Thin wrapper over fetch_with_retry that builds the /pulls/{n} URL; kept as
+    its own function since it is the --pr path's entry point and is exercised
+    directly by the test suite.
+    """
+    url = "%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, pr)
+    return fetch_with_retry(url, token, attempts=attempts, base_delay=base_delay)
 
 
 # Main poll loop-----------------------------------------------------------------
@@ -593,8 +653,24 @@ def main(argv):
         prog="ci_monitor.py",
         description="Poll a PR's CI and stream a terminal outcome plus per-test signals.",
     )
-    parser.add_argument(
-        "--pr", required=True, metavar="PR_NUMBER", help="The pull request number to monitor."
+    # Exactly one identifier is required (issue #603): --pr identifies a pull
+    # request; --sha/--run-id/--branch monitor a commit, an Actions run, or a
+    # branch head directly, with no PR involved.
+    id_group = parser.add_mutually_exclusive_group(required=True)
+    id_group.add_argument("--pr", metavar="PR_NUMBER", help="The pull request number to monitor.")
+    id_group.add_argument(
+        "--sha", metavar="SHA", help="A commit SHA to monitor directly; no PR involved."
+    )
+    id_group.add_argument(
+        "--run-id",
+        dest="run_id",
+        metavar="RUN_ID",
+        help="A specific GitHub Actions run ID to monitor, scoped to that run only.",
+    )
+    id_group.add_argument(
+        "--branch",
+        metavar="BRANCH",
+        help="A branch name to monitor; its head SHA is re-resolved every poll.",
     )
 
     # Per-outcome filter flags. Each outcome has an --include-* (optional regex)
@@ -618,9 +694,25 @@ def main(argv):
         )
 
     args = parser.parse_args(argv[1:])
-    pr = args.pr
     token = os.environ.get("GITHUB_TOKEN", "")
     outcome_filters = _parse_outcome_filters(args)
+
+    # `mode` selects the identifier this run tracks; `tag` is the output-line
+    # prefix (issue #603). Only --pr has a PR to gate mergeable_state on or a
+    # merged/closed short-circuit; the other three modes are simpler variants
+    # that fire `Clear` directly off an all-passed check verdict.
+    if args.pr:
+        mode = "pr"
+        tag = "PR#%s" % args.pr
+    elif args.sha:
+        mode = "sha"
+        tag = "SHA#%s" % args.sha[:7]
+    elif args.run_id:
+        mode = "run"
+        tag = "RUN#%s" % args.run_id
+    else:
+        mode = "branch"
+        tag = "BRANCH#%s" % args.branch
 
     # Configurable run/artifact/step/marker behavior (issue #500). Loaded once at
     # startup and threaded into the parsers below; a missing or invalid config
@@ -639,17 +731,17 @@ def main(argv):
     seen_fails = set()
 
     def emit_block(lines):
-        """Print each line prefixed with the PR tag and reset the 120s timer."""
+        """Print each line prefixed with the mode's tag and reset the 120s timer."""
         nonlocal last_output_ts
         if not lines:
             return
         text = "\n".join(lines)
         for line in text.split("\n"):
-            print("PR#%s: %s" % (pr, line))
+            print("%s: %s" % (tag, line))
         sys.stdout.flush()
         last_output_ts = time.time()
 
-    def poll_signals(sha, check_json=None):
+    def poll_signals(sha, check_json=None, explicit_targets=None):
         """Fetch and emit the per-step and per-test informational signals for `sha`.
 
         Mirrors the streamed test-result signals described in the module
@@ -667,6 +759,13 @@ def main(argv):
         check-runs request is issued. When `check_json` is None (e.g. the drain
         in drain_then_print, which must re-fetch to observe the jobs/artifacts
         endpoints catching up), poll_signals self-fetches the payload as before.
+
+        `explicit_targets`, when not None, is used directly as the (run_id,
+        job_id) target list instead of deriving it from check-runs data (issue
+        #603). --run-id mode passes `[(run_id, None)]` so it can track its one
+        run's jobs without ever fetching /commits/{sha}/check-runs--avoiding the
+        "unrelated check on the same commit" ambiguity a check-runs-derived
+        target list would reintroduce.
         """
         emitted = [False]
 
@@ -675,11 +774,14 @@ def main(argv):
                 emitted[0] = True
             emit_block(lines)
 
-        if check_json is None:
-            check_json = _request(
-                "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
-            )
-        targets = parse_actions_targets(check_json) if check_json else []
+        if explicit_targets is not None:
+            targets = explicit_targets
+        else:
+            if check_json is None:
+                check_json = _request(
+                    "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
+                )
+            targets = parse_actions_targets(check_json) if check_json else []
         if not targets:
             return emitted[0]
 
@@ -739,12 +841,12 @@ def main(argv):
         return emitted[0]
 
     def print_summary(rows):
-        """Emit the per-check summary block prefixed with the PR tag."""
+        """Emit the per-check summary block prefixed with the mode's tag."""
         for ln in format_check_summary(rows):
-            print("PR#%s: %s" % (pr, ln))
+            print("%s: %s" % (tag, ln))
         sys.stdout.flush()
 
-    def drain_then_print(sha, terminal_prefix, terminal_tail, rows):
+    def drain_then_print(sha, terminal_prefix, terminal_tail, rows, explicit_targets=None):
         """Gap E (issue #402)--drain lagging signal polls before a terminal line.
 
         Pauses DRAIN_DELAY_SECONDS and re-polls the step/artifact signals, so
@@ -765,15 +867,19 @@ def main(argv):
 
         Then emits the per-check summary block and the attributed terminal line.
         The terminal is `terminal_prefix + blocking_suffix(rows) + terminal_tail`.
+
+        `explicit_targets` is forwarded to poll_signals unchanged (issue #603);
+        --run-id mode passes its single (run_id, None) target so the drain
+        re-polls stay scoped to that run instead of self-fetching check-runs.
         """
         drained = False
         for _ in range(DRAIN_MAX_ATTEMPTS):
             time.sleep(DRAIN_DELAY_SECONDS)
-            if poll_signals(sha):
+            if poll_signals(sha, explicit_targets=explicit_targets):
                 drained = True
         diagnosed = any(r["blocking"] for r in rows)
         if not drained and not diagnosed:
-            print("PR#%s: drain poll found no new diagnostic signals" % pr)
+            print("%s: drain poll found no new diagnostic signals" % tag)
             sys.stdout.flush()
         print_summary(rows)
         terminal_line = terminal_prefix + blocking_suffix(rows) + terminal_tail
@@ -789,97 +895,146 @@ def main(argv):
     sys.stdout.flush()
 
     while True:
-        # Gap C--retry the SHA fetch with backoff and rate-limit awareness
-        # instead of a flat 30s retry, so transient blips and 403/429 throttles
-        # are handled without hammering the API.
-        pr_json = fetch_pr_with_retry(pr, token)
-        sha = parse_pr_sha(pr_json) if pr_json else ""
+        # Resolve this poll's sha (mode-specific) and check for the one
+        # mode-specific early terminal (--pr's merged/closed short-circuit;
+        # issue #603 keeps that concept --pr-only, per Gap A below).
+        if mode == "pr":
+            # Gap C--retry the SHA fetch with backoff and rate-limit awareness
+            # instead of a flat 30s retry, so transient blips and 403/429
+            # throttles are handled without hammering the API.
+            pr_json = fetch_pr_with_retry(args.pr, token)
+            sha = parse_pr_sha(pr_json) if pr_json else ""
+        elif mode == "sha":
+            sha = args.sha
+        elif mode == "branch":
+            commit_json = fetch_with_retry(
+                "%s/repos/%s/%s/commits/%s" % (API_BASE, OWNER, REPO, args.branch), token
+            )
+            sha = parse_commit_sha(commit_json) if commit_json else ""
+        else:  # mode == "run"
+            sha = None  # --run-id resolves head_sha from the run object below
 
-        if not sha:
+        if mode != "run" and not sha:
             # Throttle the noise: only surface the failure after >120s of
             # silence, matching the in_progress heartbeat suppression.
             now = time.time()
             if now - last_output_ts > SILENCE_SECONDS:
-                print("PR#%s: could not fetch SHA" % pr)
+                print("%s: could not fetch SHA" % tag)
                 sys.stdout.flush()
                 last_output_ts = now
             time.sleep(30)
             continue
 
-        # Gap A--a closed or merged PR leaves mergeable_state "unknown"
-        # forever; emit a terminal line and stop instead of spinning.
-        terminal = parse_pr_terminal(pr_json)
-        if terminal:
-            print("PR#%s: %s" % (pr, terminal))
-            sys.stdout.flush()
-            break
+        if mode == "pr":
+            # Gap A--a closed or merged PR leaves mergeable_state "unknown"
+            # forever; emit a terminal line and stop instead of spinning. This
+            # concept has no equivalent for a bare commit, run, or branch.
+            terminal = parse_pr_terminal(pr_json)
+            if terminal:
+                print("%s: %s" % (tag, terminal))
+                sys.stdout.flush()
+                break
 
-        check_json = _request(
-            "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
-        )
-        result = parse_check_result(check_json) if check_json else None
-        summary_rows = parse_check_summary(check_json, label_gate_check_regex) if check_json else []
+        if mode == "run":
+            # --run-id mode (issue #603) resolves verdict and diagnostics from
+            # the run object itself, not from /commits/{sha}/check-runs, so
+            # tracking stays scoped to this run and is not confused by an
+            # unrelated check on the same commit.
+            run_json = _request(
+                "%s/repos/%s/%s/actions/runs/%s" % (API_BASE, OWNER, REPO, args.run_id), token
+            )
+            if run_json is None:
+                now = time.time()
+                if now - last_output_ts > SILENCE_SECONDS:
+                    print("%s: could not fetch run" % tag)
+                    sys.stdout.flush()
+                    last_output_ts = now
+                time.sleep(30)
+                continue
+            sha = run_json.get("head_sha", "")
+            result = parse_run_result(run_json)
+            summary_rows = []
+            poll_signals(sha, explicit_targets=[(str(args.run_id), None)])
+        else:
+            check_json = _request(
+                "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
+            )
+            result = parse_check_result(check_json) if check_json else None
+            summary_rows = (
+                parse_check_summary(check_json, label_gate_check_regex) if check_json else []
+            )
 
-        # --- Streamed test-result signals -------------------------------------
-        # Emitted independent of the overall check conclusion, so E2E failures
-        # surface even while the check stays green via continue-on-error. Both
-        # signals are purely informational: they reset the silence timer but
-        # never end the loop.
-        poll_signals(sha, check_json=check_json)
-        # ----------------------------------------------------------------------
+            # --- Streamed test-result signals -------------------------------------
+            # Emitted independent of the overall check conclusion, so E2E failures
+            # surface even while the check stays green via continue-on-error. Both
+            # signals are purely informational: they reset the silence timer but
+            # never end the loop.
+            poll_signals(sha, check_json=check_json)
+            # ----------------------------------------------------------------------
 
         if result == "in_progress":
             now = time.time()
             if now - last_output_ts > SILENCE_SECONDS:
-                print("PR#%s: in_progress" % pr)
+                print("%s: in_progress" % tag)
                 sys.stdout.flush()
                 last_output_ts = now
         elif result == "all_passed":
-            mpr_json = _request("%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, pr), token)
-            mergeable = mpr_json.get("mergeable_state", "unknown") if mpr_json else "unknown"
-            if mergeable in ("clean", "unstable"):
+            if mode == "pr":
+                mpr_json = _request(
+                    "%s/repos/%s/%s/pulls/%s" % (API_BASE, OWNER, REPO, args.pr), token
+                )
+                mergeable = mpr_json.get("mergeable_state", "unknown") if mpr_json else "unknown"
+                if mergeable in ("clean", "unstable"):
+                    print_summary(summary_rows)
+                    print("%s: Clear (mergeable_state=%s)" % (tag, mergeable))
+                    sys.stdout.flush()
+                    break
+                elif mergeable in ("behind", "dirty"):
+                    # Gap E (issue #402)--drain lagging step/FAIL signals before
+                    # the terminal line; see drain_then_print and DRAIN_DELAY_SECONDS.
+                    drain_then_print(
+                        sha,
+                        "%s: Blocked" % tag,
+                        " (mergeable_state=%s)" % mergeable,
+                        summary_rows,
+                    )
+                    break
+                elif mergeable == "blocked":
+                    drain_then_print(
+                        sha, "%s: Infra" % tag, " (mergeable_state=blocked)", summary_rows
+                    )
+                    break
+                else:
+                    # Gap B--throttle "still computing" to >120s of silence, just
+                    # like the in_progress heartbeat, so it does not print every poll.
+                    now = time.time()
+                    if now - last_output_ts > SILENCE_SECONDS:
+                        print(
+                            "%s: all_passed mergeable_state=%s (still computing)" % (tag, mergeable)
+                        )
+                        sys.stdout.flush()
+                        last_output_ts = now
+            else:
+                # --sha/--branch/--run-id modes have no mergeable_state concept
+                # (issue #603): Clear fires directly off an all-passed verdict.
                 print_summary(summary_rows)
-                print("PR#%s: Clear (mergeable_state=%s)" % (pr, mergeable))
+                print("%s: Clear" % tag)
                 sys.stdout.flush()
                 break
-            elif mergeable in ("behind", "dirty"):
-                # Gap E (issue #402)--drain lagging step/FAIL signals before
-                # the terminal line; see drain_then_print and DRAIN_DELAY_SECONDS.
-                drain_then_print(
-                    sha,
-                    "PR#%s: Blocked" % pr,
-                    " (mergeable_state=%s)" % mergeable,
-                    summary_rows,
-                )
-                break
-            elif mergeable == "blocked":
-                drain_then_print(
-                    sha, "PR#%s: Infra" % pr, " (mergeable_state=blocked)", summary_rows
-                )
-                break
-            else:
-                # Gap B--throttle "still computing" to >120s of silence, just
-                # like the in_progress heartbeat, so it does not print every poll.
-                now = time.time()
-                if now - last_output_ts > SILENCE_SECONDS:
-                    print(
-                        "PR#%s: all_passed mergeable_state=%s (still computing)" % (pr, mergeable)
-                    )
-                    sys.stdout.flush()
-                    last_output_ts = now
         elif result in ("Blocked", "Infra"):
             # Gap E (issue #402)--drain lagging step/FAIL signals before the
             # terminal line; see drain_then_print and DRAIN_DELAY_SECONDS.
-            drain_then_print(sha, "PR#%s: %s" % (pr, result), "", summary_rows)
+            explicit_targets = [(str(args.run_id), None)] if mode == "run" else None
+            drain_then_print(sha, "%s: %s" % (tag, result), "", summary_rows, explicit_targets)
             break
         elif result == "Clear":
-            # No check runs registered (total_count == 0)--PR is already clear.
+            # No check runs registered (total_count == 0)--already clear.
             # Break immediately; no drain needed (there are no failing signals).
-            print("PR#%s: Clear" % pr)
+            print("%s: Clear" % tag)
             sys.stdout.flush()
             break
         elif result is not None:
-            print("PR#%s: %s" % (pr, result))
+            print("%s: %s" % (tag, result))
             sys.stdout.flush()
             last_output_ts = time.time()
 

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -38,6 +38,17 @@ Covers:
   (ae) #500 doc-sync: no legacy hardcoded workflow/job/marker literals remain
   (af) #500 poll_signals: a run-only target does not widen another run's job-id filter
   (al) #619: importing this module directly runs no checks and has no side effects
+  (am) #603 parse_run_result: classifies --run-id status/conclusion into
+       in_progress/all_passed/Blocked/Infra
+  (an) #603 parse_commit_sha: reads the top-level sha from a /commits/{ref} response
+  (ao) #603 argparse: exactly one of --pr/--sha/--run-id/--branch is required;
+       two or none is rejected
+  (ap) #603 main(): --sha mode Clear and Blocked paths, no mergeable_state gating
+  (aq) #603 main(): --branch mode re-resolves the head SHA each poll; Clear and Blocked
+  (ar) #603 main(): --run-id mode scopes verdict/diagnostics to the run object itself,
+       never fetching /commits/{sha}/check-runs
+  (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry; --pr's
+       output format is unchanged by the multi-mode refactor
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -3793,6 +3804,368 @@ def main() -> int:
         "check_runs_payload() not reachable via plain import; returncode=%r stdout=%r stderr=%r"
         % (_reuse_helper_al.returncode, _reuse_helper_al.stdout, _reuse_helper_al.stderr),
     )
+
+    # ── (am) #603 parse_run_result: classifies a /actions/runs/{id} response ───────
+    print(
+        "\n=== (am) #603 parse_run_result: in_progress/all_passed/Blocked/Infra classification ==="
+    )
+
+    check(
+        ci_monitor.parse_run_result({"status": "queued", "conclusion": None}) == "in_progress",
+        "queued run maps to in_progress",
+        "expected in_progress for a queued run",
+    )
+    check(
+        ci_monitor.parse_run_result({"status": "in_progress", "conclusion": None}) == "in_progress",
+        "in_progress run maps to in_progress",
+        "expected in_progress for an in_progress run",
+    )
+    check(
+        ci_monitor.parse_run_result({"status": "completed", "conclusion": "success"})
+        == "all_passed",
+        "completed+success maps to all_passed",
+        "expected all_passed for a completed/success run",
+    )
+    for concl in ("failure", "action_required"):
+        check(
+            ci_monitor.parse_run_result({"status": "completed", "conclusion": concl}) == "Blocked",
+            "completed+%s maps to Blocked" % concl,
+            "expected Blocked for completed/%s" % concl,
+        )
+    for concl in ("cancelled", "timed_out", "stale", "startup_failure"):
+        check(
+            ci_monitor.parse_run_result({"status": "completed", "conclusion": concl}) == "Infra",
+            "completed+%s maps to Infra" % concl,
+            "expected Infra for completed/%s" % concl,
+        )
+    check(
+        ci_monitor.parse_run_result({"status": "completed", "conclusion": "neutral"})
+        == "all_passed",
+        "an unrecognized completed conclusion (e.g. neutral) falls through to all_passed,"
+        " mirroring parse_check_result's default",
+        "expected all_passed fallback for an unrecognized completed conclusion",
+    )
+
+    # ── (an) #603 parse_commit_sha: top-level sha from /commits/{ref} ──────────────
+    print("\n=== (an) #603 parse_commit_sha: reads the top-level 'sha' field ===")
+
+    check(
+        ci_monitor.parse_commit_sha({"sha": "abc123", "commit": {}}) == "abc123",
+        "parse_commit_sha reads the top-level sha",
+        "expected 'abc123'",
+    )
+    check(
+        ci_monitor.parse_commit_sha({}) == "",
+        "parse_commit_sha returns '' when sha is absent",
+        "expected ''",
+    )
+    check(
+        ci_monitor.parse_commit_sha({"head": {"sha": "nested-only"}}) == "",
+        "parse_commit_sha does not read the nested head.sha shape (that's parse_pr_sha's job)",
+        "parse_commit_sha should not read a PR-shaped head.sha",
+    )
+
+    # ── (ao) #603 argparse: exactly one of --pr/--sha/--run-id/--branch required ───
+    print("\n=== (ao) #603 argparse: mutually exclusive identifier group ===")
+
+    with unittest.mock.patch("sys.stderr", new=io.StringIO()):
+        try:
+            ci_monitor.main(["ci_monitor.py"])
+            _fail("main() with no identifier flag should exit, but returned normally")
+        except SystemExit as e:
+            check(
+                e.code == 2,
+                "supplying none of --pr/--sha/--run-id/--branch exits with code 2",
+                "expected exit code 2, got %r" % e.code,
+            )
+
+    with unittest.mock.patch("sys.stderr", new=io.StringIO()):
+        try:
+            ci_monitor.main(["ci_monitor.py", "--pr", "1", "--sha", "deadbeef"])
+            _fail("main() with two identifier flags should exit, but returned normally")
+        except SystemExit as e:
+            check(
+                e.code == 2,
+                "supplying two identifier flags (--pr and --sha) exits with code 2",
+                "expected exit code 2, got %r" % e.code,
+            )
+    # Each flag being independently accepted is demonstrated by (ap)/(aq)/(ar)
+    # below, each of which drives main() to a terminal line via exactly one of
+    # --sha/--branch/--run-id.
+
+    # ── (ap) #603 main(): --sha mode Clear and Blocked, no PR involved ─────────────
+    print("\n=== (ap) #603 main(): --sha mode Clear path (no mergeable_state fetch) ===")
+
+    SHA_AP = "d34db33fcafe"
+    tag_ap = "SHA#%s" % SHA_AP[:7]
+    CHECK_PASS_AP = {
+        "total_count": 1,
+        "check_runs": [{"name": "build-and-test", "status": "completed", "conclusion": "success"}],
+    }
+
+    def fake_request_ap_clear(url, token, raw=False):
+        return CHECK_PASS_AP
+
+    buf_ap1 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_ap_clear),
+        unittest.mock.patch("sys.stdout", new=buf_ap1),
+    ):
+        rc_ap1 = ci_monitor.main(["ci_monitor.py", "--sha", SHA_AP])
+
+    lines_ap1 = buf_ap1.getvalue().splitlines()
+    check(
+        ("%s: Clear" % tag_ap) in lines_ap1,
+        "sha mode emits '%s: Clear' with no mergeable_state suffix" % tag_ap,
+        "expected a bare Clear line; output: %r" % lines_ap1,
+    )
+    check(
+        not any("mergeable_state" in ln for ln in lines_ap1),
+        "sha mode never fetches or mentions mergeable_state",
+        "unexpected mergeable_state reference; output: %r" % lines_ap1,
+    )
+    check(rc_ap1 == 0, "main() returned 0", "main() returned %r" % rc_ap1)
+
+    print("\n=== (ap) #603 main(): --sha mode Blocked path, attributed by check name ===")
+
+    CHECK_BLOCKED_AP = {
+        "total_count": 1,
+        "check_runs": [{"name": "build-and-test", "status": "completed", "conclusion": "failure"}],
+    }
+    # 1 verdict poll + DRAIN_MAX_ATTEMPTS drain self-fetches of check-runs (no
+    # github-actions-shaped check run is present, so parse_actions_targets finds
+    # no jobs/artifacts to fetch on any of them).
+    side_effects_ap2 = collections.deque([CHECK_BLOCKED_AP] * (1 + ci_monitor.DRAIN_MAX_ATTEMPTS))
+
+    def fake_request_ap_blocked(url, token, raw=False):
+        return side_effects_ap2.popleft()
+
+    buf_ap2 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_ap_blocked),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_ap2),
+    ):
+        rc_ap2 = ci_monitor.main(["ci_monitor.py", "--sha", SHA_AP])
+
+    lines_ap2 = buf_ap2.getvalue().splitlines()
+    check(
+        ("%s: Blocked by: build-and-test" % tag_ap) in lines_ap2,
+        "sha mode Blocked terminal attributes the failing check by name",
+        "expected an attributed Blocked line; output: %r" % lines_ap2,
+    )
+    check(
+        len(side_effects_ap2) == 0,
+        "all mocked check-runs requests consumed (1 poll + %d drain attempts)"
+        % ci_monitor.DRAIN_MAX_ATTEMPTS,
+        "request deque not drained; %d entries left" % len(side_effects_ap2),
+    )
+    check(rc_ap2 == 0, "main() returned 0", "main() returned %r" % rc_ap2)
+
+    # ── (aq) #603 main(): --branch mode re-resolves the head SHA each poll ─────────
+    print(
+        "\n=== (aq) #603 main(): --branch mode Clear path, sha resolved via /commits/{branch} ==="
+    )
+
+    BRANCH_AQ = "feature/x"
+    tag_aq = "BRANCH#%s" % BRANCH_AQ
+    COMMIT_AQ = {"sha": "0ff1ceb0a7d0"}
+    CHECK_PASS_AQ = {
+        "total_count": 1,
+        "check_runs": [{"name": "build-and-test", "status": "completed", "conclusion": "success"}],
+    }
+    side_effects_aq1 = collections.deque([COMMIT_AQ, CHECK_PASS_AQ])
+
+    def fake_request_aq1(url, token, raw=False):
+        return side_effects_aq1.popleft()
+
+    buf_aq1 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_aq1),
+        unittest.mock.patch("sys.stdout", new=buf_aq1),
+    ):
+        rc_aq1 = ci_monitor.main(["ci_monitor.py", "--branch", BRANCH_AQ])
+
+    lines_aq1 = buf_aq1.getvalue().splitlines()
+    check(
+        ("%s: Clear" % tag_aq) in lines_aq1,
+        "branch mode emits '%s: Clear'" % tag_aq,
+        "expected a Clear line; output: %r" % lines_aq1,
+    )
+    check(
+        len(side_effects_aq1) == 0,
+        "both the commit-resolution and check-runs requests were consumed",
+        "request deque not drained; %d entries left" % len(side_effects_aq1),
+    )
+    check(rc_aq1 == 0, "main() returned 0", "main() returned %r" % rc_aq1)
+
+    print("\n=== (aq) #603 main(): --branch mode Blocked path ===")
+
+    CHECK_BLOCKED_AQ = {
+        "total_count": 1,
+        "check_runs": [{"name": "build-and-test", "status": "completed", "conclusion": "failure"}],
+    }
+    # Commit resolution + 1 verdict poll + DRAIN_MAX_ATTEMPTS drain self-fetches of
+    # check-runs (the drain re-polls check-runs directly by sha, not via the
+    # branch, so no further /commits/{branch} request is issued).
+    side_effects_aq2 = collections.deque(
+        [COMMIT_AQ, CHECK_BLOCKED_AQ] + [CHECK_BLOCKED_AQ] * ci_monitor.DRAIN_MAX_ATTEMPTS
+    )
+
+    def fake_request_aq2(url, token, raw=False):
+        return side_effects_aq2.popleft()
+
+    buf_aq2 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_aq2),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_aq2),
+    ):
+        rc_aq2 = ci_monitor.main(["ci_monitor.py", "--branch", BRANCH_AQ])
+
+    lines_aq2 = buf_aq2.getvalue().splitlines()
+    check(
+        ("%s: Blocked by: build-and-test" % tag_aq) in lines_aq2,
+        "branch mode Blocked terminal attributes the failing check by name",
+        "expected an attributed Blocked line; output: %r" % lines_aq2,
+    )
+    check(
+        len(side_effects_aq2) == 0,
+        "all mocked requests consumed (commit resolve + verdict + %d drain attempts)"
+        % ci_monitor.DRAIN_MAX_ATTEMPTS,
+        "request deque not drained; %d entries left" % len(side_effects_aq2),
+    )
+    check(rc_aq2 == 0, "main() returned 0", "main() returned %r" % rc_aq2)
+
+    # ── (ar) #603 main(): --run-id mode scopes to the run object itself ────────────
+    print(
+        "\n=== (ar) #603 main(): --run-id mode Clear path (never fetches check-runs) ==="
+    )
+
+    RUN_ID_AR = "778899"
+    tag_ar = "RUN#%s" % RUN_ID_AR
+    RUN_SUCCESS_AR = {"status": "completed", "conclusion": "success", "head_sha": "5eed1234"}
+
+    def fake_request_ar1(url, token, raw=False):
+        check(
+            "check-runs" not in url,
+            "run-id mode never fetches /commits/{sha}/check-runs",
+            "unexpected check-runs fetch: %s" % url,
+        )
+        return RUN_SUCCESS_AR
+
+    buf_ar1 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_ar1),
+        unittest.mock.patch("sys.stdout", new=buf_ar1),
+    ):
+        rc_ar1 = ci_monitor.main(["ci_monitor.py", "--run-id", RUN_ID_AR])
+
+    lines_ar1 = buf_ar1.getvalue().splitlines()
+    check(
+        ("%s: Clear" % tag_ar) in lines_ar1,
+        "run-id mode emits '%s: Clear'" % tag_ar,
+        "expected a Clear line; output: %r" % lines_ar1,
+    )
+    check(rc_ar1 == 0, "main() returned 0", "main() returned %r" % rc_ar1)
+
+    print(
+        "\n=== (ar) #603 main(): --run-id mode Blocked path, scoped to this run's jobs only ==="
+    )
+
+    RUN_FAILURE_AR = {"status": "completed", "conclusion": "failure", "head_sha": "5eed1234"}
+    JOBS_AR = {
+        "jobs": [
+            {
+                "id": 1,
+                "name": "build-and-test",
+                "steps": [
+                    {
+                        "number": 4,
+                        "name": "Build and run unit tests",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    }
+                ],
+            }
+        ]
+    }
+    ARTS_EMPTY_AR = {"artifacts": []}
+    # 1 run fetch + 1 poll_signals (jobs+artifacts) + DRAIN_MAX_ATTEMPTS drain
+    # attempts, each just jobs+artifacts (explicit_targets skips any check-runs
+    # or run re-fetch during the drain).
+    side_effects_ar2 = collections.deque(
+        [RUN_FAILURE_AR, JOBS_AR, ARTS_EMPTY_AR]
+        + [JOBS_AR, ARTS_EMPTY_AR] * ci_monitor.DRAIN_MAX_ATTEMPTS
+    )
+
+    def fake_request_ar2(url, token, raw=False):
+        check(
+            "check-runs" not in url,
+            "run-id mode's drain never fetches check-runs either",
+            "unexpected check-runs fetch during drain: %s" % url,
+        )
+        return side_effects_ar2.popleft()
+
+    buf_ar2 = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_ar2),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_ar2),
+    ):
+        rc_ar2 = ci_monitor.main(["ci_monitor.py", "--run-id", RUN_ID_AR])
+
+    lines_ar2 = buf_ar2.getvalue().splitlines()
+    check(
+        ('%s: step "Build and run unit tests" -> failure' % tag_ar) in lines_ar2,
+        "run-id mode surfaces the failing step from its own run's jobs",
+        "expected a step failure line; output: %r" % lines_ar2,
+    )
+    check(
+        ("%s: Blocked" % tag_ar) in lines_ar2,
+        "run-id mode emits a bare Blocked terminal (no check-run summary to attribute)",
+        "expected a Blocked line; output: %r" % lines_ar2,
+    )
+    check(
+        len(side_effects_ar2) == 0,
+        "all mocked requests consumed (run fetch + jobs/artifacts + %d drain attempts)"
+        % ci_monitor.DRAIN_MAX_ATTEMPTS,
+        "request deque not drained; %d entries left" % len(side_effects_ar2),
+    )
+    check(rc_ar2 == 0, "main() returned 0", "main() returned %r" % rc_ar2)
+
+    # ── (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry; ───
+    # --pr's output format is unchanged by the multi-mode refactor
+    print(
+        "\n=== (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry ==="
+    )
+
+    delegate_calls_as = []
+
+    def _spy_fetch_with_retry_as(url, token, attempts=3, base_delay=2):
+        delegate_calls_as.append((url, attempts, base_delay))
+        return {"head": {"sha": "beefcafe"}}
+
+    with unittest.mock.patch.object(
+        ci_monitor, "fetch_with_retry", side_effect=_spy_fetch_with_retry_as
+    ):
+        got_as = ci_monitor.fetch_pr_with_retry("999", "tok")
+    check(
+        got_as == {"head": {"sha": "beefcafe"}},
+        "fetch_pr_with_retry returns fetch_with_retry's result",
+        "expected the delegate's return value; got %r" % got_as,
+    )
+    expected_url_as = "%s/repos/%s/%s/pulls/999" % (ci_monitor.API_BASE, OWNER_T, REPO_T)
+    check(
+        len(delegate_calls_as) == 1 and delegate_calls_as[0][0] == expected_url_as,
+        "fetch_pr_with_retry builds the same /pulls/{n} URL as before and calls"
+        " fetch_with_retry exactly once",
+        "unexpected delegate call(s): %r" % delegate_calls_as,
+    )
+    # The PR-mode tests above ((i),(j),(k),(m),(n),(p),(q),(r),(s),(t),(u),(v),(w),
+    # (x),(y),(z),(aa)-(ak)) all still assert exact 'PR#N: ...' lines byte-for-byte;
+    # their continued passing after this multi-mode refactor (issue #603) is itself
+    # the regression check that --pr's output shape is unchanged.
 
     # ── Summary ────────────────────────────────────────────────────────────────────
     print("\nResults: %d passed, %d failed." % (PASS, FAIL))

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -42,7 +42,10 @@ Covers:
        in_progress/all_passed/Blocked/Infra
   (an) #603 parse_commit_sha: reads the top-level sha from a /commits/{ref} response
   (ao) #603 argparse: exactly one of --pr/--sha/--run-id/--branch is required;
-       two or none is rejected
+       two or none is rejected. Also: _select_mode() branches on "was this
+       flag supplied" not on truthiness, so an empty-string value for the
+       supplied flag (e.g. --sha "") is not misrouted to the next mode
+       (review finding on PR #636)
   (ap) #603 main(): --sha mode Clear and Blocked paths, no mergeable_state gating
   (aq) #603 main(): --branch mode re-resolves the head SHA each poll; Clear and Blocked
   (ar) #603 main(): --run-id mode scopes verdict/diagnostics to the run object itself,
@@ -3892,6 +3895,47 @@ def main() -> int:
     # Each flag being independently accepted is demonstrated by (ap)/(aq)/(ar)
     # below, each of which drives main() to a terminal line via exactly one of
     # --sha/--branch/--run-id.
+
+    # _select_mode must branch on "was this flag supplied" (argparse's
+    # un-supplied dest stays at its None default), not on truthiness--a review
+    # finding on this PR: a truthiness check misroutes a literal empty-string
+    # value for the flag actually used (e.g. `--sha ""`) to the next mode in
+    # the chain, since "" is falsy but still means --sha was supplied.
+    import argparse as _argparse_ao  # noqa: E402
+
+    def _mode_args(**kw):
+        defaults = {"pr": None, "sha": None, "run_id": None, "branch": None}
+        defaults.update(kw)
+        return _argparse_ao.Namespace(**defaults)
+
+    check(
+        ci_monitor._select_mode(_mode_args(pr="")) == ("pr", "PR#"),
+        "_select_mode: --pr '' (empty but supplied) selects pr mode, not the next one",
+        "expected ('pr', 'PR#'); got %r" % (ci_monitor._select_mode(_mode_args(pr="")),),
+    )
+    check(
+        ci_monitor._select_mode(_mode_args(sha="")) == ("sha", "SHA#"),
+        "_select_mode: --sha '' (empty but supplied) selects sha mode, not branch mode"
+        " (the exact bug reported in review)",
+        "expected ('sha', 'SHA#'); got %r" % (ci_monitor._select_mode(_mode_args(sha="")),),
+    )
+    check(
+        ci_monitor._select_mode(_mode_args(run_id="")) == ("run", "RUN#"),
+        "_select_mode: --run-id '' (empty but supplied) selects run mode",
+        "expected ('run', 'RUN#'); got %r" % (ci_monitor._select_mode(_mode_args(run_id="")),),
+    )
+    check(
+        ci_monitor._select_mode(_mode_args(branch="main")) == ("branch", "BRANCH#main"),
+        "_select_mode: --branch selects branch mode with the expected tag",
+        "expected ('branch', 'BRANCH#main'); got %r"
+        % (ci_monitor._select_mode(_mode_args(branch="main")),),
+    )
+    check(
+        ci_monitor._select_mode(_mode_args(sha="deadbeefcafe")) == ("sha", "SHA#deadbee"),
+        "_select_mode: --sha tag truncates to the first 7 characters",
+        "expected ('sha', 'SHA#deadbee'); got %r"
+        % (ci_monitor._select_mode(_mode_args(sha="deadbeefcafe")),),
+    )
 
     # ── (ap) #603 main(): --sha mode Clear and Blocked, no PR involved ─────────────
     print("\n=== (ap) #603 main(): --sha mode Clear path (no mergeable_state fetch) ===")


### PR DESCRIPTION
Fixes #603.

`ci_monitor.py` previously accepted only `--pr`. This adds a required, mutually exclusive group of `--pr`/`--sha`/`--run-id`/`--branch`, so the monitor can track a bare commit, a specific Actions run, or a branch head with no PR involved.

## What changed

- `--sha <SHA>`: monitors a commit's check-runs directly. Output prefix `SHA#<first 7 chars>:`.
- `--branch <BRANCH>`: re-resolves the branch's head SHA every poll via a new `parse_commit_sha`, so a new push is picked up. Output prefix `BRANCH#<name>:`.
- `--run-id <RUN_ID>`: resolves verdict and diagnostics from the Actions run object itself (`GET /actions/runs/{run_id}`) via a new `parse_run_result`, instead of `/commits/{sha}/check-runs`. This scopes tracking to that one run so it can't be confused by an unrelated check on the same commit (e.g. this repo's `semgrep.yml`). Output prefix `RUN#<id>:`.
- `--sha`/`--run-id`/`--branch` have no PR to consult, so their `Clear` terminal fires directly off an all-passed check verdict, with no `mergeable_state` gating (that concept stays `--pr`-only, along with the merged/closed short-circuit).
- `poll_signals`/`drain_then_print` gained an `explicit_targets` path so `--run-id` mode can skip `/commits/{sha}/check-runs` and `parse_actions_targets` entirely, going straight to its one `(run_id, None)` target.
- Generalized `fetch_pr_with_retry` into `fetch_with_retry(url, token, ...)`, shared by the `--pr` and `--branch` fetches; `fetch_pr_with_retry` is now a thin wrapper.
- Hoisted the Infra/Blocked conclusion buckets (`_INFRA_CONCLUSIONS`/`_BLOCKED_CONCLUSIONS`) to module level so the new `parse_run_result` classifier doesn't re-duplicate them.
- `--pr` mode's behavior and output format are unchanged; all pre-existing PR-mode tests still assert exact `PR#N: ...` lines byte-for-byte and continue to pass.

## Tests

Added test cases (am)-(as) to `scripts/test_ci_monitor.py`:

- `parse_run_result` and `parse_commit_sha` classification/parsing.
- Argparse: exactly one of the four identifiers is accepted; two or none is rejected.
- One mocked-HTTP `main()` test per new mode, each covering a `Clear` and a `Blocked` path.
- A regression check that `fetch_pr_with_retry` delegates to `fetch_with_retry` with the same URL, plus a note that the exhaustive pre-existing `--pr`-mode tests are the regression proof that its output is unchanged.

All 287 tests pass (`python3 scripts/test_ci_monitor.py`), and `ruff check` passes clean.

Also updated `scripts/ci_monitor/README.md` (flag/prefix table, and which outcome-vocabulary behaviors are `--pr`-only vs. shared) and the module docstring's `Usage:` section.

## Test plan

- [x] None outside the automated suite; this is a script with no runtime dependency on a live GitHub Actions run to verify manually before merge.

