### PR TITLE
Strip Authorization header on cross-host artifact-zip redirects

### DIFF
--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -38,6 +38,7 @@ import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import zipfile
 
@@ -605,6 +606,36 @@ def _retry_after_seconds(e, now):
     return None
 
 
+class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that drops the Authorization header on a cross-host redirect.
+
+    `GET /repos/{owner}/{repo}/actions/artifacts/{id}/zip` (the `raw=True` path)
+    redirects to a `*.blob.core.windows.net` URL that is already fully
+    authorized by a SAS token in its own query string. urllib's default
+    redirect handling forwards the original request's `Authorization` header
+    to the redirect target regardless of host, and Azure Blob Storage then
+    rejects the request with HTTP 401 because it receives both a valid SAS
+    token and an unexpected bearer token (issue #634). Stripping the header
+    only when the redirect target's host differs from the original request's
+    host keeps same-host redirects (if any) unaffected.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        old_host = urllib.parse.urlparse(req.full_url).hostname
+        new_host = urllib.parse.urlparse(newurl).hostname
+        if new_host != old_host:
+            new_req.remove_header("Authorization")
+        return new_req
+
+
+# Reused across raw=True (artifact-zip) requests: the handler itself is
+# stateless, so a single opener built once suffices (issue #634).
+_RAW_OPENER = urllib.request.build_opener(_StripAuthOnCrossHostRedirect)
+
+
 def _request(url, token, raw=False):
     """Perform an authenticated GET. Returns parsed JSON (or raw bytes if raw).
 
@@ -612,6 +643,11 @@ def _request(url, token, raw=False):
     On an HTTP error the originating HTTPError is recorded on the function as
     `_request.last_error` so callers that retry (e.g. the SHA fetch) can inspect
     rate-limit headers; it is cleared to None on a successful request.
+
+    The `raw=True` path (artifact-zip downloads) uses an opener whose redirect
+    handler strips the `Authorization` header on a cross-host redirect (see
+    `_StripAuthOnCrossHostRedirect`); the JSON API path never redirects off
+    `api.github.com`, so it keeps the plain `urllib.request.urlopen` call.
     """
     _request.last_error = None
     req = urllib.request.Request(url)
@@ -619,8 +655,12 @@ def _request(url, token, raw=False):
     req.add_header("Accept", "application/vnd.github+json")
     try:
         # URL is built from a GitHub API constant; the file:// risk does not apply.
-        with urllib.request.urlopen(req) as resp:  # nosemgrep
-            data = resp.read()
+        if raw:
+            with _RAW_OPENER.open(req) as resp:  # nosemgrep
+                data = resp.read()
+        else:
+            with urllib.request.urlopen(req) as resp:  # nosemgrep
+                data = resp.read()
     except (urllib.error.URLError, OSError) as e:
         _request.last_error = e
         sys.stderr.write("request failed (%s): %s\n" % (url, _err_detail(e)))

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -58,6 +58,9 @@ Covers:
        into failed_steps
   (au) #602 parse_fails: failed_tests collects only FAIL "[suite] name"
        identifiers (not PASS/SKIP), deduped via the shared seen set
+  (av) #634 _StripAuthOnCrossHostRedirect strips Authorization on a cross-host
+       redirect (the artifact-zip -> Azure Blob Storage case) but keeps it on
+       a same-host redirect; _request(raw=True) routes through this handler
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4450,6 +4453,99 @@ def main() -> int:
         failed_tests_au2 == ["[com.gb4pc.e2e.GalleryButtonVisualE2ETest] test1a"],
         "failed_tests is deduped across calls via the shared seen set",
         "failed_tests dedup wrong; got %r" % failed_tests_au2,
+    )
+
+    # ── (av) #634 artifact-zip redirect: Authorization stripped cross-host ──────────
+    print("\n=== (av) #634 _StripAuthOnCrossHostRedirect drops Authorization across hosts ===")
+
+    _redirect_handler = ci_monitor._StripAuthOnCrossHostRedirect()
+
+    # Cross-host redirect (the real bug: api.github.com -> *.blob.core.windows.net,
+    # a SAS-signed URL that itself rejects an unexpected bearer Authorization header).
+    cross_host_req = ci_monitor.urllib.request.Request(
+        "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
+    )
+    cross_host_req.add_header("Authorization", "Bearer sekrit")
+    cross_host_req.add_header("Accept", "application/vnd.github+json")
+    cross_host_redirected = _redirect_handler.redirect_request(
+        cross_host_req,
+        None,
+        302,
+        "Found",
+        {},
+        "https://productionresultssa.blob.core.windows.net/artifacts/1.zip?sv=2021&sig=abc",
+    )
+    check(
+        cross_host_redirected is not None and cross_host_redirected.get_header("Authorization") is None,
+        "cross-host redirect strips the Authorization header",
+        "cross-host redirect kept Authorization: %r"
+        % (cross_host_redirected and cross_host_redirected.get_header("Authorization")),
+    )
+    check(
+        cross_host_redirected is not None
+        and cross_host_redirected.get_header("Accept") == "application/vnd.github+json",
+        "cross-host redirect keeps unrelated headers (e.g. Accept)",
+        "cross-host redirect dropped an unrelated header unexpectedly",
+    )
+
+    # Same-host redirect: Authorization is not the cross-host leak this guards
+    # against, so it is left intact.
+    same_host_req = ci_monitor.urllib.request.Request(
+        "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
+    )
+    same_host_req.add_header("Authorization", "Bearer sekrit")
+    same_host_redirected = _redirect_handler.redirect_request(
+        same_host_req,
+        None,
+        302,
+        "Found",
+        {},
+        "%s/repos/%s/%s/actions/artifacts/1/zip/redirected"
+        % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO),
+    )
+    check(
+        same_host_redirected is not None and same_host_redirected.get_header("Authorization") == "Bearer sekrit",
+        "same-host redirect keeps the Authorization header",
+        "same-host redirect unexpectedly dropped Authorization",
+    )
+
+    # _request(raw=True) routes through the stripping opener, not plain urlopen:
+    # patching urlopen to raise proves the raw path never calls it, while the
+    # opener mock supplies the (redirect-safe) response.
+    class _FakeRawResp:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with unittest.mock.patch.object(
+        ci_monitor._RAW_OPENER, "open", return_value=_FakeRawResp(b"PK\x03\x04fake-zip-bytes")
+    ) as mock_opener_open, unittest.mock.patch.object(
+        ci_monitor.urllib.request,
+        "urlopen",
+        side_effect=AssertionError("raw=True must not call urlopen directly"),
+    ):
+        got_raw = ci_monitor._request(
+            "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO),
+            "tok",
+            raw=True,
+        )
+    check(
+        got_raw == b"PK\x03\x04fake-zip-bytes",
+        "_request(raw=True) returns the opener's raw bytes",
+        "_request(raw=True) returned wrong data: %r" % got_raw,
+    )
+    check(
+        mock_opener_open.call_count == 1,
+        "_request(raw=True) calls the stripping opener exactly once",
+        "_request(raw=True) called the opener %d times" % mock_opener_open.call_count,
     )
 
     # ── Summary ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #634.

`ci_monitor.py`'s artifact-zip download (`_request(url, token, raw=True)`) failed with HTTP 401 whenever it tried to download a real artifact's zip contents from `GET /repos/{owner}/{repo}/actions/artifacts/{id}/zip`.

## Root cause

That endpoint responds with a redirect to a `*.blob.core.windows.net` URL that is already fully authorized by a SAS token in its own query string. `urllib.request.urlopen` follows the redirect automatically but does not strip the `Authorization` header when the redirect target is a different host, so Azure Blob Storage rejects the request because it receives both a valid SAS token and an unexpected bearer `Authorization` header.

## Fix

Adds a `_StripAuthOnCrossHostRedirect` (`urllib.request.HTTPRedirectHandler` subclass) that drops the `Authorization` header only when the redirect target's host differs from the original request's host. `_request(..., raw=True)` now routes through an opener built from this handler; the JSON API path (`raw=False`) is unchanged, since calls to `api.github.com` never redirect off that host.

## Testing

- Added test case (av) to `scripts/test_ci_monitor.py`: unit-tests `_StripAuthOnCrossHostRedirect.redirect_request` directly (strips `Authorization` on a cross-host redirect, keeps it on a same-host redirect, leaves unrelated headers alone), and confirms `_request(raw=True)` routes through the new opener rather than plain `urlopen`.
- Full suite: `python3 scripts/test_ci_monitor.py` — 309 passed, 0 failed.
- Verified live against a real PR artifact (an unexpired `ci-monitor-feed-*` artifact from a recent workflow run): a plain `urlopen` call reproduces the HTTP 401, while the patched `_request(url, token, raw=True)` downloads the zip and `extract_ndjson_lines` parses a real `PASS` marker, with no `request failed (...): HTTP 401` line to stderr.

This unblocks PR #630's before-merging item #631 and PR #638's before-merging item #640, both of which were waiting on this fix (see issue #634 for cross-references).
