### PR TITLE
DO NOT MERGE: throwaway CI run to verify e2e-video-* artifacts (issue #641)

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -237,6 +237,11 @@ class GalleryButtonVisualE2ETest {
                     "The gallery opened showing unexpected green content with an empty roll.",
             )
         }
+
+        // THROWAWAY: deliberate failure for issue #641 verification (forces this suite's
+        // e2e-video-* artifact to be produced so it can be inspected for tap/toast content).
+        // Not a real product assertion--revert before merging; see issue #641.
+        fail("THROWAWAY failure for issue #641 CI-artifact verification--do not merge")
     }
 
     // test3a: Populated gallery: tapping overlay shows GREEN------------------

--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
@@ -9,6 +9,7 @@ import com.gb4pc.util.DebugLog
 import com.gb4pc.util.PermissionHelper
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -121,5 +122,10 @@ class PermissionsDeniedE2ETest {
             "A tap-to-fix notification should be posted when the media permission is missing",
             notified,
         )
+
+        // THROWAWAY: deliberate failure for issue #641 verification (forces this suite's
+        // e2e-video-* artifact to be produced so it can be inspected). Not a real product
+        // assertion--revert before merging; see issue #641.
+        fail("THROWAWAY failure for issue #641 CI-artifact verification--do not merge")
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
@@ -6,6 +6,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.gb4pc.util.DebugLog
 import com.gb4pc.util.PermissionHelper
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -75,5 +76,10 @@ class PermissionsGrantedE2ETest {
             "Overlay thumbnail should update to the newly captured photo within 10 s (issue #509)",
             updated,
         )
+
+        // THROWAWAY: deliberate failure for issue #641 verification (forces this suite's
+        // e2e-video-* artifact to be produced so it can be inspected). Not a real product
+        // assertion--revert before merging; see issue #641.
+        fail("THROWAWAY failure for issue #641 CI-artifact verification--do not merge")
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -5,6 +5,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.gb4pc.Constants
 import com.gb4pc.service.OverlayService
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -76,6 +77,11 @@ class PixelCameraOverlayE2ETest {
 
         val appeared = fixture.waitForCondition(timeoutMs = 30000L) { OverlayService.isOverlayActive }
         assertTrue("Overlay should appear within 30 s of launching Pixel Camera viewfinder", appeared)
+
+        // THROWAWAY: deliberate failure for issue #641 verification (forces this suite's
+        // e2e-video-* artifact to be produced so it can be inspected). Not a real product
+        // assertion--revert before merging; see issue #641.
+        fail("THROWAWAY failure for issue #641 CI-artifact verification--do not merge")
     }
 
     /**

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityGrantedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityGrantedE2ETest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.gb4pc.R
 import com.gb4pc.ui.setup.SetupActivity
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExternalResource
@@ -81,5 +82,10 @@ class SetupActivityGrantedE2ETest {
         val context = instrumentation.targetContext
 
         composeRule.onNodeWithText(context.getString(R.string.setup_media_title)).assertDoesNotExist()
+
+        // THROWAWAY: deliberate failure for issue #641 verification (forces this suite's
+        // e2e-video-* artifact to be produced so it can be inspected). Not a real product
+        // assertion--revert before merging; see issue #641.
+        fail("THROWAWAY failure for issue #641 CI-artifact verification--do not merge")
     }
 }


### PR DESCRIPTION
Disposable verification PR for issue #641 (unautomated verification step tracked from PR #637 / issue #604).

This PR deliberately breaks one test method in each of the five E2E suites that have never failed in real CI (`GalleryButtonVisualE2ETest`, `PixelCameraOverlayE2ETest`, `PermissionsGrantedE2ETest`, `PermissionsDeniedE2ETest`, `SetupActivityGrantedE2ETest`), so this run's CI actually reaches the "pull and upload e2e-video-*" step for each of them. No product code is touched--only a `fail()` call appended after each test's real body.

Purpose: download and inspect the resulting `e2e-video-*` artifacts to confirm taps/toast/valid-video content, closing out the last unconfirmed acceptance criteria on issue #641.

**Do not merge.** This PR will be closed (not merged) once the artifacts have been inspected, and the throwaway branch will be deleted.
