### PR TITLE
Pin scripts/requirements.txt to currently resolved versions

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-defusedxml
-requests
-PyYAML
+defusedxml==0.7.1
+requests==2.34.2
+PyYAML==6.0.3


### PR DESCRIPTION
## Summary

- `scripts/requirements.txt` listed `defusedxml`, `requests`, and `PyYAML` with no version specifiers, so `pip install -r scripts/requirements.txt` (run in CI in `build.yml`) floats to whatever is newest at install time.
- Pins each to the version pip currently resolves: `defusedxml==0.7.1`, `requests==2.34.2`, `PyYAML==6.0.3`.

## Test plan

- [x] Verified `pip install -r scripts/requirements.txt` succeeds cleanly in a fresh virtualenv with the pinned versions.

