### PR TITLE
Capture UI Automator dump and full logcat on E2E instrumentation timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1167,6 +1167,23 @@ jobs:
           $ANDROID_HOME/platform-tools/adb emu kill 2>/dev/null || true
           [[ -n "${EMULATOR_PID:-}" ]] && kill "$EMULATOR_PID" 2>/dev/null || true
 
+      - name: Upload E2E timeout diagnostics
+        # Issue #629: connectedE2EAndroidTest (app/build.gradle.kts) writes a UI Automator
+        # screen dump and the full, unfiltered logcat buffer into
+        # app/build/outputs/e2e-diagnostics/ only when its own 10-minute `am instrument`
+        # timeout (issue #611/#628) fires, captured before force-stop tears the hung
+        # activity down. Whichever E2E suite step (if any) hit that timeout is the only one
+        # that would have populated the directory, so this single step runs unconditionally
+        # after every suite rather than being duplicated per-suite; if-no-files-found:
+        # ignore keeps the common (no timeout) case from warning.
+        if: always() && steps.diff_check.outputs.needs_full_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-timeout-diagnostics
+          path: app/build/outputs/e2e-diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
+
       - name: Upload instrumented test results
         if: always() && steps.diff_check.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -245,6 +245,43 @@ val e2eXmlDir =
     layout.buildDirectory
         .dir("outputs/androidTest-results/connected/debug")
 
+/**
+ * Runs [command] via a plain ProcessBuilder, bounded by [timeoutSeconds]: `Process.waitFor(timeout,
+ * unit)` + `destroyForcibly()` on expiry, the same pattern `e2eInstrumentTimeoutMinutes` uses below
+ * for `am instrument` -- not the `timeout` coreutil `build.yml` uses for its own adb waits, to keep
+ * this task portable to local dev on any OS (see that call site's own rationale).
+ *
+ * Returns combined stdout/stderr, or "" on any failure (non-zero exit, thrown exception, or the
+ * timeout itself, which is logged as a warning rather than thrown). Callers use this only for
+ * best-effort diagnostic capture (issue #629): a command that hangs or errors here must never
+ * block the build or mask the failure that triggered the capture in the first place -- exactly the
+ * class of hang this whole task's timeout guard exists to eliminate.
+ */
+fun runBestEffort(
+    command: List<String>,
+    timeoutSeconds: Long,
+): String =
+    try {
+        val process = ProcessBuilder(command).redirectErrorStream(true).start()
+        val out = ByteArrayOutputStream()
+        val drainThread =
+            Thread {
+                process.inputStream.copyTo(out)
+            }.apply {
+                isDaemon = true
+                start()
+            }
+        if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            println("WARNING: '${command.joinToString(" ")}' did not finish within ${timeoutSeconds}s; killed")
+        }
+        drainThread.join(TimeUnit.SECONDS.toMillis(5))
+        out.toString()
+    } catch (e: Exception) {
+        println("WARNING: '${command.joinToString(" ")}' failed: ${e.message}")
+        ""
+    }
+
 tasks.register("connectedE2EAndroidTest") {
     group = "verification"
     description = "Runs E2E instrumented tests (requires device/emulator with Pixel Camera installed)."
@@ -374,38 +411,36 @@ tasks.register("connectedE2EAndroidTest") {
             // actually on screen. Grab both BEFORE the force-stop below tears the activity
             // down, so the device state reflects the hang itself rather than a freshly
             // cleaned slate. Best-effort: a device unresponsive enough to hang a whole suite
-            // might not answer these either, so failures here must not mask the timeout
-            // exception thrown below.
+            // might not answer these either, so each capture is bounded via runBestEffort()
+            // (PR #651 review): an unbounded `exec {}` here could itself hang against the exact
+            // unresponsive-device state this issue documents, reintroducing the multi-hour block
+            // issue #611/#628 already eliminated for `am instrument`, just three calls later.
             val diagnosticsDir =
                 layout.buildDirectory
                     .dir("outputs/e2e-diagnostics")
                     .get()
                     .asFile
                     .also { it.mkdirs() }
+            val diagnosticsTimeoutSeconds = 30L
             val onDeviceDumpPath = "/sdcard/gb4pc-e2e-timeout-uidump.xml"
-            exec {
-                commandLine(e2eAdb, "shell", "uiautomator", "dump", onDeviceDumpPath)
-                isIgnoreExitValue = true
-            }
-            exec {
-                commandLine(
+            runBestEffort(
+                listOf(e2eAdb, "shell", "uiautomator", "dump", onDeviceDumpPath),
+                diagnosticsTimeoutSeconds,
+            )
+            runBestEffort(
+                listOf(
                     e2eAdb,
                     "pull",
                     onDeviceDumpPath,
                     File(diagnosticsDir, "$xmlSuiteName-timeout-uidump.xml").absolutePath,
-                )
-                isIgnoreExitValue = true
-            }
+                ),
+                diagnosticsTimeoutSeconds,
+            )
             // Unfiltered: unlike every other CI failure branch (which pipes through
             // scripts/filter_logcat.sh), this dumps the raw buffer so a symptom outside that
             // script's tag allowlist can't be silently dropped again.
-            val rawLogcat = ByteArrayOutputStream()
-            exec {
-                commandLine(e2eAdb, "logcat", "-d")
-                standardOutput = rawLogcat
-                isIgnoreExitValue = true
-            }
-            File(diagnosticsDir, "$xmlSuiteName-timeout-logcat.txt").writeText(rawLogcat.toString())
+            val rawLogcat = runBestEffort(listOf(e2eAdb, "logcat", "-d"), diagnosticsTimeoutSeconds)
+            File(diagnosticsDir, "$xmlSuiteName-timeout-logcat.txt").writeText(rawLogcat)
             println(
                 "E2E timeout diagnostics captured for $xmlSuiteName in " +
                     "${diagnosticsDir.absolutePath} (UI Automator dump + full logcat); " +

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -366,6 +366,52 @@ tasks.register("connectedE2EAndroidTest") {
         val finishedInTime = instrumentProcess.waitFor(e2eInstrumentTimeoutMinutes, TimeUnit.MINUTES)
         val timedOut = !finishedInTime
         if (timedOut) {
+            // Issue #629: this class's own hang history has already shown two different
+            // symptoms (a keyguard-driven RESUMED/PAUSED flicker, then later a launch that
+            // never produced any further system activity at all), and the second recurrence
+            // left no real clue to work from: scripts/filter_logcat.sh's tag allowlist may
+            // have dropped lines relevant to a stuck launch, and nothing captured what was
+            // actually on screen. Grab both BEFORE the force-stop below tears the activity
+            // down, so the device state reflects the hang itself rather than a freshly
+            // cleaned slate. Best-effort: a device unresponsive enough to hang a whole suite
+            // might not answer these either, so failures here must not mask the timeout
+            // exception thrown below.
+            val diagnosticsDir =
+                layout.buildDirectory
+                    .dir("outputs/e2e-diagnostics")
+                    .get()
+                    .asFile
+                    .also { it.mkdirs() }
+            val onDeviceDumpPath = "/sdcard/gb4pc-e2e-timeout-uidump.xml"
+            exec {
+                commandLine(e2eAdb, "shell", "uiautomator", "dump", onDeviceDumpPath)
+                isIgnoreExitValue = true
+            }
+            exec {
+                commandLine(
+                    e2eAdb,
+                    "pull",
+                    onDeviceDumpPath,
+                    File(diagnosticsDir, "$xmlSuiteName-timeout-uidump.xml").absolutePath,
+                )
+                isIgnoreExitValue = true
+            }
+            // Unfiltered: unlike every other CI failure branch (which pipes through
+            // scripts/filter_logcat.sh), this dumps the raw buffer so a symptom outside that
+            // script's tag allowlist can't be silently dropped again.
+            val rawLogcat = ByteArrayOutputStream()
+            exec {
+                commandLine(e2eAdb, "logcat", "-d")
+                standardOutput = rawLogcat
+                isIgnoreExitValue = true
+            }
+            File(diagnosticsDir, "$xmlSuiteName-timeout-logcat.txt").writeText(rawLogcat.toString())
+            println(
+                "E2E timeout diagnostics captured for $xmlSuiteName in " +
+                    "${diagnosticsDir.absolutePath} (UI Automator dump + full logcat); " +
+                    "see the e2e-timeout-diagnostics CI artifact.",
+            )
+
             instrumentProcess.destroyForcibly()
             // PR #628 review: destroyForcibly() above only kills the local `adb shell am
             // instrument` client process; it does not by itself confirm the on-device


### PR DESCRIPTION
Fixes #629, as far as an automated change reasonably can.

### Why not a "fix" for the hang itself

Issue #629 documents `SetupActivityDeniedE2ETest` hanging in CI a second time, with a *different* symptom from the first occurrence (issue #509/PR #564): no `RESUMED`/`PAUSED` keyguard flicker this time, just total silence after `SetupActivity`'s `START` intent until the issue #611/#628 timeout force-killed it. The issue's own "Suggested next step" says whoever picks it up should decide whether this is the same root cause recurring or a distinct failure mode, "ideally with a full instrumented-test logcat capture ... and possibly a UI Automator dump captured on timeout to see what's actually on screen when this happens." Guessing at a code fix for an unconfirmed root cause isn't warranted; this PR implements exactly the diagnostic capture the issue asked for, so the *next* occurrence (of this or a similar hang, in any E2E suite) has real evidence to diagnose from.

### What changed

- **`app/build.gradle.kts`**: when `connectedE2EAndroidTest`'s own 10-minute `am instrument` timeout fires, capture a UI Automator screen dump and the full, unfiltered `adb logcat -d` buffer *before* the existing `am force-stop` cleanup runs — so the captured state reflects the hang itself, not a freshly reset device. This runs for whichever suite times out, not just `SetupActivityDeniedE2ETest`, since the timeout mechanism itself is generic across all `connectedE2EAndroidTest` invocations.
  - The logcat capture is deliberately unfiltered: `scripts/filter_logcat.sh`'s tag allowlist is exactly what the issue flagged as a likely reason the last recurrence's actual symptom (silence, no matching tag at all) went uncaptured.
  - Both are best-effort (`isIgnoreExitValue = true`) so a device unresponsive enough to hang a whole suite can't also mask the timeout `GradleException` that already fails the build.
- **`.github/workflows/build.yml`**: one new "Upload E2E timeout diagnostics" step uploads `app/build/outputs/e2e-diagnostics/` as the `e2e-timeout-diagnostics` artifact, `if-no-files-found: ignore` since the directory is only populated on an actual timeout.

### Test plan

- [x] `python3 -m unittest discover -s scripts -p "test_*.py"`, `scripts/test_ci_monitor.py`, and `scripts/test_*.sh` all still pass (unaffected by this change, run as a general health check).
- [x] `.github/workflows/build.yml` validated with `yaml.safe_load`.
- [ ] This PR's own CI run exercises the modified `connectedE2EAndroidTest` code path on every "Run *E2ETest" step in the normal (non-timeout) case. I could not run a full local Gradle build in this environment (no Android SDK, and the Gradle-distribution download is blocked here too), and deliberately reproducing a 10-minute hang isn't practical to do here; the new capture logic was verified by code review only. If a hang recurs after this merges, the `e2e-timeout-diagnostics` artifact should contain the UI Automator dump and full logcat for that run.

