### PR TITLE
Pin ktlint download to an exact version; fail loudly on error

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -163,9 +163,6 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]] \
 fi
 
 # STEP 3a: ktlint binary.
-# Pinned to an exact release (not releases/latest): an unpinned URL means a
-# fresh install can silently pick up a different ktlint version than the one
-# this project was last verified against (issue #667).
 KTLINT_VERSION="1.8.0"
 KTLINT_BIN="$LOCAL_BIN/ktlint"
 if [[ -x "$KTLINT_BIN" ]]; then

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -163,13 +163,19 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]] \
 fi
 
 # STEP 3a: ktlint binary.
+# Pinned to an exact release (not releases/latest): an unpinned URL means a
+# fresh install can silently pick up a different ktlint version than the one
+# this project was last verified against (issue #667).
+KTLINT_VERSION="1.8.0"
 KTLINT_BIN="$LOCAL_BIN/ktlint"
 if [[ -x "$KTLINT_BIN" ]]; then
     echo "[session-start] Step 3a: ktlint present--skip"
 else
-    echo "[session-start] Step 3a: installing ktlint..."
-    curl -sSL \
-        https://github.com/pinterest/ktlint/releases/latest/download/ktlint \
+    echo "[session-start] Step 3a: installing ktlint $KTLINT_VERSION..."
+    # -f: fail on an HTTP error status instead of writing the error response
+    # body to $KTLINT_BIN as if it were the binary (issue #667).
+    curl -fsSL \
+        "https://github.com/pinterest/ktlint/releases/download/$KTLINT_VERSION/ktlint" \
         -o "$KTLINT_BIN"
     chmod +x "$KTLINT_BIN"
     echo "[session-start] Step 3a: ktlint installed"


### PR DESCRIPTION
## Summary

Tourniquet for #667, not a fix for the underlying concern raised there.

- `.claude/hooks/session-start.sh` installed `ktlint` from `releases/latest/download/ktlint` with plain `curl -sSL`. In a session where that repository is outside the sandbox's authorized scope, the request 403s and `curl -sSL` silently wrote the JSON error body to `$KTLINT_BIN` as if it were the binary. `chmod +x` succeeded and the bootstrap reported success; the corruption only surfaced later as an opaque `Exec format error` when the pre-commit `ktlint` hook tried to run it.
- Pins the download to an exact released version (`1.8.0`) instead of `releases/latest`.
- Switches to `curl -f` so a failed/blocked download now aborts the hook loudly instead of writing a corrupted file that fails mysteriously downstream.

This does not address #667's actual ask: the bootstrap still fetches and executes a third-party binary over the network at every session without any verification. See #667 for that.

## Test plan

- [x] Verified `bash -n` on the modified script.
- [x] Verified `curl -f` against the pinned URL exits non-zero and writes nothing (rather than a corrupted file) when the request is blocked.
- [ ] Confirm a full session-start run installs `ktlint` successfully in an environment where the download is not blocked.

