### PR TITLE
Fail loudly when dismissSecureKeyguard() times out without dismissing the keyguard

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -270,6 +270,19 @@ class E2EFixture(
      * [KeyguardManager.isKeyguardLocked] and retrying the whole dismissal sequence until it
      * reports unlocked (or [DISMISS_KEYGUARD_TIMEOUT_MS] elapses) makes this method robust to that
      * variance instead of assuming a fixed wall-clock budget is always enough.
+     *
+     * ### Fails loudly on timeout instead of racing a downstream assertion (issue #642)
+     *
+     * If the keyguard is still locked when [DISMISS_KEYGUARD_TIMEOUT_MS] elapses, this method
+     * fails immediately with [fail], the same way [lockScreen] fails loudly on its own timeout
+     * path, instead of silently returning and letting the caller's next assertion fail with a
+     * symptom (e.g. an activity bouncing `RESUMED` then `PAUSED`) that does not point back to the
+     * keyguard as the actual cause. This exact silent-return path was implicated in a confusing
+     * intermittent CI failure (PR #637) before the retry loop above was added; failing loudly here
+     * makes any future recurrence of that race immediately diagnosable instead of requiring the
+     * same investigation to be repeated.
+     *
+     * @throws AssertionError if the keyguard is still locked after [DISMISS_KEYGUARD_TIMEOUT_MS].
      */
     fun dismissSecureKeyguard() {
         val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
@@ -284,6 +297,13 @@ class E2EFixture(
             uiAutomation.executeShellCommand("input keyevent 66").close() // KEYCODE_ENTER
             Thread.sleep(300)
         } while (keyguardManager.isKeyguardLocked && System.currentTimeMillis() < deadline)
+        if (keyguardManager.isKeyguardLocked) {
+            fail(
+                "dismissSecureKeyguard(): KeyguardManager.isKeyguardLocked still true after " +
+                    "$DISMISS_KEYGUARD_TIMEOUT_MS ms; the dismissal sequence did not clear the " +
+                    "secure keyguard within its retry budget.",
+            )
+        }
     }
 
     fun goHome() {


### PR DESCRIPTION
Fixes #642.

`dismissSecureKeyguard()` (`app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt`) polls `KeyguardManager.isKeyguardLocked` and retries its wake/dismiss/PIN/enter sequence until unlocked or `DISMISS_KEYGUARD_TIMEOUT_MS` (10s) elapses, but previously returned silently on timeout even if the keyguard was still locked. This meant a timeout would surface later as a confusing downstream assertion failure (e.g. an activity bouncing `RESUMED` then `PAUSED`) instead of pointing at the actual cause — exactly the kind of race that made the CI failure during PR #637's review hard to diagnose.

This PR adds an explicit check after the retry loop: if the keyguard is still locked once the budget elapses, the method now fails immediately with a descriptive `fail(...)` message, the same way its sibling `lockScreen()` already fails loudly on its own timeout path.

## Test plan

- The four existing callers of `dismissSecureKeyguard()` (`SetupActivityGrantedE2ETest`, `SetupActivityDeniedE2ETest`, `SetupActivityPermissionDialogE2ETest`, `PartialAccessPhotoPickerE2ETest`) already exercise this method on every CI run; no new test class is needed since this only changes what happens on the (already-covered) timeout path, matching the existing precedent of `lockScreen()`'s own fail-on-timeout path having no dedicated test.
- This sandbox has no Android SDK and no network access to provision one (the Gradle wrapper distribution download is blocked), so `./gradlew` could not be run locally, consistent with the note on PR #637. The change is a small, mechanical addition (one `if` block) reviewed manually against the existing `lockScreen()` pattern in the same file.

