### PR TITLE
Strip Accept header, not just Authorization, on cross-host artifact-zip redirects

### DIFF
--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -607,18 +607,26 @@ def _retry_after_seconds(e, now):
 
 
 class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
-    """Redirect handler that drops the Authorization header on a cross-host redirect.
+    """Redirect handler that drops GitHub-specific headers on a cross-host redirect.
 
     `GET /repos/{owner}/{repo}/actions/artifacts/{id}/zip` (the `raw=True` path)
     redirects to a `*.blob.core.windows.net` URL that is already fully
     authorized by a SAS token in its own query string. urllib's default
-    redirect handling forwards the original request's `Authorization` header
-    to the redirect target regardless of host, and Azure Blob Storage then
-    rejects the request with HTTP 401 because it receives both a valid SAS
-    token and an unexpected bearer token (issue #634). Stripping the header
-    only when the redirect target's host differs from the original request's
-    host keeps same-host redirects (if any) unaffected.
+    redirect handling forwards the original request's headers to the redirect
+    target regardless of host. The `Authorization` header causes Azure Blob
+    Storage to reject the request with HTTP 401 because it receives both a
+    valid SAS token and an unexpected bearer token (issue #634). The `Accept:
+    application/vnd.github+json` header set by `_request()` is GitHub-specific
+    too and has no business riding along to a non-GitHub host, so it is
+    stripped alongside `Authorization` for the same reason, even though it is
+    not currently known to cause a failure (issue #650). Stripping only
+    applies when the redirect target's host differs from the original
+    request's host, so same-host redirects (if any) are unaffected.
     """
+
+    # Headers added by `_request()` that are meaningful only to api.github.com
+    # and should not be forwarded to a cross-host redirect target.
+    _GITHUB_SPECIFIC_HEADERS = ("Authorization", "Accept")
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
@@ -627,7 +635,8 @@ class _StripAuthOnCrossHostRedirect(urllib.request.HTTPRedirectHandler):
         old_host = urllib.parse.urlparse(req.full_url).hostname
         new_host = urllib.parse.urlparse(newurl).hostname
         if new_host != old_host:
-            new_req.remove_header("Authorization")
+            for header_name in self._GITHUB_SPECIFIC_HEADERS:
+                new_req.remove_header(header_name)
         return new_req
 
 
@@ -645,9 +654,10 @@ def _request(url, token, raw=False):
     rate-limit headers; it is cleared to None on a successful request.
 
     The `raw=True` path (artifact-zip downloads) uses an opener whose redirect
-    handler strips the `Authorization` header on a cross-host redirect (see
-    `_StripAuthOnCrossHostRedirect`); the JSON API path never redirects off
-    `api.github.com`, so it keeps the plain `urllib.request.urlopen` call.
+    handler strips GitHub-specific headers (`Authorization`, `Accept`) on a
+    cross-host redirect (see `_StripAuthOnCrossHostRedirect`); the JSON API
+    path never redirects off `api.github.com`, so it keeps the plain
+    `urllib.request.urlopen` call.
     """
     _request.last_error = None
     req = urllib.request.Request(url)

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -4485,21 +4485,6 @@ def main() -> int:
         "cross-host redirect kept Authorization: %r"
         % (cross_host_redirected and cross_host_redirected.get_header("Authorization")),
     )
-    # (aw) #650: Accept is GitHub-specific too (it rides along from `_request()`
-    # as "application/vnd.github+json") and has no business reaching a
-    # non-GitHub host, so the cross-host redirect strips it just like
-    # Authorization, even though it is not known to cause a failure.
-    check(
-        cross_host_redirected is not None and cross_host_redirected.get_header("Accept") is None,
-        "cross-host redirect strips the Accept header",
-        "cross-host redirect kept Accept: %r"
-        % (cross_host_redirected and cross_host_redirected.get_header("Accept")),
-    )
-    check(
-        cross_host_redirected is not None and cross_host_redirected.get_header("X-unrelated") == "keep-me",
-        "cross-host redirect keeps a genuinely unrelated header",
-        "cross-host redirect dropped an unrelated header unexpectedly",
-    )
 
     # Same-host redirect: Authorization is not the cross-host leak this guards
     # against, so it is left intact.
@@ -4559,6 +4544,27 @@ def main() -> int:
         mock_opener_open.call_count == 1,
         "_request(raw=True) calls the stripping opener exactly once",
         "_request(raw=True) called the opener %d times" % mock_opener_open.call_count,
+    )
+
+    # ── (aw) #650 cross-host redirect also strips Accept ──────────
+    print("\n=== (aw) #650 _StripAuthOnCrossHostRedirect also strips Accept across hosts ===")
+
+    # Accept is GitHub-specific too (it rides along from `_request()` as
+    # "application/vnd.github+json") and has no business reaching a
+    # non-GitHub host, so the cross-host redirect strips it just like
+    # Authorization, even though it is not known to cause a failure. Reuses
+    # `cross_host_redirected` from the (av) section above, which was built
+    # from a request carrying Authorization, Accept, and an unrelated header.
+    check(
+        cross_host_redirected is not None and cross_host_redirected.get_header("Accept") is None,
+        "cross-host redirect strips the Accept header",
+        "cross-host redirect kept Accept: %r"
+        % (cross_host_redirected and cross_host_redirected.get_header("Accept")),
+    )
+    check(
+        cross_host_redirected is not None and cross_host_redirected.get_header("X-unrelated") == "keep-me",
+        "cross-host redirect keeps a genuinely unrelated header",
+        "cross-host redirect dropped an unrelated header unexpectedly",
     )
 
     # ── Summary ────────────────────────────────────────────────────────────────────

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -61,6 +61,9 @@ Covers:
   (av) #634 _StripAuthOnCrossHostRedirect strips Authorization on a cross-host
        redirect (the artifact-zip -> Azure Blob Storage case) but keeps it on
        a same-host redirect; _request(raw=True) routes through this handler
+  (aw) #650 _StripAuthOnCrossHostRedirect also strips Accept (another
+       GitHub-specific header) on a cross-host redirect, while leaving an
+       unrelated header untouched
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4467,6 +4470,7 @@ def main() -> int:
     )
     cross_host_req.add_header("Authorization", "Bearer sekrit")
     cross_host_req.add_header("Accept", "application/vnd.github+json")
+    cross_host_req.add_header("X-Unrelated", "keep-me")
     cross_host_redirected = _redirect_handler.redirect_request(
         cross_host_req,
         None,
@@ -4481,10 +4485,19 @@ def main() -> int:
         "cross-host redirect kept Authorization: %r"
         % (cross_host_redirected and cross_host_redirected.get_header("Authorization")),
     )
+    # (aw) #650: Accept is GitHub-specific too (it rides along from `_request()`
+    # as "application/vnd.github+json") and has no business reaching a
+    # non-GitHub host, so the cross-host redirect strips it just like
+    # Authorization, even though it is not known to cause a failure.
     check(
-        cross_host_redirected is not None
-        and cross_host_redirected.get_header("Accept") == "application/vnd.github+json",
-        "cross-host redirect keeps unrelated headers (e.g. Accept)",
+        cross_host_redirected is not None and cross_host_redirected.get_header("Accept") is None,
+        "cross-host redirect strips the Accept header",
+        "cross-host redirect kept Accept: %r"
+        % (cross_host_redirected and cross_host_redirected.get_header("Accept")),
+    )
+    check(
+        cross_host_redirected is not None and cross_host_redirected.get_header("X-unrelated") == "keep-me",
+        "cross-host redirect keeps a genuinely unrelated header",
         "cross-host redirect dropped an unrelated header unexpectedly",
     )
 


### PR DESCRIPTION
Fixes #650.

`_StripAuthOnCrossHostRedirect` (added in PR #648 for issue #634, in `scripts/ci_monitor/ci_monitor.py`) only removed the `Authorization` header when a redirect crossed hosts (the artifact-zip download hopping from `api.github.com` to a SAS-signed `*.blob.core.windows.net` URL). The `Accept: application/vnd.github+json` header set by `_request()` is just as GitHub-specific and had no reason to keep riding along to a non-GitHub host, even though it is not currently known to cause a failure. This PR strips both headers on a cross-host redirect, while leaving genuinely unrelated headers untouched.

Changes:
- `_StripAuthOnCrossHostRedirect.redirect_request` now strips `Authorization` and `Accept` (via a small `_GITHUB_SPECIFIC_HEADERS` tuple) instead of only `Authorization`, when the redirect target's host differs from the original request's host.
- Updated docstrings on the class and on `_request()` to describe the broadened stripping.

Test changes (`scripts/test_ci_monitor.py`):
- Modified test `cross-host redirect keeps unrelated headers (e.g. Accept)` to instead require that `Accept` is stripped on a cross-host redirect, since that is the behavior this PR intentionally changes.
- Added an `X-Unrelated` header to the same test case so it still proves that headers that are *not* GitHub-specific survive the cross-host redirect untouched.

All 310 checks in `scripts/test_ci_monitor.py` pass locally.
