### PR TITLE
CI: synthesize a monitor-feed marker on the permission-dialog teardown path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -938,6 +938,38 @@ jobs:
           else
             # Gradle exited non-zero. Diagnose host-side, immune to com.gb4pc having died.
             echo "=== SetupActivityPermissionDialogE2ETest: non-zero Gradle exit; host-side diagnosis ==="
+            # Deterministically rebuild the monitor feed from the fully-written log before
+            # inspecting it below (issue #601). The in-line `tee >(grep ...)` process
+            # substitution above can still be flushing when Gradle returns, so rebuilding
+            # from /tmp/e2e-permission-dialog.log (which `tee` has finished writing by the
+            # time the pipeline's exit status is known) makes the "outcome":"FAIL" check
+            # and any synthesized marker below race-free. `|| true`: grep exits non-zero
+            # when the log has no marker lines (the torn-down case this step handles),
+            # which is expected and must not abort the step under `set -o pipefail`.
+            grep '^##GB4PC_TEST##' /tmp/e2e-permission-dialog.log > results/e2e-setup-activity-permission-dialog.ndjson || true
+            # Helper: append a synthesized terminal marker for this suite's single test
+            # method when the instrumented process was torn down mid-test so no in-process
+            # ##GB4PC_TEST## line was emitted (issue #601), giving this feed the same
+            # per-test attribution the other six suites get for every run. Idempotent:
+            # no-ops if a genuine marker for this method is already present (the rebuild
+            # above guarantees a real one, if any exists, is there). Only static ASCII text
+            # and integer pids are ever interpolated and `trace` is empty, so the payload
+            # never needs general JSON escaping. $1 is the outcome (FAIL/PASS), $2 the msg.
+            # The suite/name/ms values are fixed to match the class/method the in-process
+            # parser and JUnit XML use, so ci_monitor's suite#name#outcome dedup and its
+            # --include-fail/--include-pass name filters work on these lines unchanged.
+            SYNTH_MARKER_SUITE="com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest"
+            SYNTH_MARKER_NAME="setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances"
+            synthesize_marker() {
+              if grep -q "\"name\":\"$SYNTH_MARKER_NAME\"" results/e2e-setup-activity-permission-dialog.ndjson 2>/dev/null; then
+                echo "  monitor marker for $SYNTH_MARKER_NAME already present; not synthesizing a $1"
+                return 0
+              fi
+              printf '##GB4PC_TEST## {"suite":"%s","name":"%s","outcome":"%s","ms":0,"msg":"%s","trace":""}\n' \
+                "$SYNTH_MARKER_SUITE" "$SYNTH_MARKER_NAME" "$1" "$2" \
+                >> results/e2e-setup-activity-permission-dialog.ndjson
+              echo "  synthesized $1 monitor marker for $SYNTH_MARKER_NAME"
+            }
             PID_AFTER=$("$ADB" shell pidof com.gb4pc | tr -d '\r' || true)
             echo "com.gb4pc pid after dialog grant:  '${PID_AFTER:-<not running>}'"
             GRANT_LINE=$("$ADB" shell dumpsys package com.gb4pc | tr -d '\r' \
@@ -1002,6 +1034,11 @@ jobs:
                 echo "           is not shown again, so the grant survived the restart and no"
                 echo "           setup progress was lost."
                 echo "outcome=success" >> "$GITHUB_OUTPUT"
+                # Synthesize a PASS so this benign torn-down-but-recovered run still gets a
+                # per-test marker (issue #601). CI Monitor suppresses PASS by default, but it
+                # is available to --include-pass 'SetupActivityPermissionDialog' task-relevance
+                # validation, which otherwise has no marker at all on this recovery path.
+                synthesize_marker PASS "host-side diagnosis: the real Photos and Media dialog grant restarted com.gb4pc but the setup flow recovered on the BATTERY step without losing progress (the benign scoped-storage remount)"
               else
                 echo "REGRESSION: relaunching SetupActivity did not land cleanly on the BATTERY"
                 echo "            step after the restart (dump snippet:"
@@ -1009,11 +1046,19 @@ jobs:
                 echo "            the flow reverted to MEDIA or failed to render, so the crash"
                 echo "            was not the benign, expected scoped-storage restart."
                 echo "outcome=failure" >> "$GITHUB_OUTPUT"
+                # Synthesize a FAIL so this torn-down regression gets the same per-test
+                # attribution the other suites emit in-process (issue #601). Message uses
+                # only static text plus the integer pids captured above.
+                synthesize_marker FAIL "host-side diagnosis: the dialog grant tore down com.gb4pc (pid before=${PID_BEFORE:-<none>} after=${PID_AFTER:-<none>}) and the recovery relaunch (pid=${RECOVERED_PID:-<none>}) did not land on the BATTERY step, so the restart was not the benign scoped-storage remount"
               fi
             else
               # Non-zero exit with neither a reported failure nor a confirmed grant: treat as a
               # real failure (e.g. the dialog never appeared, or the grant did not land).
               echo "outcome=failure" >> "$GITHUB_OUTPUT"
+              # Synthesize a FAIL so this torn-down failure gets the same per-test
+              # attribution the other suites emit in-process (issue #601). Message uses
+              # only static text plus the integer pids captured above.
+              synthesize_marker FAIL "host-side diagnosis: non-zero Gradle exit with no in-process FAIL marker and READ_MEDIA_IMAGES not granted (pid before=${PID_BEFORE:-<none>} after=${PID_AFTER:-<none>}); the permission-dialog flow did not complete"
               echo "=== LOGCAT (since test start) ==="
               "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -961,7 +961,7 @@ jobs:
             SYNTH_MARKER_SUITE="com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest"
             SYNTH_MARKER_NAME="setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances"
             synthesize_marker() {
-              if grep -q "\"name\":\"$SYNTH_MARKER_NAME\"" results/e2e-setup-activity-permission-dialog.ndjson 2>/dev/null; then
+              if grep -qF "\"name\":\"$SYNTH_MARKER_NAME\"" results/e2e-setup-activity-permission-dialog.ndjson 2>/dev/null; then
                 echo "  monitor marker for $SYNTH_MARKER_NAME already present; not synthesizing a $1"
                 return 0
               fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1036,8 +1036,15 @@ jobs:
                 echo "outcome=success" >> "$GITHUB_OUTPUT"
                 # Synthesize a PASS so this benign torn-down-but-recovered run still gets a
                 # per-test marker (issue #601). CI Monitor suppresses PASS by default, but it
-                # is available to --include-pass 'SetupActivityPermissionDialog' task-relevance
-                # validation, which otherwise has no marker at all on this recovery path.
+                # is available to task-relevance validation via --include-pass: a bare
+                # --include-pass, or one whose pattern matches a substring of this marker's
+                # fixed `name` (e.g. --include-pass 'setupFlow'), surfaces it. ci_monitor.py's
+                # parse_fails matches --include-pass PATTERN against the marker's `name` field
+                # only, never `suite`, so a suite-shaped pattern like
+                # --include-pass 'SetupActivityPermissionDialog' will NOT match this marker's
+                # name (setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances) and would
+                # silently surface nothing (PR #644 review). Otherwise this recovery path has
+                # no marker at all.
                 synthesize_marker PASS "host-side diagnosis: the real Photos and Media dialog grant restarted com.gb4pc but the setup flow recovered on the BATTERY step without losing progress (the benign scoped-storage remount)"
               else
                 echo "REGRESSION: relaunching SetupActivity did not land cleanly on the BATTERY"


### PR DESCRIPTION
🤖 Author

Part of #599. Fixes #601.

## Problem

The "Run SetupActivityPermissionDialogE2ETest" step has a host-side diagnosis branch for when granting the real Photos & Media permission dialog restarts `com.gb4pc` mid-test (a scoped-storage remount). When that happens the instrumented process dies before it can emit an in-process `##GB4PC_TEST##` marker, so `results/e2e-setup-activity-permission-dialog.ndjson` has no FAIL/PASS/SKIP line. This one suite alone then lacks the per-test attribution `ci_monitor.py` gets for every other suite (the build still goes red via the Gate, but the per-test signal is missing from this feed).

## Change

Entirely within the permission-dialog Run step in `.github/workflows/build.yml`:

- **Race-free rebuild.** At the very top of the diagnosis `else` block, deterministically rebuild the ndjson from the fully-written `/tmp/e2e-permission-dialog.log` (`grep '^##GB4PC_TEST##' … > … || true`). The in-line `tee >(grep …)` process substitution can still be flushing when Gradle returns, so this makes the `"outcome":"FAIL"` check and the synthesis below race-free.
- **Idempotent helper.** `synthesize_marker <outcome> <msg>` appends one marker line with the fixed identity `suite=com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest`, `name=setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances`, `ms=0` — matching what the in-process parser and JUnit XML use, so ci_monitor's `suite#name#outcome` dedup and name filters work unchanged. A name-guard (`grep -qF`) no-ops if a genuine marker for this method already exists.
- **FAIL** on the two torn-down failure branches (recovery relaunch did not reach BATTERY; non-zero exit with no marker and grant not landed), messages built from static text plus the integer pids.
- **PASS** on the confirmed-benign recovery branch. Suppressed by default in CI Monitor, available to `--include-pass`.
- The genuine in-process FAIL branch is left untouched; the log rebuild guarantees its real marker is present and the helper's name-guard no-ops there.

Only static ASCII text and integer pids are interpolated and `trace` is empty, so the payload needs no JSON escaping. No change to the upload step, gate wiring, or `ci_monitor.*`.

## Verification

- YAML parses; `bash -n` on the extracted 166-line run script is clean.
- Simulated the helper: emits exactly one clean `##GB4PC_TEST##` JSON line; a second call no-ops via the name-guard (idempotent).
- Ran the synthesized FAIL and PASS lines through `ci_monitor.py`'s `parse_fails`: FAIL surfaces by default. PASS is suppressed by default and surfaces under a bare `--include-pass` or any pattern matching a substring of the fixed `name` value (e.g. `setupFlow`).
  - **Correction from an earlier revision of this description:** the issue's illustrative filter, `--include-pass 'SetupActivityPermissionDialog'`, does **not** surface this PASS marker. `parse_fails` matches `--include-pass PATTERN` against the marker's `name` field only, never `suite` (`scripts/ci_monitor/ci_monitor.py`, `parse_fails`), and the fixed `name` (`setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances`) does not contain the substring `SetupActivityPermissionDialog`. This appears to originate in the issue text's own example query, not in this PR's marker identity (which is fixed by the issue and matches the real in-process emitter). Making that specific query work would require `ci_monitor.py` to also match `--include-pass` against `suite`, which is out of scope here per the issue ("No changes to ... `scripts/ci_monitor/*`"). Flagged back on #601 as a possible follow-up rather than addressed in this PR.

Integration (dispatching the workflow and forcing each teardown branch on a real emulator) is not runnable from here; the branch logic is exercised only when the dialog grant actually restarts the process.
