### PR TITLE
Pin third-party CI/pre-commit deps to commit SHAs; require SHA pinning in code_edit.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Set up Android SDK
         if: steps.diff_check.outputs.needs_full_build == 'true'
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Enable KVM
         if: steps.diff_check.outputs.needs_full_build == 'true'
@@ -1403,7 +1403,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Cache Gradle packages
         uses: actions/cache@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Cache Gradle packages
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Cache Gradle packages
         uses: actions/cache@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,14 +10,14 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: f0b5944bef86f50d875305821a0ab0d8c601e465 # v0.8.4
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.14.0
+    rev: da711fa8b30421506086eb2dc7ea0a6c3cb27b9f # v0.14.0
     hooks:
       - id: markdownlint-cli2
 

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -14,9 +14,9 @@
 
 ## Dependency versions
 
-- Every dependency version must be pinned (exact version or commit SHA; never a range, a tag, or an unpinned "latest"). A tag is not a valid pin: unlike a commit SHA, a tag can be moved to point at a different commit after the fact, so it is not truly immutable.
-- Pin to a recent version, not an old one you happen to already know; check what is current before picking a version.
-- Always pin the latest patch build of whichever minor/major version you choose.
+- This section applies to third-party dependencies: anything not published directly by GitHub itself (the `actions/` and `github/` GitHub Actions namespaces are first-party and exempt). It covers third-party GitHub Actions (for example `android-actions/setup-android`, `softprops/action-gh-release`) and pre-commit hook repos (for example `astral-sh/ruff-pre-commit`), regardless of how well-known or trusted the publisher is.
+- Every such dependency version must be pinned to a commit SHA (never a range, a tag, or an unpinned "latest"). A tag is not a valid pin; unlike a commit SHA, a tag can be moved to point at a different commit after the fact, so it is not truly immutable.
+- When you newly introduce or update a pin, pin to a recent version, not an old one you happen to already know. Check what is current before picking a version, and pin the latest patch build of whichever minor/major version you choose. This does not obligate you to bump every existing pin in a file just because you touched it; only the ones you are adding or intentionally updating.
 
 ## Test coverage
 

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -12,6 +12,12 @@
   - **Do not** organize your commits by file rather than by concern (e.g. "all changes to Foo.kt in one commit, Bar.kt in another").
 - When you refactor existing code, **always** commit the pure refactoring (which does not change behavior or output) separately. **Do not** combine that refactoring with a change in functionality or behavior.
 
+## Dependency versions
+
+- Every dependency version must be pinned (exact version, tag, or commit SHA; never a range or an unpinned "latest").
+- Pin to a recent version, not an old one you happen to already know; check what is current before picking a version.
+- Always pin the latest patch build of whichever minor/major version you choose.
+
 ## Test coverage
 
 - New behavior must be accompanied by automated tests.

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -14,7 +14,7 @@
 
 ## Dependency versions
 
-- Every dependency version must be pinned (exact version, tag, or commit SHA; never a range or an unpinned "latest").
+- Every dependency version must be pinned (exact version or commit SHA; never a range, a tag, or an unpinned "latest"). A tag is not a valid pin: unlike a commit SHA, a tag can be moved to point at a different commit after the fact, so it is not truly immutable.
 - Pin to a recent version, not an old one you happen to already know; check what is current before picking a version.
 - Always pin the latest patch build of whichever minor/major version you choose.
 

--- a/agents/code_edit.md
+++ b/agents/code_edit.md
@@ -17,6 +17,7 @@
 - This section applies to third-party dependencies: anything not published directly by GitHub itself (the `actions/` and `github/` GitHub Actions namespaces are first-party and exempt). It covers third-party GitHub Actions (for example `android-actions/setup-android`, `softprops/action-gh-release`) and pre-commit hook repos (for example `astral-sh/ruff-pre-commit`), regardless of how well-known or trusted the publisher is.
 - Every such dependency version must be pinned to a commit SHA (never a range, a tag, or an unpinned "latest"). A tag is not a valid pin; unlike a commit SHA, a tag can be moved to point at a different commit after the fact, so it is not truly immutable.
 - When you newly introduce or update a pin, pin to a recent version, not an old one you happen to already know. Check what is current before picking a version, and pin the latest patch build of whichever minor/major version you choose. This does not obligate you to bump every existing pin in a file just because you touched it; only the ones you are adding or intentionally updating.
+- Converting an existing pin from a tag to the equivalent commit SHA, without changing which version it points to, is not itself an "update" for this purpose. Only pin an unfamiliar or newer version when you are intentionally changing which version is used.
 
 ## Test coverage
 


### PR DESCRIPTION
## Summary

- `android-actions/setup-android` is a third-party action (not GitHub- or Microsoft-authored) and was pinned only to the `v4` tag in all four places it's used (`build.yml` x2, `codeql.yml`, `release.yml`), unlike `softprops/action-gh-release`, the repo's other third-party action, which is already pinned to a full commit SHA.
- Resolves `v4` to its current commit (`40fd30fb8d7440372e1316f5d1809ec01dcd3699`) and pins each usage there, with a trailing `# v4` comment matching the existing `softprops/action-gh-release` style.
- Adds a "Dependency versions" section to `agents/code_edit.md` requiring dependency versions be pinned to a commit SHA, to a recent version, with the latest patch build. Explicitly drops "tag" as a valid pin and explains why: a tag can be repointed to a different commit after the fact, so it isn't truly immutable.
- Applies the same fix to `.pre-commit-config.yaml`: the three hosted hook repos (`pre-commit-hooks`, `ruff-pre-commit`, `markdownlint-cli2`) were pinned by tag (`rev: vX.Y.Z`); resolved each to its commit SHA, keeping the version as a trailing comment.

## Test plan

- [ ] Confirm CI (build, codeql, release workflows) runs successfully against the pinned SHA.
- [x] Verified `pre-commit run` resolves and installs each hook correctly from its pinned SHA.
