### PR TITLE
Add test-failure as a mutually exclusive label prefix group

### DIFF
--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -12,8 +12,11 @@ Mutually exclusive sets (fixed):
     [orchestrate, orchestrating]
 
 Mutually exclusive prefix groups (any label sharing a prefix is exclusive):
-    c-a-*   (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
-    c-r-*   (reviewer model, e.g. c-r-haiku, c-r-sonnet, c-r-opus)
+    c-a-*          (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
+    c-r-*          (reviewer model, e.g. c-r-haiku, c-r-sonnet, c-r-opus)
+    test-failure   (test-failure vs. test-failure-archive; an issue should
+                    carry at most one, since test-failure-archive replaces
+                    test-failure once the archive window has passed)
 
 Usage:
     python3 scripts/enforce_mutually_exclusive_labels.py
@@ -58,6 +61,7 @@ MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
 MUTUALLY_EXCLUSIVE_PREFIXES: list[str] = [
     "c-a-",
     "c-r-",
+    "test-failure",
 ]
 
 

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -128,10 +128,20 @@ class TestFindConflictingPrefix(unittest.TestCase):
     def test_case_insensitive_c_r(self):
         self.assertEqual(emxl.find_conflicting_prefix("C-R-Haiku"), "c-r-")
 
+    def test_test_failure_label_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("test-failure"), "test-failure")
+
+    def test_test_failure_archive_label_returns_prefix(self):
+        self.assertEqual(emxl.find_conflicting_prefix("test-failure-archive"), "test-failure")
+
+    def test_case_insensitive_test_failure(self):
+        self.assertEqual(emxl.find_conflicting_prefix("Test-Failure-Archive"), "test-failure")
+
     def test_unrelated_label_returns_none(self):
         self.assertIsNone(emxl.find_conflicting_prefix("ci"))
         self.assertIsNone(emxl.find_conflicting_prefix("p1"))
         self.assertIsNone(emxl.find_conflicting_prefix("bug"))
+        self.assertIsNone(emxl.find_conflicting_prefix("testing"))
 
     def test_empty_string_returns_none(self):
         self.assertIsNone(emxl.find_conflicting_prefix(""))
@@ -187,6 +197,25 @@ class TestLabelsByPrefix(unittest.TestCase):
         )
         self.assertIn("c-a-haiku", result)
         self.assertNotIn("c-r-opus", result)
+
+    def test_removes_test_failure_when_archive_added(self):
+        result = emxl.labels_to_remove_by_prefix(
+            "test-failure-archive", ["test-failure", "testing"], "test-failure"
+        )
+        self.assertEqual(result, ["test-failure"])
+
+    def test_removes_test_failure_archive_when_test_failure_added(self):
+        result = emxl.labels_to_remove_by_prefix(
+            "test-failure", ["test-failure-archive", "testing"], "test-failure"
+        )
+        self.assertEqual(result, ["test-failure-archive"])
+
+    def test_test_failure_prefix_does_not_touch_testing_label(self):
+        """The 'testing' label shares no real prefix with 'test-failure' and must survive."""
+        result = emxl.labels_to_remove_by_prefix(
+            "test-failure", ["testing", "ci"], "test-failure"
+        )
+        self.assertEqual(result, [])
         self.assertNotIn("ci", result)
 
 
@@ -618,6 +647,56 @@ class TestMain(unittest.TestCase):
         # c-a-opus must not appear in any DELETE call
         delete_paths = [c[0][0] for c in mock_api.call_args_list[1:]]
         self.assertFalse(any("c-a-opus" in p for p in delete_paths))
+
+    def test_test_failure_archive_removes_test_failure(self):
+        """Adding test-failure-archive when test-failure is present removes test-failure."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "test-failure-archive"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["test-failure", "testing"]),
+                    None,  # DELETE test-failure
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("test-failure", delete_call[0][0])
+        self.assertEqual(delete_call[1]["method"], "DELETE")
+
+    def test_test_failure_removes_test_failure_archive(self):
+        """Adding test-failure when test-failure-archive is present removes test-failure-archive."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "test-failure"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["test-failure-archive", "testing"]),
+                    None,  # DELETE test-failure-archive
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("test-failure-archive", delete_call[0][0])
+        self.assertEqual(delete_call[1]["method"], "DELETE")
+
+    def test_test_failure_prefix_does_not_remove_testing_label(self):
+        """Enforcing the test-failure group must not touch the unrelated 'testing' label."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "test-failure"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[self._make_issue_response(["testing", "ci"])],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        # Only the GET call to fetch the issue should be made; no conflicts found.
+        self.assertEqual(mock_api.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -197,6 +197,7 @@ class TestLabelsByPrefix(unittest.TestCase):
         )
         self.assertIn("c-a-haiku", result)
         self.assertNotIn("c-r-opus", result)
+        self.assertNotIn("ci", result)
 
     def test_removes_test_failure_when_archive_added(self):
         result = emxl.labels_to_remove_by_prefix(
@@ -216,7 +217,6 @@ class TestLabelsByPrefix(unittest.TestCase):
             "test-failure", ["testing", "ci"], "test-failure"
         )
         self.assertEqual(result, [])
-        self.assertNotIn("ci", result)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `"test-failure"` to `MUTUALLY_EXCLUSIVE_PREFIXES` in `scripts/enforce_mutually_exclusive_labels.py`, so `test-failure` and `test-failure-archive` are enforced as mutually exclusive the same way the existing `c-a-*`/`c-r-*` prefix groups are.
- `test-failure-archive` already replaces `test-failure` when `archive_stale_test_failures.py` runs (see that script's own label swap), but nothing previously stopped the two from coexisting if `test-failure-archive` were added by hand without also removing `test-failure`--which is exactly what happened when issues #657, #656, #571, and #233 were manually archived. This closes that gap for future manual label changes.
- Adds test coverage in `scripts/test_enforce_mutually_exclusive_labels.py`: `find_conflicting_prefix`/`labels_to_remove_by_prefix` unit tests for both directions (`test-failure-archive` added removes `test-failure`, and vice versa), a check that the unrelated `testing` label is untouched, and `main()` integration tests mirroring the existing prefix-group coverage.

## Test plan

- [x] `python3 -m unittest scripts.test_enforce_mutually_exclusive_labels -v` passes locally (76/76 tests).

