### PR TITLE
Retry the Allow-all tap when the grant hasn't landed (issue #581)

### DIFF
--- a/.github/allowed-test-failures.txt
+++ b/.github/allowed-test-failures.txt
@@ -22,6 +22,3 @@
 
 # Tracking issue: #243
 com.gb4pc.e2e.GalleryButtonVisualE2ETest#test5a_secureCameraLockedPopulatedGalleryShowsGreen
-
-# Tracking issue: #581
-com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest#setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1018,14 +1018,15 @@ jobs:
               "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
             fi
           fi
-          # E2EFixture.waitForWindowFocus()'s diagnostic (issue #581) logs via the GB4PC_E2E tag
-          # regardless of whether the test itself passes or fails, but the LOGCAT dump above only
-          # runs on a non-zero Gradle exit. Pull just this suite's focus-transfer line
-          # unconditionally, on every outcome, so the actual settle time is visible even on a
-          # green run instead of only when something else already failed.
-          echo "=== Permission-controller window-focus diagnostic (issue #581) ==="
-          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "took input focus\|never took input focus" \
-            || echo "  (no focus diagnostic line found in logcat)"
+          # The tapAllowAllInSystemDialog()/tapSelectPhotosInSystemDialog() button-enabled poll's
+          # diagnostic (issue #581) logs via the GB4PC_E2E tag regardless of whether the test
+          # itself passes or fails, but the LOGCAT dump above only runs on a non-zero Gradle exit.
+          # Pull just this suite's diagnostic lines unconditionally, on every outcome, so the
+          # actual timings are visible even on a green run instead of only when something else
+          # already failed.
+          echo "=== Permission dialog button-enabled diagnostic (issue #581) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "reported enabled\|never reported enabled" \
+            || echo "  (no button-enabled diagnostic line found in logcat)"
           # Stop screenrecord cleanly so the moov atom is written and the MP4 is playable.
           # Runs unconditionally after every branch above (including the torn-down/recovery
           # path): screenrecord is a separate device-side process under `shell`, so it is
@@ -1129,14 +1130,15 @@ jobs:
             echo "=== LOGCAT (since test start) ==="
             "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
           fi
-          # E2EFixture.waitForWindowFocus()'s diagnostic (issue #581) logs via the GB4PC_E2E tag
-          # regardless of whether the test itself passes or fails, but the LOGCAT dump above only
-          # runs on a non-zero Gradle exit. Pull just this suite's focus-transfer line
-          # unconditionally, on every outcome, so the actual settle time is visible even on a
-          # green run instead of only when something else already failed.
-          echo "=== Permission-controller window-focus diagnostic (issue #581) ==="
-          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "took input focus\|never took input focus" \
-            || echo "  (no focus diagnostic line found in logcat)"
+          # The tapAllowAllInSystemDialog()/tapSelectPhotosInSystemDialog() button-enabled poll's
+          # diagnostic (issue #581) logs via the GB4PC_E2E tag regardless of whether the test
+          # itself passes or fails, but the LOGCAT dump above only runs on a non-zero Gradle exit.
+          # Pull just this suite's diagnostic lines unconditionally, on every outcome, so the
+          # actual timings are visible even on a green run instead of only when something else
+          # already failed.
+          echo "=== Permission dialog button-enabled diagnostic (issue #581) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "reported enabled\|never reported enabled" \
+            || echo "  (no button-enabled diagnostic line found in logcat)"
 
       - name: Re-grant media permission after PartialAccessPhotoPickerE2ETest
         # Mirrors "Re-grant media permission after PermissionsDeniedE2ETest" above: this suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1018,15 +1018,14 @@ jobs:
               "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
             fi
           fi
-          # The tapAllowAllInSystemDialog()/tapSelectPhotosInSystemDialog() button-enabled poll's
-          # diagnostic (issue #581) logs via the GB4PC_E2E tag regardless of whether the test
-          # itself passes or fails, but the LOGCAT dump above only runs on a non-zero Gradle exit.
-          # Pull just this suite's diagnostic lines unconditionally, on every outcome, so the
-          # actual timings are visible even on a green run instead of only when something else
-          # already failed.
-          echo "=== Permission dialog button-enabled diagnostic (issue #581) ==="
-          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "reported enabled\|never reported enabled" \
-            || echo "  (no button-enabled diagnostic line found in logcat)"
+          # The grant-poll retry loop's diagnostic (issue #581) logs via the GB4PC_E2E tag only
+          # when a retry actually happens (silence means the first tap registered), regardless of
+          # whether the test itself ultimately passes or fails; the LOGCAT dump above only runs
+          # on a non-zero Gradle exit. Pull any retry lines unconditionally, on every outcome, so
+          # a retry that happened on an otherwise-green run is still visible.
+          echo "=== Allow-all tap retry diagnostic (issue #581) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:W | grep -i "retrying" \
+            || echo "  (no retry occurred; first tap registered)"
           # Stop screenrecord cleanly so the moov atom is written and the MP4 is playable.
           # Runs unconditionally after every branch above (including the torn-down/recovery
           # path): screenrecord is a separate device-side process under `shell`, so it is
@@ -1130,15 +1129,6 @@ jobs:
             echo "=== LOGCAT (since test start) ==="
             "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
           fi
-          # The tapAllowAllInSystemDialog()/tapSelectPhotosInSystemDialog() button-enabled poll's
-          # diagnostic (issue #581) logs via the GB4PC_E2E tag regardless of whether the test
-          # itself passes or fails, but the LOGCAT dump above only runs on a non-zero Gradle exit.
-          # Pull just this suite's diagnostic lines unconditionally, on every outcome, so the
-          # actual timings are visible even on a green run instead of only when something else
-          # already failed.
-          echo "=== Permission dialog button-enabled diagnostic (issue #581) ==="
-          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "reported enabled\|never reported enabled" \
-            || echo "  (no button-enabled diagnostic line found in logcat)"
 
       - name: Re-grant media permission after PartialAccessPhotoPickerE2ETest
         # Mirrors "Re-grant media permission after PermissionsDeniedE2ETest" above: this suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1018,6 +1018,14 @@ jobs:
               "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
             fi
           fi
+          # E2EFixture.waitForWindowFocus()'s diagnostic (issue #581) logs via the GB4PC_E2E tag
+          # regardless of whether the test itself passes or fails, but the LOGCAT dump above only
+          # runs on a non-zero Gradle exit. Pull just this suite's focus-transfer line
+          # unconditionally, on every outcome, so the actual settle time is visible even on a
+          # green run instead of only when something else already failed.
+          echo "=== Permission-controller window-focus diagnostic (issue #581) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "took input focus\|never took input focus" \
+            || echo "  (no focus diagnostic line found in logcat)"
           # Stop screenrecord cleanly so the moov atom is written and the MP4 is playable.
           # Runs unconditionally after every branch above (including the torn-down/recovery
           # path): screenrecord is a separate device-side process under `shell`, so it is
@@ -1121,6 +1129,14 @@ jobs:
             echo "=== LOGCAT (since test start) ==="
             "$ADB" logcat -d -T "$LOGCAT_SINCE" | bash scripts/filter_logcat.sh
           fi
+          # E2EFixture.waitForWindowFocus()'s diagnostic (issue #581) logs via the GB4PC_E2E tag
+          # regardless of whether the test itself passes or fails, but the LOGCAT dump above only
+          # runs on a non-zero Gradle exit. Pull just this suite's focus-transfer line
+          # unconditionally, on every outcome, so the actual settle time is visible even on a
+          # green run instead of only when something else already failed.
+          echo "=== Permission-controller window-focus diagnostic (issue #581) ==="
+          "$ADB" logcat -d -T "$LOGCAT_SINCE" -s GB4PC_E2E:I | grep -i "took input focus\|never took input focus" \
+            || echo "  (no focus diagnostic line found in logcat)"
 
       - name: Re-grant media permission after PartialAccessPhotoPickerE2ETest
         # Mirrors "Re-grant media permission after PermissionsDeniedE2ETest" above: this suite

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -69,9 +69,6 @@ class E2EFixture(
         /** Package name of the mock gallery APK (see `:e2e-mock-gallery` module). */
         private const val MOCK_GALLERY_PACKAGE = "com.gb4pc.mockgallery"
 
-        /** Matches `dumpsys window displays`' focused-window line; see [waitForWindowFocus]. */
-        private val FOCUS_LINE_PATTERN = Regex("""mCurrentFocus=Window\{[0-9a-f]+ u0 ([^}]+)\}""")
-
         // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
         //
         // The per-attempt verify windows must not false-positive a *healthy* launch as a failed
@@ -342,53 +339,6 @@ class E2EFixture(
             Thread.sleep(100)
         }
         return condition()
-    }
-
-    /**
-     * Polls `dumpsys window` for the moment the window whose component name contains
-     * [componentFragment] takes input focus (issue #581's cross-process activity-switch
-     * diagnostic: a UI Automator click can find and tap a target's accessibility node before
-     * WindowManagerService finishes handing that window input focus, so the tap lands on a
-     * window that is not yet receiving touches). Logs how long the transfer took, or that it
-     * never happened within [timeoutMs], via [TAG] so CI logcat carries a real measurement
-     * regardless of whether the caller's own assertions pass or fail afterward.
-     *
-     * Matches on a substring of the reported component (`package/Class`), not a package prefix:
-     * an earlier revision of this diagnostic compared against
-     * `com.android.permissioncontroller` and always reported a false "never took focus" on this
-     * CI emulator's Google-branded system image, whose permission controller actually runs as
-     * `com.google.android.permissioncontroller` (its resource package, used by `By.res()` button
-     * lookups elsewhere, is still `com.android.permissioncontroller`; only the runtime
-     * application id differs). An activity class name fragment such as
-     * `"GrantPermissionsActivity"` is stable across that branding difference.
-     */
-    fun waitForWindowFocus(
-        componentFragment: String,
-        timeoutMs: Long,
-    ): Boolean {
-        val start = System.currentTimeMillis()
-        val focused = waitForCondition(timeoutMs) { currentFocusedComponent().contains(componentFragment) }
-        val elapsedMs = System.currentTimeMillis() - start
-        if (focused) {
-            Log.i(TAG, "'$componentFragment' took input focus after ${elapsedMs}ms")
-        } else {
-            Log.w(
-                TAG,
-                "'$componentFragment' never took input focus within ${timeoutMs}ms " +
-                    "(last focused component: '${currentFocusedComponent()}')",
-            )
-        }
-        return focused
-    }
-
-    private fun currentFocusedComponent(): String {
-        val pfd = uiAutomation.executeShellCommand("dumpsys window displays")
-        return ParcelFileDescriptor.AutoCloseInputStream(pfd).use { stream ->
-            FOCUS_LINE_PATTERN.find(stream.bufferedReader().readText())
-                ?.groupValues
-                ?.get(1)
-                .orEmpty()
-        }
     }
 
     // ── Phase 4 extensions ────────────────────────────────────────────────────

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -345,27 +345,36 @@ class E2EFixture(
     }
 
     /**
-     * Polls `dumpsys window` for the moment [packageName]'s window takes input focus (issue
-     * #581's cross-process activity-switch diagnostic: a UI Automator click can find and tap a
-     * target's accessibility node before WindowManagerService finishes handing that window
-     * input focus, so the tap lands on a window that is not yet receiving touches). Logs how
-     * long the transfer took, or that it never happened within [timeoutMs], via [TAG] so CI
-     * logcat carries a real measurement regardless of whether the caller's own assertions pass
-     * or fail afterward.
+     * Polls `dumpsys window` for the moment the window whose component name contains
+     * [componentFragment] takes input focus (issue #581's cross-process activity-switch
+     * diagnostic: a UI Automator click can find and tap a target's accessibility node before
+     * WindowManagerService finishes handing that window input focus, so the tap lands on a
+     * window that is not yet receiving touches). Logs how long the transfer took, or that it
+     * never happened within [timeoutMs], via [TAG] so CI logcat carries a real measurement
+     * regardless of whether the caller's own assertions pass or fail afterward.
+     *
+     * Matches on a substring of the reported component (`package/Class`), not a package prefix:
+     * an earlier revision of this diagnostic compared against
+     * `com.android.permissioncontroller` and always reported a false "never took focus" on this
+     * CI emulator's Google-branded system image, whose permission controller actually runs as
+     * `com.google.android.permissioncontroller` (its resource package, used by `By.res()` button
+     * lookups elsewhere, is still `com.android.permissioncontroller`; only the runtime
+     * application id differs). An activity class name fragment such as
+     * `"GrantPermissionsActivity"` is stable across that branding difference.
      */
     fun waitForWindowFocus(
-        packageName: String,
+        componentFragment: String,
         timeoutMs: Long,
     ): Boolean {
         val start = System.currentTimeMillis()
-        val focused = waitForCondition(timeoutMs) { currentFocusedComponent().startsWith("$packageName/") }
+        val focused = waitForCondition(timeoutMs) { currentFocusedComponent().contains(componentFragment) }
         val elapsedMs = System.currentTimeMillis() - start
         if (focused) {
-            Log.i(TAG, "$packageName took input focus after ${elapsedMs}ms")
+            Log.i(TAG, "'$componentFragment' took input focus after ${elapsedMs}ms")
         } else {
             Log.w(
                 TAG,
-                "$packageName never took input focus within ${timeoutMs}ms " +
+                "'$componentFragment' never took input focus within ${timeoutMs}ms " +
                     "(last focused component: '${currentFocusedComponent()}')",
             )
         }

--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -69,6 +69,9 @@ class E2EFixture(
         /** Package name of the mock gallery APK (see `:e2e-mock-gallery` module). */
         private const val MOCK_GALLERY_PACKAGE = "com.gb4pc.mockgallery"
 
+        /** Matches `dumpsys window displays`' focused-window line; see [waitForWindowFocus]. */
+        private val FOCUS_LINE_PATTERN = Regex("""mCurrentFocus=Window\{[0-9a-f]+ u0 ([^}]+)\}""")
+
         // Issue #233: bounded relaunch for the first-launch teardown race in launchPixelCamera().
         //
         // The per-attempt verify windows must not false-positive a *healthy* launch as a failed
@@ -339,6 +342,44 @@ class E2EFixture(
             Thread.sleep(100)
         }
         return condition()
+    }
+
+    /**
+     * Polls `dumpsys window` for the moment [packageName]'s window takes input focus (issue
+     * #581's cross-process activity-switch diagnostic: a UI Automator click can find and tap a
+     * target's accessibility node before WindowManagerService finishes handing that window
+     * input focus, so the tap lands on a window that is not yet receiving touches). Logs how
+     * long the transfer took, or that it never happened within [timeoutMs], via [TAG] so CI
+     * logcat carries a real measurement regardless of whether the caller's own assertions pass
+     * or fail afterward.
+     */
+    fun waitForWindowFocus(
+        packageName: String,
+        timeoutMs: Long,
+    ): Boolean {
+        val start = System.currentTimeMillis()
+        val focused = waitForCondition(timeoutMs) { currentFocusedComponent().startsWith("$packageName/") }
+        val elapsedMs = System.currentTimeMillis() - start
+        if (focused) {
+            Log.i(TAG, "$packageName took input focus after ${elapsedMs}ms")
+        } else {
+            Log.w(
+                TAG,
+                "$packageName never took input focus within ${timeoutMs}ms " +
+                    "(last focused component: '${currentFocusedComponent()}')",
+            )
+        }
+        return focused
+    }
+
+    private fun currentFocusedComponent(): String {
+        val pfd = uiAutomation.executeShellCommand("dumpsys window displays")
+        return ParcelFileDescriptor.AutoCloseInputStream(pfd).use { stream ->
+            FOCUS_LINE_PATTERN.find(stream.bufferedReader().readText())
+                ?.groupValues
+                ?.get(1)
+                .orEmpty()
+        }
     }
 
     // ── Phase 4 extensions ────────────────────────────────────────────────────

--- a/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
@@ -191,6 +191,15 @@ class PartialAccessPhotoPickerE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
+        // Diagnostic (issue #581): this test drives the same permission-controller dialog as
+        // SetupActivityPermissionDialogE2ETest, whose "Allow all" button intermittently failed
+        // to register a tap that landed correctly by resource id, traced to a possible
+        // cross-process window-focus-transfer race after the activity switch from SetupActivity.
+        // This suite's own button tap has not shown that flake, but measuring it here too costs
+        // nothing and gives a second data point on whether the transfer time is consistent
+        // across both buttons on the same dialog. See E2EFixture.waitForWindowFocus.
+        fixture.waitForWindowFocus(PERMISSION_CONTROLLER_PKG, FOCUS_TIMEOUT_MS)
+
         // Drive the real com.android.permissioncontroller dialog: pick "Select photos and
         // videos" (partial access, H2) instead of SetupActivityPermissionDialogE2ETest's
         // "Allow all", then drive the resulting system photo picker to completion.
@@ -345,5 +354,10 @@ class PartialAccessPhotoPickerE2ETest {
         const val DIALOG_TIMEOUT_MS = 5_000L
         const val GRANT_TIMEOUT_MS = 10_000L
         const val BANNER_TIMEOUT_MS = 10_000L
+
+        // Matches SetupActivityPermissionDialogE2ETest's budget for the same diagnostic (issue
+        // #581): generous enough that a genuine non-transfer within it is itself the interesting
+        // result, not a timeout to tighten.
+        const val FOCUS_TIMEOUT_MS = 45_000L
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
@@ -3,7 +3,6 @@ package com.gb4pc.e2e
 import android.Manifest
 import android.app.NotificationManager
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -299,11 +298,12 @@ class PartialAccessPhotoPickerE2ETest {
      * in that source and always failed over. The text fallbacks remain in case a future Android
      * version renames the id.
      *
-     * Also applies [SetupActivityPermissionDialogE2ETest]'s tapjacking-defense experiment (issue
-     * #581): waits for the early window-content-change event, then polls the found button's own
-     * `isEnabled()` state before clicking, rather than assuming presence in the accessibility
-     * tree means it is already clickable. This suite's button tap has not shown the sibling's
-     * flake, but applying the same sequence here too costs little and gives a second data point.
+     * `device.waitForWindowUpdate()` is a cheap, early guard against the button not existing in
+     * the tree yet. It is deliberately not paired with the retry-on-failure loop
+     * [SetupActivityPermissionDialogE2ETest] uses to work around AOSP's `SecureButton` silently
+     * dropping window-obscured touches (issue #581): this suite has not shown that flake, and a
+     * blind retry here is riskier, since a re-tap that lands after the button dismisses could hit
+     * whatever the system photo picker (a second dialog) puts in its place instead.
      */
     private fun tapSelectPhotosInSystemDialog() {
         device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
@@ -317,19 +317,6 @@ class PartialAccessPhotoPickerE2ETest {
                 "within $DIALOG_TIMEOUT_MS ms after tapping the MEDIA step button. Either the " +
                 "requestPermissions() dialog did not appear, or this option's wording/resource " +
                 "id differs on this emulator/Android build (see the class doc's H2 caveat)."
-        }
-
-        val start = System.currentTimeMillis()
-        val enabled = fixture.waitForCondition(BUTTON_ENABLED_TIMEOUT_MS) { button.isEnabled }
-        val elapsedMs = System.currentTimeMillis() - start
-        if (enabled) {
-            Log.i(TAG, "Select photos button reported enabled after ${elapsedMs}ms")
-        } else {
-            Log.w(
-                TAG,
-                "Select photos button never reported enabled within ${BUTTON_ENABLED_TIMEOUT_MS}ms; " +
-                    "clicking anyway",
-            )
         }
         button.click()
     }
@@ -369,7 +356,6 @@ class PartialAccessPhotoPickerE2ETest {
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
     private companion object {
-        const val TAG = "GB4PC_E2E"
         const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
         const val PHOTO_PICKER_PKG_GOOGLE = "com.google.android.providers.media.module"
         const val PHOTO_PICKER_PKG_AOSP = "com.android.providers.media.module"
@@ -377,9 +363,7 @@ class PartialAccessPhotoPickerE2ETest {
         const val GRANT_TIMEOUT_MS = 10_000L
         const val BANNER_TIMEOUT_MS = 10_000L
 
-        // Matches SetupActivityPermissionDialogE2ETest's budgets for the same diagnostics (issue
-        // #581).
+        // Matches SetupActivityPermissionDialogE2ETest's budget for the same guard (issue #581).
         const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
-        const val BUTTON_ENABLED_TIMEOUT_MS = 45_000L
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
@@ -117,16 +117,20 @@ import java.util.regex.Pattern
  *
  * ### Uncertainties this class cannot resolve without a real CI run
  *
- * As the issue anticipated ("expect more work identifying the right resource IDs/gestures"),
- * neither the permission dialog's "Select photos and videos" option nor the system photo
- * picker's thumbnail/confirm controls have a resource id confirmed against this CI emulator (API
- * 35, `google_apis` system image) the way [SetupActivityPermissionDialogE2ETest]'s
- * `permission_allow_all_button` was. This dev environment has no emulator/device to verify
- * against (see the several "NOT AUTOMATABLE" comments on issue #568), so:
+ * As the issue anticipated ("expect more work identifying the right resource IDs/gestures"), the
+ * system photo picker's thumbnail/confirm controls do not have a resource id confirmed against
+ * this CI emulator (API 35, `google_apis` system image) the way
+ * [SetupActivityPermissionDialogE2ETest]'s `permission_allow_all_button` was. The permission
+ * dialog's own "Select photos and videos" option no longer shares that uncertainty:
+ * `permission_allow_selected_button` is confirmed against current AOSP `PermissionController`
+ * source (issue #581), so [tapSelectPhotosInSystemDialog] leads with it rather than guessing. This
+ * dev environment has no emulator/device to verify the picker controls against (see the several
+ * "NOT AUTOMATABLE" comments on issue #568), so:
  *
- *  - [tapSelectPhotosInSystemDialog] tries several plausible resource ids, then falls back to a
- *    case-insensitive "Select photos" text match -- the exact phrase Android's own developer
- *    documentation uses for this option, which should hold even if the resource id differs.
+ *  - [tapSelectPhotosInSystemDialog] falls back from the confirmed id to a case-insensitive
+ *    "Select photos" text match -- the exact phrase Android's own developer documentation uses
+ *    for this option, which should hold even if the resource id changes in a future Android
+ *    version.
  *  - [selectPhotosInSystemPickerAndConfirm] tries both the Google-branded and AOSP package names
  *    for the MediaProvider photo picker module. It requires a selectable thumbnail rather than
  *    tolerating an empty grid: the test seeds one image via [E2EFixture.seedOnePhoto] before the
@@ -295,13 +299,17 @@ class PartialAccessPhotoPickerE2ETest {
     /**
      * Waits for the real system permission dialog and taps its "Select photos and videos"
      * option (partial access, H2), rather than [SetupActivityPermissionDialogE2ETest]'s "Allow
-     * all". See the class doc for why the resource id guesses below are unconfirmed.
+     * all". `permission_allow_selected_button` is confirmed against the current AOSP
+     * `PermissionController` source (issue #581's investigation): it is the id
+     * `GrantPermissionsViewHandlerImpl`'s `BUTTON_RES_ID_TO_NUM` maps to `ALLOW_SELECTED_BUTTON`,
+     * so it leads the list rather than the two ids this class originally guessed
+     * (`permission_more_photos_button`, `permission_allow_partial_button`), which do not exist
+     * in that source and always failed over. The text fallbacks remain in case a future Android
+     * version renames the id.
      */
     private fun tapSelectPhotosInSystemDialog() {
         val button =
-            findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_more_photos_button"))
-                ?: findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_selected_button"))
-                ?: findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_partial_button"))
+            findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_selected_button"))
                 ?: findDialogObject(By.textContains("Select photos"))
                 ?: findDialogObject(By.text(Pattern.compile(".*select.*photo.*", Pattern.CASE_INSENSITIVE)))
         requireNotNull(button) {

--- a/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
@@ -3,6 +3,7 @@ package com.gb4pc.e2e
 import android.Manifest
 import android.app.NotificationManager
 import android.content.pm.PackageManager
+import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -195,18 +196,6 @@ class PartialAccessPhotoPickerE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
-        // Diagnostic (issue #581): this test drives the same permission-controller dialog as
-        // SetupActivityPermissionDialogE2ETest, whose "Allow all" button intermittently failed
-        // to register a tap that landed correctly by resource id, traced to a possible
-        // cross-process window-focus-transfer race after the activity switch from SetupActivity.
-        // This suite's own button tap has not shown that flake, but measuring it here too costs
-        // nothing and gives a second data point on whether the transfer time is consistent
-        // across both buttons on the same dialog. Matched by activity class name, not
-        // PERMISSION_CONTROLLER_PKG: see E2EFixture.waitForWindowFocus's doc for why that
-        // constant (correct for the By.res() lookups below) isn't this dialog's runtime
-        // application id on this CI emulator's Google-branded system image.
-        fixture.waitForWindowFocus("GrantPermissionsActivity", FOCUS_TIMEOUT_MS)
-
         // Drive the real com.android.permissioncontroller dialog: pick "Select photos and
         // videos" (partial access, H2) instead of SetupActivityPermissionDialogE2ETest's
         // "Allow all", then drive the resulting system photo picker to completion.
@@ -309,8 +298,16 @@ class PartialAccessPhotoPickerE2ETest {
      * (`permission_more_photos_button`, `permission_allow_partial_button`), which do not exist
      * in that source and always failed over. The text fallbacks remain in case a future Android
      * version renames the id.
+     *
+     * Also applies [SetupActivityPermissionDialogE2ETest]'s tapjacking-defense experiment (issue
+     * #581): waits for the early window-content-change event, then polls the found button's own
+     * `isEnabled()` state before clicking, rather than assuming presence in the accessibility
+     * tree means it is already clickable. This suite's button tap has not shown the sibling's
+     * flake, but applying the same sequence here too costs little and gives a second data point.
      */
     private fun tapSelectPhotosInSystemDialog() {
+        device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
+
         val button =
             findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_selected_button"))
                 ?: findDialogObject(By.textContains("Select photos"))
@@ -320,6 +317,19 @@ class PartialAccessPhotoPickerE2ETest {
                 "within $DIALOG_TIMEOUT_MS ms after tapping the MEDIA step button. Either the " +
                 "requestPermissions() dialog did not appear, or this option's wording/resource " +
                 "id differs on this emulator/Android build (see the class doc's H2 caveat)."
+        }
+
+        val start = System.currentTimeMillis()
+        val enabled = fixture.waitForCondition(BUTTON_ENABLED_TIMEOUT_MS) { button.isEnabled }
+        val elapsedMs = System.currentTimeMillis() - start
+        if (enabled) {
+            Log.i(TAG, "Select photos button reported enabled after ${elapsedMs}ms")
+        } else {
+            Log.w(
+                TAG,
+                "Select photos button never reported enabled within ${BUTTON_ENABLED_TIMEOUT_MS}ms; " +
+                    "clicking anyway",
+            )
         }
         button.click()
     }
@@ -359,6 +369,7 @@ class PartialAccessPhotoPickerE2ETest {
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
     private companion object {
+        const val TAG = "GB4PC_E2E"
         const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
         const val PHOTO_PICKER_PKG_GOOGLE = "com.google.android.providers.media.module"
         const val PHOTO_PICKER_PKG_AOSP = "com.android.providers.media.module"
@@ -366,9 +377,9 @@ class PartialAccessPhotoPickerE2ETest {
         const val GRANT_TIMEOUT_MS = 10_000L
         const val BANNER_TIMEOUT_MS = 10_000L
 
-        // Matches SetupActivityPermissionDialogE2ETest's budget for the same diagnostic (issue
-        // #581): generous enough that a genuine non-transfer within it is itself the interesting
-        // result, not a timeout to tighten.
-        const val FOCUS_TIMEOUT_MS = 45_000L
+        // Matches SetupActivityPermissionDialogE2ETest's budgets for the same diagnostics (issue
+        // #581).
+        const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
+        const val BUTTON_ENABLED_TIMEOUT_MS = 45_000L
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PartialAccessPhotoPickerE2ETest.kt
@@ -201,8 +201,11 @@ class PartialAccessPhotoPickerE2ETest {
         // cross-process window-focus-transfer race after the activity switch from SetupActivity.
         // This suite's own button tap has not shown that flake, but measuring it here too costs
         // nothing and gives a second data point on whether the transfer time is consistent
-        // across both buttons on the same dialog. See E2EFixture.waitForWindowFocus.
-        fixture.waitForWindowFocus(PERMISSION_CONTROLLER_PKG, FOCUS_TIMEOUT_MS)
+        // across both buttons on the same dialog. Matched by activity class name, not
+        // PERMISSION_CONTROLLER_PKG: see E2EFixture.waitForWindowFocus's doc for why that
+        // constant (correct for the By.res() lookups below) isn't this dialog's runtime
+        // application id on this CI emulator's Google-branded system image.
+        fixture.waitForWindowFocus("GrantPermissionsActivity", FOCUS_TIMEOUT_MS)
 
         // Drive the real com.android.permissioncontroller dialog: pick "Select photos and
         // videos" (partial access, H2) instead of SetupActivityPermissionDialogE2ETest's

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -1,5 +1,6 @@
 package com.gb4pc.e2e
 
+import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -124,18 +125,6 @@ class SetupActivityPermissionDialogE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
-        // Diagnostic (issue #581): a flat 1-minute sleep in an earlier commit on this PR did not
-        // fix the flake, ruling out the timing-theory family wholesale rather than confirming one
-        // mechanism within it. Measure the actual thing that theory family was about, instead of
-        // guessing at a delay: wait for GrantPermissionsActivity's window to actually take input
-        // focus (see E2EFixture.waitForWindowFocus), logging how long that took, or that it
-        // never happened, so CI logcat carries a real number regardless of whether the assertion
-        // below passes or fails. Matched by activity class name, not PERMISSION_CONTROLLER_PKG:
-        // that constant is the dialog's resource package (correct for the By.res() lookups
-        // below), not necessarily its runtime application id, which differs on this CI
-        // emulator's Google-branded system image (see waitForWindowFocus's doc).
-        fixture.waitForWindowFocus("GrantPermissionsActivity", FOCUS_TIMEOUT_MS)
-
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
 
@@ -173,8 +162,27 @@ class SetupActivityPermissionDialogE2ETest {
      * Older single-permission layouts use `permission_allow_button` instead; both are tried by
      * resource id, with a case-insensitive "Allow all"/"Allow" text match as a final fallback so
      * the test does not silently pass by failing to find the dialog.
+     *
+     * ### The tapjacking-defense theory (issue #581)
+     *
+     * A prior commit on this PR confirmed the permission-controller window itself takes input
+     * focus quickly (under 1 s), which undercuts the window-focus-transfer theory as the flake's
+     * cause. A different, security-motivated mechanism is also plausible for a dialog this
+     * sensitive: the button may exist in the accessibility tree, and its window may hold focus,
+     * before the button itself is actually enabled for input, specifically to defeat
+     * tapjacking (a touch landing on the button the instant it renders, e.g. under a finger
+     * already mid-tap from the action that triggered the dialog). `device.waitForWindowUpdate()`
+     * alone (an early, near-instant window-content-change event) did not fix the flake in an
+     * earlier commit. This combines that same early signal with an explicit poll of the found
+     * button's own `isEnabled()` state: `UiObject2.isEnabled()` re-syncs against the live
+     * `AccessibilityNodeInfo` on every call (confirmed against current
+     * androidx.test.uiautomator source), so polling the same captured button reference correctly
+     * observes a disabled-to-enabled transition, rather than assuming presence in the tree means
+     * the button is already clickable.
      */
     private fun tapAllowAllInSystemDialog() {
+        device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
+
         val button =
             findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_all_button"))
                 ?: findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_button"))
@@ -185,19 +193,37 @@ class SetupActivityPermissionDialogE2ETest {
                 "$DIALOG_TIMEOUT_MS ms after tapping the MEDIA step button. The requestPermissions() " +
                 "dialog may not have appeared, or its resource ids/labels differ on this emulator."
         }
+
+        val start = System.currentTimeMillis()
+        val enabled = fixture.waitForCondition(BUTTON_ENABLED_TIMEOUT_MS) { button.isEnabled }
+        val elapsedMs = System.currentTimeMillis() - start
+        if (enabled) {
+            Log.i(TAG, "Allow all button reported enabled after ${elapsedMs}ms")
+        } else {
+            Log.w(
+                TAG,
+                "Allow all button never reported enabled within ${BUTTON_ENABLED_TIMEOUT_MS}ms; " +
+                    "clicking anyway",
+            )
+        }
         button.click()
     }
 
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
     private companion object {
+        const val TAG = "GB4PC_E2E"
         const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
         const val DIALOG_TIMEOUT_MS = 5_000L
 
-        // Generous relative to the diagnostic 1-minute sleep this replaced (issue #581): if focus
-        // genuinely never transfers within this budget, that is itself the interesting result, not
-        // a timeout to tighten.
-        const val FOCUS_TIMEOUT_MS = 45_000L
+        // The window-content-change event alone arrives too early to fix the flake on its own
+        // (issue #581); this is just its own find-the-window budget, not expected to be load-bearing.
+        const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
+
+        // Generous relative to the diagnostic sleeps/polls this replaced (issue #581): if the
+        // button genuinely never reports enabled within this budget, that is itself the
+        // interesting result, not a timeout to tighten.
+        const val BUTTON_ENABLED_TIMEOUT_MS = 45_000L
 
         // Widened from 10 s to 20 s (issue #604): this suite gained a `screenrecord` process for
         // the first time in issue #604 (see build.yml's "Run SetupActivityPermissionDialogE2ETest"

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -127,11 +127,14 @@ class SetupActivityPermissionDialogE2ETest {
         // Diagnostic (issue #581): a flat 1-minute sleep in an earlier commit on this PR did not
         // fix the flake, ruling out the timing-theory family wholesale rather than confirming one
         // mechanism within it. Measure the actual thing that theory family was about, instead of
-        // guessing at a delay: wait for the permission-controller window to actually take input
+        // guessing at a delay: wait for GrantPermissionsActivity's window to actually take input
         // focus (see E2EFixture.waitForWindowFocus), logging how long that took, or that it
         // never happened, so CI logcat carries a real number regardless of whether the assertion
-        // below passes or fails.
-        fixture.waitForWindowFocus(PERMISSION_CONTROLLER_PKG, FOCUS_TIMEOUT_MS)
+        // below passes or fails. Matched by activity class name, not PERMISSION_CONTROLLER_PKG:
+        // that constant is the dialog's resource package (correct for the By.res() lookups
+        // below), not necessarily its runtime application id, which differs on this CI
+        // emulator's Google-branded system image (see waitForWindowFocus's doc).
+        fixture.waitForWindowFocus("GrantPermissionsActivity", FOCUS_TIMEOUT_MS)
 
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -1,7 +1,5 @@
 package com.gb4pc.e2e
 
-import android.os.ParcelFileDescriptor
-import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -126,28 +124,14 @@ class SetupActivityPermissionDialogE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
-        // Diagnostic (issue #581): a flat 1-minute sleep in the previous commit on this PR did not
+        // Diagnostic (issue #581): a flat 1-minute sleep in an earlier commit on this PR did not
         // fix the flake, ruling out the timing-theory family wholesale rather than confirming one
         // mechanism within it. Measure the actual thing that theory family was about, instead of
-        // guessing at a delay: poll dumpsys window for the moment WindowManagerService reports
-        // GrantPermissionsActivity as having input focus, and log how long that took (or that it
-        // never happened) so CI logcat carries a real number regardless of whether the assertion
+        // guessing at a delay: wait for the permission-controller window to actually take input
+        // focus (see E2EFixture.waitForWindowFocus), logging how long that took, or that it
+        // never happened, so CI logcat carries a real number regardless of whether the assertion
         // below passes or fails.
-        val focusStart = System.currentTimeMillis()
-        val focusTransferred =
-            fixture.waitForCondition(FOCUS_TIMEOUT_MS) {
-                currentFocusedComponent().startsWith("$PERMISSION_CONTROLLER_PKG/")
-            }
-        val focusElapsedMs = System.currentTimeMillis() - focusStart
-        if (focusTransferred) {
-            Log.i(TAG, "GrantPermissionsActivity took input focus after ${focusElapsedMs}ms")
-        } else {
-            Log.w(
-                TAG,
-                "GrantPermissionsActivity never took input focus within ${FOCUS_TIMEOUT_MS}ms " +
-                    "(last focused component: '${currentFocusedComponent()}')",
-            )
-        }
+        fixture.waitForWindowFocus(PERMISSION_CONTROLLER_PKG, FOCUS_TIMEOUT_MS)
 
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
@@ -203,27 +187,9 @@ class SetupActivityPermissionDialogE2ETest {
 
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
-    /**
-     * Reads the focused window's component name from `dumpsys window displays` (issue #581's
-     * focus-transfer diagnostic). Returns an empty string if the current dump has no
-     * `mCurrentFocus` line in the expected shape, which is treated the same as "not yet focused
-     * on the permission controller" by the poll above.
-     */
-    private fun currentFocusedComponent(): String {
-        val pfd = instrumentation.uiAutomation.executeShellCommand("dumpsys window displays")
-        return ParcelFileDescriptor.AutoCloseInputStream(pfd).use { stream ->
-            FOCUS_LINE_PATTERN.find(stream.bufferedReader().readText())
-                ?.groupValues
-                ?.get(1)
-                .orEmpty()
-        }
-    }
-
     private companion object {
-        const val TAG = "GB4PC_E2E"
         const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
         const val DIALOG_TIMEOUT_MS = 5_000L
-        val FOCUS_LINE_PATTERN = Regex("""mCurrentFocus=Window\{[0-9a-f]+ u0 ([^}]+)\}""")
 
         // Generous relative to the diagnostic 1-minute sleep this replaced (issue #581): if focus
         // genuinely never transfers within this budget, that is itself the interesting result, not

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -124,17 +124,18 @@ class SetupActivityPermissionDialogE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
-        // Wait for the permission-controller window to report an update (issue #581) before
-        // searching for its buttons. permission_allow_all_button's node can appear in the
-        // accessibility tree fast enough that findDialogObject() matches and clicks it before
-        // WindowManager has finished handing this cross-process activity switch its input focus,
-        // so the tap lands on a window that is not yet receiving touches: the grant never
-        // registers (no PackageManager grant, no onRequestPermissionsResult callback, no
-        // GrantPermissionsActivity finish), and the sole symptom is hasMediaPermission() never
-        // becoming true within GRANT_TIMEOUT_MS. This wait is not merely redundant with
-        // findDialogObject()'s own device.wait(): that call only waits for the node to exist, not
-        // for its window to be focused for input.
-        device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
+        // DELIBERATE DIAGNOSTIC OVERSHOOT (issue #581), not the intended fix: a flat one-minute
+        // sleep before searching for the dialog's buttons at all, to test the timing-theory family
+        // wholesale rather than any one specific settle signal. device.waitForWindowUpdate() (a
+        // window content/state-change event wait) did not fix the flake in the previous commit on
+        // this PR; that leaves open whether the settle time this test actually needs is simply
+        // longer than an event-driven wait provides, or whether timing is not the cause at all. A
+        // sleep this long relative to PartialAccessPhotoPickerE2ETest's accidental ~10 s settle
+        // (from two dead resource-id lookups before it reaches its real button) should clear
+        // either possibility if the root cause is timing-related in any form; if the assertion
+        // still fails after this, that rules out the whole timing-theory family, not just one
+        // mechanism within it.
+        Thread.sleep(60_000L)
 
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
@@ -203,10 +204,5 @@ class SetupActivityPermissionDialogE2ETest {
         // requireNotNull(button) failure tapAllowAllInSystemDialog() would otherwise throw).
         const val GRANT_TIMEOUT_MS = 20_000L
         const val ADVANCE_TIMEOUT_MS = 10_000L
-
-        // Bounded by DIALOG_TIMEOUT_MS's own budget for finding the dialog at all: if the window
-        // update never arrives within this long, findDialogObject()'s own wait below will time
-        // out too and report the clearer "button not found" failure instead.
-        const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.StaleObjectException
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
@@ -142,6 +143,16 @@ class SetupActivityPermissionDialogE2ETest {
         //    If the button has disappeared, the previous tap succeeded and the grant is simply
         //    propagating asynchronously (the pre-existing, documented issue #604 case); nothing
         //    to retry.
+        //
+        //    findAllowAllButtonNow() and button.click() are two separate round-trips to the
+        //    accessibility tree, so the button can go stale in between: the dialog can start
+        //    tearing down (e.g. because the *previous* tap actually did register, just after
+        //    this poll tick's find call) between the find and the click, which makes
+        //    UiObject2.click() throw StaleObjectException instead of silently no-op'ing. That is
+        //    the same "previous tap already succeeded" case findAllowAllButtonNow() returning
+        //    null handles, just observed at click time rather than find time, so it is caught
+        //    and treated the same way (poll again) rather than letting it escape and fail the
+        //    test with an exception instead of the intended assertion.
         var retryCount = 0
         val granted =
             fixture.waitForCondition(GRANT_TIMEOUT_MS) {
@@ -149,7 +160,17 @@ class SetupActivityPermissionDialogE2ETest {
                 findAllowAllButtonNow()?.let { button ->
                     retryCount++
                     Log.w(TAG, "Grant not yet registered; retrying \"Allow all\" tap (attempt ${retryCount + 1})")
-                    button.click()
+                    try {
+                        button.click()
+                    } catch (e: StaleObjectException) {
+                        Log.w(
+                            TAG,
+                            "\"Allow all\" button went stale between find and click (attempt " +
+                                "${retryCount + 1}); the previous tap likely already registered " +
+                                "and the dialog is tearing down, so treating this like a vanished " +
+                                "button rather than failing the test",
+                        )
+                    }
                 }
                 false
             }

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -1,5 +1,7 @@
 package com.gb4pc.e2e
 
+import android.os.ParcelFileDescriptor
+import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -124,18 +126,28 @@ class SetupActivityPermissionDialogE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
-        // DELIBERATE DIAGNOSTIC OVERSHOOT (issue #581), not the intended fix: a flat one-minute
-        // sleep before searching for the dialog's buttons at all, to test the timing-theory family
-        // wholesale rather than any one specific settle signal. device.waitForWindowUpdate() (a
-        // window content/state-change event wait) did not fix the flake in the previous commit on
-        // this PR; that leaves open whether the settle time this test actually needs is simply
-        // longer than an event-driven wait provides, or whether timing is not the cause at all. A
-        // sleep this long relative to PartialAccessPhotoPickerE2ETest's accidental ~10 s settle
-        // (from two dead resource-id lookups before it reaches its real button) should clear
-        // either possibility if the root cause is timing-related in any form; if the assertion
-        // still fails after this, that rules out the whole timing-theory family, not just one
-        // mechanism within it.
-        Thread.sleep(60_000L)
+        // Diagnostic (issue #581): a flat 1-minute sleep in the previous commit on this PR did not
+        // fix the flake, ruling out the timing-theory family wholesale rather than confirming one
+        // mechanism within it. Measure the actual thing that theory family was about, instead of
+        // guessing at a delay: poll dumpsys window for the moment WindowManagerService reports
+        // GrantPermissionsActivity as having input focus, and log how long that took (or that it
+        // never happened) so CI logcat carries a real number regardless of whether the assertion
+        // below passes or fails.
+        val focusStart = System.currentTimeMillis()
+        val focusTransferred =
+            fixture.waitForCondition(FOCUS_TIMEOUT_MS) {
+                currentFocusedComponent().startsWith("$PERMISSION_CONTROLLER_PKG/")
+            }
+        val focusElapsedMs = System.currentTimeMillis() - focusStart
+        if (focusTransferred) {
+            Log.i(TAG, "GrantPermissionsActivity took input focus after ${focusElapsedMs}ms")
+        } else {
+            Log.w(
+                TAG,
+                "GrantPermissionsActivity never took input focus within ${FOCUS_TIMEOUT_MS}ms " +
+                    "(last focused component: '${currentFocusedComponent()}')",
+            )
+        }
 
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
@@ -191,9 +203,32 @@ class SetupActivityPermissionDialogE2ETest {
 
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
+    /**
+     * Reads the focused window's component name from `dumpsys window displays` (issue #581's
+     * focus-transfer diagnostic). Returns an empty string if the current dump has no
+     * `mCurrentFocus` line in the expected shape, which is treated the same as "not yet focused
+     * on the permission controller" by the poll above.
+     */
+    private fun currentFocusedComponent(): String {
+        val pfd = instrumentation.uiAutomation.executeShellCommand("dumpsys window displays")
+        return ParcelFileDescriptor.AutoCloseInputStream(pfd).use { stream ->
+            FOCUS_LINE_PATTERN.find(stream.bufferedReader().readText())
+                ?.groupValues
+                ?.get(1)
+                .orEmpty()
+        }
+    }
+
     private companion object {
+        const val TAG = "GB4PC_E2E"
         const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
         const val DIALOG_TIMEOUT_MS = 5_000L
+        val FOCUS_LINE_PATTERN = Regex("""mCurrentFocus=Window\{[0-9a-f]+ u0 ([^}]+)\}""")
+
+        // Generous relative to the diagnostic 1-minute sleep this replaced (issue #581): if focus
+        // genuinely never transfers within this budget, that is itself the interesting result, not
+        // a timeout to tighten.
+        const val FOCUS_TIMEOUT_MS = 45_000L
 
         // Widened from 10 s to 20 s (issue #604): this suite gained a `screenrecord` process for
         // the first time in issue #604 (see build.yml's "Run SetupActivityPermissionDialogE2ETest"

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -124,6 +124,18 @@ class SetupActivityPermissionDialogE2ETest {
         // system permission dialog over SetupActivity.
         composeRule.onNodeWithText(mediaButton).performClick()
 
+        // Wait for the permission-controller window to report an update (issue #581) before
+        // searching for its buttons. permission_allow_all_button's node can appear in the
+        // accessibility tree fast enough that findDialogObject() matches and clicks it before
+        // WindowManager has finished handing this cross-process activity switch its input focus,
+        // so the tap lands on a window that is not yet receiving touches: the grant never
+        // registers (no PackageManager grant, no onRequestPermissionsResult callback, no
+        // GrantPermissionsActivity finish), and the sole symptom is hasMediaPermission() never
+        // becoming true within GRANT_TIMEOUT_MS. This wait is not merely redundant with
+        // findDialogObject()'s own device.wait(): that call only waits for the node to exist, not
+        // for its window to be focused for input.
+        device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
+
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
 
@@ -191,5 +203,10 @@ class SetupActivityPermissionDialogE2ETest {
         // requireNotNull(button) failure tapAllowAllInSystemDialog() would otherwise throw).
         const val GRANT_TIMEOUT_MS = 20_000L
         const val ADVANCE_TIMEOUT_MS = 10_000L
+
+        // Bounded by DIALOG_TIMEOUT_MS's own budget for finding the dialog at all: if the window
+        // update never arrives within this long, findDialogObject()'s own wait below will time
+        // out too and report the clearer "button not found" failure instead.
+        const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -128,11 +128,30 @@ class SetupActivityPermissionDialogE2ETest {
         // Drive the real com.android.permissioncontroller dialog: tap "Allow all".
         tapAllowAllInSystemDialog()
 
-        // 1) The grant actually took effect. Poll, because the permission result and the
-        //    PackageManager grant-state update are delivered asynchronously after the tap.
+        // 1) The grant actually took effect. Poll, retrying the tap if the button is still
+        //    visible (issue #581): AOSP's SecureButton (the permission dialog's button class)
+        //    silently drops any touch the system's input dispatcher flags
+        //    FLAG_WINDOW_IS_OBSCURED/FLAG_WINDOW_IS_PARTIALLY_OBSCURED, with no exception, no
+        //    log, and no symptom other than the grant never landing. SecureButton's own AOSP
+        //    source contains no self-timer; the flag comes from the real dispatcher computation,
+        //    which can transiently flag even a freshly created window's first touches while its
+        //    input bookkeeping settles, with no second app window involved. Retrying the tap,
+        //    rather than waiting longer or polling a different pre-tap signal, is the fix that
+        //    does not depend on identifying which transient condition caused any one drop: if
+        //    the button is still visible, the previous tap did not register, so tap it again.
+        //    If the button has disappeared, the previous tap succeeded and the grant is simply
+        //    propagating asynchronously (the pre-existing, documented issue #604 case); nothing
+        //    to retry.
+        var retryCount = 0
         val granted =
             fixture.waitForCondition(GRANT_TIMEOUT_MS) {
-                PermissionHelper.hasMediaPermission(context)
+                if (PermissionHelper.hasMediaPermission(context)) return@waitForCondition true
+                findAllowAllButtonNow()?.let { button ->
+                    retryCount++
+                    Log.w(TAG, "Grant not yet registered; retrying \"Allow all\" tap (attempt ${retryCount + 1})")
+                    button.click()
+                }
+                false
             }
         assertTrue(
             "hasMediaPermission() should become true after tapping \"Allow all\" in the real " +
@@ -163,51 +182,47 @@ class SetupActivityPermissionDialogE2ETest {
      * resource id, with a case-insensitive "Allow all"/"Allow" text match as a final fallback so
      * the test does not silently pass by failing to find the dialog.
      *
-     * ### The tapjacking-defense theory (issue #581)
-     *
-     * A prior commit on this PR confirmed the permission-controller window itself takes input
-     * focus quickly (under 1 s), which undercuts the window-focus-transfer theory as the flake's
-     * cause. A different, security-motivated mechanism is also plausible for a dialog this
-     * sensitive: the button may exist in the accessibility tree, and its window may hold focus,
-     * before the button itself is actually enabled for input, specifically to defeat
-     * tapjacking (a touch landing on the button the instant it renders, e.g. under a finger
-     * already mid-tap from the action that triggered the dialog). `device.waitForWindowUpdate()`
-     * alone (an early, near-instant window-content-change event) did not fix the flake in an
-     * earlier commit. This combines that same early signal with an explicit poll of the found
-     * button's own `isEnabled()` state: `UiObject2.isEnabled()` re-syncs against the live
-     * `AccessibilityNodeInfo` on every call (confirmed against current
-     * androidx.test.uiautomator source), so polling the same captured button reference correctly
-     * observes a disabled-to-enabled transition, rather than assuming presence in the tree means
-     * the button is already clickable.
+     * `device.waitForWindowUpdate()` is a cheap, early guard against the common case (the button
+     * not existing in the tree yet), but two prior commits on this PR ruled out both a longer
+     * pre-tap wait (a window-focus-transfer poll: the window takes focus in under 1 s, so there
+     * is nothing slow to wait for) and a pre-tap `isEnabled()` poll (the button reported enabled
+     * after ~100ms and the tap still silently failed) as fixes for the flake by themselves. See
+     * the retry loop around this method's call site for the mechanism that actually addresses
+     * it: AOSP's `SecureButton` class drops touches the system flags as window-obscured, with no
+     * exception or log, and that is inherently a transient condition worth retrying rather than
+     * waiting out.
      */
     private fun tapAllowAllInSystemDialog() {
         device.waitForWindowUpdate(PERMISSION_CONTROLLER_PKG, WINDOW_UPDATE_TIMEOUT_MS)
 
-        val button =
-            findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_all_button"))
-                ?: findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_button"))
-                ?: findDialogObject(By.textContains("Allow all"))
-                ?: findDialogObject(By.text(Pattern.compile("Allow.*", Pattern.CASE_INSENSITIVE)))
+        val button = findAllowAllButton()
         requireNotNull(button) {
             "The system permission dialog's \"Allow all\" button was not found within " +
                 "$DIALOG_TIMEOUT_MS ms after tapping the MEDIA step button. The requestPermissions() " +
                 "dialog may not have appeared, or its resource ids/labels differ on this emulator."
         }
-
-        val start = System.currentTimeMillis()
-        val enabled = fixture.waitForCondition(BUTTON_ENABLED_TIMEOUT_MS) { button.isEnabled }
-        val elapsedMs = System.currentTimeMillis() - start
-        if (enabled) {
-            Log.i(TAG, "Allow all button reported enabled after ${elapsedMs}ms")
-        } else {
-            Log.w(
-                TAG,
-                "Allow all button never reported enabled within ${BUTTON_ENABLED_TIMEOUT_MS}ms; " +
-                    "clicking anyway",
-            )
-        }
         button.click()
     }
+
+    private fun findAllowAllButton(): UiObject2? =
+        findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_all_button"))
+            ?: findDialogObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_button"))
+            ?: findDialogObject(By.textContains("Allow all"))
+            ?: findDialogObject(By.text(Pattern.compile("Allow.*", Pattern.CASE_INSENSITIVE)))
+
+    /**
+     * Non-blocking counterpart to [findAllowAllButton], used by the retry poll in
+     * [setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances]: an immediate lookup (no
+     * `device.wait()`) so a poll tick that finds nothing returns quickly instead of blocking for
+     * up to [DIALOG_TIMEOUT_MS] per selector, which would stack badly inside a 100 ms poll loop.
+     * `null` here means the dialog has already dismissed (the previous tap likely succeeded and
+     * the grant is just propagating), not that it never appeared in the first place.
+     */
+    private fun findAllowAllButtonNow(): UiObject2? =
+        device.findObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_all_button"))
+            ?: device.findObject(By.res(PERMISSION_CONTROLLER_PKG, "permission_allow_button"))
+            ?: device.findObject(By.textContains("Allow all"))
+            ?: device.findObject(By.text(Pattern.compile("Allow.*", Pattern.CASE_INSENSITIVE)))
 
     private fun findDialogObject(selector: BySelector): UiObject2? = device.wait(Until.findObject(selector), DIALOG_TIMEOUT_MS)
 
@@ -219,11 +234,6 @@ class SetupActivityPermissionDialogE2ETest {
         // The window-content-change event alone arrives too early to fix the flake on its own
         // (issue #581); this is just its own find-the-window budget, not expected to be load-bearing.
         const val WINDOW_UPDATE_TIMEOUT_MS = 5_000L
-
-        // Generous relative to the diagnostic sleeps/polls this replaced (issue #581): if the
-        // button genuinely never reports enabled within this budget, that is itself the
-        // interesting result, not a timeout to tighten.
-        const val BUTTON_ENABLED_TIMEOUT_MS = 45_000L
 
         // Widened from 10 s to 20 s (issue #604): this suite gained a `screenrecord` process for
         // the first time in issue #604 (see build.yml's "Run SetupActivityPermissionDialogE2ETest"


### PR DESCRIPTION
## Summary

`SetupActivityPermissionDialogE2ETest#setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances` has been flaky since 2026-07-04 (issue #581), quarantined via the allowlist since PR #639. The failure was always the same assertion: `hasMediaPermission()` never becomes true after tapping "Allow all" in the real system permission dialog.

Several theories were tested and ruled out on real CI runs before finding the actual cause:
- **Window-focus-transfer race**: ruled out. A `dumpsys window` poll showed `GrantPermissionsActivity` takes input focus in under 1 second.
- **Button not yet enabled** (a tapjacking-style defense theory): ruled out. `UiObject2.isEnabled()` reported the button enabled after about 100ms, and the tap still silently failed.
- **Root cause, confirmed against AOSP source**: the permission dialog's buttons are `SecureButton`, which silently drops any touch the system's input dispatcher flags `FLAG_WINDOW_IS_OBSCURED`/`FLAG_WINDOW_IS_PARTIALLY_OBSCURED`, with no exception and no log. `SecureButton` has no self-timer of its own, so this is a real, transient dispatcher condition, not a fixed delay that can be waited out.

## Change

Retry the tap when the grant-poll finds it hasn't landed and the button is still visible (meaning the previous tap didn't register). If the button has disappeared, the previous tap succeeded and the grant is simply propagating asynchronously (the pre-existing, documented issue #604 case), so there is nothing to retry.

Confirmed on a real CI run: logcat shows a genuine `Grant not yet registered; retrying "Allow all" tap (attempt 2)` line, immediately followed by a pass.

Also in this PR:
- Removes the now-unneeded allowlist entry for this test in `.github/allowed-test-failures.txt`.
- Confirms and reorders `PartialAccessPhotoPickerE2ETest`'s "Select photos and videos" selector against current AOSP `PermissionController` source (`permission_allow_selected_button`), dropping two resource ids that never existed in that source and always failed over.
- The commit history documents the full investigation trail (each ruled-out theory tested live on CI before moving to the next).

## Test plan

- [x] CI run 29177827342: the retry loop caught and recovered from a live drop (logcat line above); `SetupActivityPermissionDialogE2ETest` and `PartialAccessPhotoPickerE2ETest` both passed.
- [x] CI run 29179684676 (commit 2b14b6b, allowlist entry removed): Clear, no failures.
- Not manually verified on a device/emulator: this dev environment has no Android SDK/emulator available.