### PR TITLE
Quarantine flaky SetupActivityPermissionDialogE2ETest # setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -22,3 +22,6 @@
 
 # Tracking issue: #243
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen
+
+# Tracking issue: #581
+com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest#setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances


### PR DESCRIPTION
Quarantines #581.

`SetupActivityPermissionDialogE2ETest#setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances` has failed intermittently on the same assertion (`hasMediaPermission() should become true after tapping "Allow all" in the real system permission dialog`) 11 times since 2026-07-04, on `main` directly and on several unrelated feature branches/PRs (#582, #610, #613, #620, #637, #638). This spread across unrelated diffs confirms the failure is not caused by any one change, but is a genuine flake in the test/emulator interaction.

It is currently blocking merge on unrelated PRs (#637, #638) via the required `build-and-test` check, per `.github/workflows/CLAUDE.md`'s red-to-green allowlist design (issue #309).

## Change

Add the test method to `.github/allowed-test-failures.txt`, tagged with the tracking issue, so it stops failing the build while #581 investigates and fixes the underlying flake. This is the documented, temporary mechanism for exactly this situation; remove the entry once #581 is resolved.

## Test plan

- [x] `python3 scripts/test_check_allowed_failures.py` passes (22/22), confirming the allowlist still parses correctly with the new entry.

