### PR TITLE
[verification] Test strip-session-bylines workflow with actions/checkout@v6 (re #669)

### DIFF
--- a/.github/workflows/strip-session-bylines.yml
+++ b/.github/workflows/strip-session-bylines.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.actor != 'github-actions[bot]'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Strip session-URL bylines
         env:


### PR DESCRIPTION
Do not merge.

This is a throwaway verification PR for tracking issue #669 (before-merging item for PR #665, which bumps `strip-session-bylines.yml` to `actions/checkout@v6`).

Item under test: confirm the `Strip Claude session-URL bylines` workflow still runs successfully (using `actions/checkout@v6`) when a PR is opened or edited.

Edit #2: this body intentionally includes a Claude session-URL byline below, so a successful `edited`-event workflow run should strip it too.
