### PR TITLE
Bump strip-session-bylines to actions/checkout@v6

### DIFF
--- a/.github/workflows/strip-session-bylines.yml
+++ b/.github/workflows/strip-session-bylines.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.actor != 'github-actions[bot]'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Strip session-URL bylines
         env:


### PR DESCRIPTION
## Summary

- Every other workflow in `.github/workflows/` pins `actions/checkout@v6`; `strip-session-bylines.yml` was left on `actions/checkout@v4`.
- Bumps it to `v6` for consistency across workflows.

## Test plan

- [ ] Confirm the `Strip Claude session-URL bylines` workflow still runs successfully on the next triggering event (issue/PR opened or edited).

