### PR TITLE
Replace markdownlint-cli2 with mdformat for Markdown formatting

### DIFF
--- a/.claude/agents/deep-planner.md
+++ b/.claude/agents/deep-planner.md
@@ -7,18 +7,30 @@ description: Use for designing implementation plans and working through hard arc
 
 You are a software architect producing implementation plans.
 
-Your job is to think through the problem deeply and return a clear, actionable plan, not to carry out the implementation.
-Favor thorough reasoning about trade-offs, edge cases, and failure modes over speed.
+Your job is to think through the problem deeply and return a clear,
+actionable plan,
+not to carry out the implementation.
+Favor thorough reasoning about trade-offs,
+edge cases, and failure modes over speed.
 
-Before finalization, check for opportunities to simplify.
+Before finalization,
+check for opportunities to simplify.
 
 When you produce a plan:
 
 - State the goal and any assumptions or constraints you are working under.
-- Lay out the steps in order, each concrete enough to act on without further design decisions.
-- Identify the critical files, modules, or interfaces involved, and how they interact.
-- Call out trade-offs, alternatives you considered and rejected (with reasons), risks, and anything that needs a decision from the requester.
+- Lay out the steps in order,
+  each concrete enough to act on without further design decisions.
+- Identify the critical files,
+  modules,
+  or interfaces involved,
+  and how they interact.
+- Call out trade-offs,
+  alternatives you considered and rejected (with reasons),
+  risks,
+  and anything that needs a decision from the requester.
 - Note how the change should be tested or verified.
 
 Explore the codebase as needed to ground the plan in what actually exists.
-If the request is ambiguous in a way that changes the plan, surface the ambiguity and the options rather than guessing.
+If the request is ambiguous in a way that changes the plan,
+surface the ambiguity and the options rather than guessing.

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -45,7 +45,7 @@ by the container; never hard-code them.
 
 ## Linting and formatting
 
-The `SessionStart` hook installs and wires up the linting stack automatically (steps 3a-3c).
+The `SessionStart` hook installs and wires up the linting stack automatically (steps 3a-3d).
 No manual setup is needed.
 
 ### Tools installed at session start
@@ -53,8 +53,9 @@ No manual setup is needed.
 | Tool | Step | Location | Purpose |
 |------|------|----------|---------|
 | `ktlint` | 3a | `~/.local/bin/ktlint` | Kotlin formatting and style (official Kotlin style guide) |
-| `pre-commit` | 3b | `~/.local/bin/pre-commit` | Hook framework; manages ruff, markdownlint, and ktlint |
+| `pre-commit` | 3b | `~/.local/bin/pre-commit` | Hook framework; manages ruff, mdformat, and ktlint |
 | git hook | 3c | `.git/hooks/pre-commit` | Runs all hooks automatically on every `git commit` |
+| `mdformat` | 3d | `~/.local/bin/mdformat` | Markdown prose formatting (sentence wrap via `mdformat-sentencebreak`; see `.pre-commit-config.yaml`) |
 | hook envs | -- | `~/.cache/pre-commit/` | Populated on first commit (not pre-warmed at startup) |
 
 ### Hooks configured in `.pre-commit-config.yaml`
@@ -69,7 +70,7 @@ No manual setup is needed.
 | check-added-large-files | all | blocks large binary commits |
 | ruff | `*.py` | lint + auto-fix (E, F rules) |
 | ruff-format | `*.py` | format |
-| markdownlint-cli2 | `*.md` | lint; MD013 (line length) disabled via `.markdownlint.yaml` |
+| mdformat | `*.md`, `*.markdown` | format; sentence wrap plus frontmatter/table support, auto-corrects in place (a fixed list of files is excluded; see `.pre-commit-config.yaml`) |
 | ktlint | `*.kt`, `*.kts` | format; auto-corrects in place |
 
 When a hook modifies a file, the agent did not cause that change--

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -201,6 +201,37 @@ else
     echo "[session-start] Step 3c: pre-commit hook wired"
 fi
 
+# STEP 3d: mdformat + plugins (Markdown formatter).
+# Same --force-reinstall rationale as pre-commit above: PATH may not yet
+# include $LOCAL_BIN, and pip skips reinstalling the entrypoint script when
+# the package dist-info already exists. Appended after the existing steps
+# rather than inserted before pre-commit, so this doesn't renumber steps
+# 3b/3c that might be referenced by name elsewhere.
+#
+# mdformat is pinned to 0.7.22, not the current 1.0.0: mdformat-sentencebreak
+# (the sentence-wrap plugin; see .pre-commit-config.yaml) requires
+# `mdformat>=0.7.16,<0.8.0` and has had no release since 2022, so this repo
+# cannot move to mdformat 1.0.0 without dropping that plugin. mdformat-tables
+# and mdformat-frontmatter are both required too: without them, core mdformat
+# (CommonMark only) mangles GFM pipe tables and destroys YAML frontmatter
+# (confirmed: it re-parses frontmatter as a thematic break plus a regular
+# paragraph, escaping asterisks inside it). See the PR's Known limitations
+# for the full story, including a mdformat-sentencebreak bug this repo works
+# around by excluding a specific list of files from the hook.
+MDFORMAT_VERSION="0.7.22"
+MDFORMAT_BIN="$LOCAL_BIN/mdformat"
+if [[ -x "$MDFORMAT_BIN" ]]; then
+    echo "[session-start] Step 3d: mdformat present--skip"
+else
+    echo "[session-start] Step 3d: installing mdformat $MDFORMAT_VERSION + plugins..."
+    pip install --user --force-reinstall --quiet \
+        "mdformat==$MDFORMAT_VERSION" \
+        "mdformat-sentencebreak==0.4.0" \
+        "mdformat-frontmatter==2.1.2" \
+        "mdformat-tables==1.0.0"
+    echo "[session-start] Step 3d: mdformat installed"
+fi
+
 # ───────────────────────────────────────────────────────────────────────────────
 # STEP 4: Fetch remote refs.
 #

--- a/.claude/rules/prose-style.md
+++ b/.claude/rules/prose-style.md
@@ -4,26 +4,38 @@ paths:
   - "**/*.{kt,java,sh,py}"
   - "**/*.*"
 ---
+
 # Prose style and typographical standards
 
-The following rules apply to prose in documents, code comments, and text output.
+The following rules apply to prose in documents,
+code comments, and text output.
 
 ## Word wrap in Markdown, etc
 
 Split prose at sentence breaks.
 This balances line-diff stability with moderate line lengths.
 
-This rule applies only when word wrap is a matter of preference or style, such as in Markdown and other auto-flowed source text.
+This rule applies only when word wrap is a matter of preference or style,
+such as in Markdown and other auto-flowed source text.
 
 ## Avoid angle quote, em-dash, and ellipsis characters
 
-Prefer widely compatible characters, such as those in ASCII, when the option exists.
+Prefer widely compatible characters,
+such as those in ASCII,
+when the option exists.
 
-Since this rule refers only to prose, characters chosen for their specific meaning in code or markup (such as pairs of back-ticks) are exempt.
+Since this rule refers only to prose,
+characters chosen for their specific meaning in code or markup (such as pairs of back-ticks) are exempt.
 
-- Replace dashes with commas, semicolons, or parentheses when grammatically possible, and double-hyphens otherwise.
+- Replace dashes with commas,
+  semicolons,
+  or parentheses when grammatically possible,
+  and double-hyphens otherwise.
 - Replace ellipses with triple periods.
-- Replace angled, directional, or smart quotes (single quote or double quote) with straight quote characters.
+- Replace angled,
+  directional,
+  or smart quotes (single quote or double quote)
+  with straight quote characters.
 
 ## Do not surround dashes or double-hyphens with spaces
 

--- a/.claude/rules/yaml-action-reminders.md
+++ b/.claude/rules/yaml-action-reminders.md
@@ -2,12 +2,16 @@
 paths:
   - "**/*.{yaml,yml}"
 ---
+
 # GitHub Actions version reminders
 
-When editing YAML files, keep these priorities in mind:
+When editing YAML files,
+keep these priorities in mind:
 
 1. Be consistent with Action versions across this project.
    Match the versions used by other workflows and *particularly* this same workflow.
-2. If introducing an Action to this project, start with the current version (not just the most recent version you're aware of).
+2. If introducing an Action to this project,
+   start with the current version (not just the most recent version you're aware of).
 3. Avoid using Actions developed by third-parties (not GitHub or Microsoft).
-   This isn't a hard rule, but prefer writing your own action script if it's not complex.
+   This isn't a hard rule,
+   but prefer writing your own action script if it's not complex.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,0 @@
-# MD013: line length -- disabled because URLs and code spans can exceed any reasonable limit.
-MD013: false
-# MD026: trailing punctuation in headings -- disabled; documentation-style headings ending with '.' are intentional.
-MD026: false
-# MD032: blanks around lists -- disabled; tight list formatting is the prevailing style in this project.
-MD032: false
-# MD041: first line heading -- disabled; CLAUDE.md files open with include directives, not headings.
-MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: da711fa8b30421506086eb2dc7ea0a6c3cb27b9f # v0.14.0
-    hooks:
-      - id: markdownlint-cli2
-
   - repo: local
     hooks:
       - id: ktlint
@@ -29,3 +24,42 @@ repos:
         entry: ktlint
         args: [--format]
         files: '\.(kt|kts)$'
+      - id: mdformat
+        name: mdformat
+        language: system
+        entry: mdformat
+        # --wrap keep (the default) is the only wrap mode compatible with the
+        # mdformat-sentencebreak plugin below; --wrap no or --wrap <N> crash
+        # it with "AssertionError: null bytes should be removed by now"
+        # (confirmed against mdformat 0.7.22 / mdformat-sentencebreak 0.4.0).
+        # --number keeps ordered-list numbering sequential (1, 2, 3, ...)
+        # instead of mdformat's own default of repeating "1." for every item.
+        # Extensions (frontmatter, tables, sentencebreak) are picked up
+        # automatically from whatever is pip-installed; see
+        # .claude/hooks/session-start.sh and .claude/environment.md.
+        args: [--wrap, keep, --number]
+        files: '\.(md|markdown)$'
+        # These files trip a reproducible mdformat-sentencebreak bug: any
+        # inline code span containing a period (e.g. `.claude/hooks/foo.sh`,
+        # `pr_creation.md`) gets split in half mid-token whenever nearby
+        # prose is long enough to trigger a wrap point, corrupting the code
+        # span and failing mdformat's own render round-trip check. See the
+        # PR's Known limitations for the minimal repro; no workaround exists
+        # in the plugin's config (its break regexes are hardcoded, not
+        # configurable), so these files are excluded rather than corrupted.
+        exclude: >
+          (?x)^(
+            agents/inaugurate\.md|
+            agents/pr_participation\.md|
+            agents/code_edit\.md|
+            agents/verification_planning\.md|
+            agents/pr_verify\.md|
+            agents/dev_orchestration\.md|
+            agents/pr_creation\.md|
+            \.github/workflows/CLAUDE\.md|
+            SPEC\.md|
+            scripts/ci_monitor/README\.md|
+            \.claude/agents/NOTES\.md|
+            \.claude/environment\.md|
+            \.claude/rules/github-mcp-authenticate\.md
+          )$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,19 @@
 # Instructions for agents
 
-- If addressing a GitHub issue or PR without a specific assigned role, read `./agents/dev_orchestration.md`.
-- If participating in a PR or review (as Author, Reviewer, or Orchestrator), read `./agents/pr_participation.md`.
-- If creating a PR, read `./agents/pr_creation.md`.
-- If editing code, read `./agents/code_edit.md`.
-- If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
-- If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
-- If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.
+- If addressing a GitHub issue or PR without a specific assigned role,
+  read `./agents/dev_orchestration.md`.
+- If participating in a PR or review (as Author,
+  Reviewer,
+  or Orchestrator),
+  read `./agents/pr_participation.md`.
+- If creating a PR,
+  read `./agents/pr_creation.md`.
+- If editing code,
+  read `./agents/code_edit.md`.
+- If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo),
+  or planning automation of such steps,
+  read `./agents/verification_planning.md`.
+- If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent),
+  read `./agents/pr_verify.md`.
+- If a sub-agent that is delegating work to nested sub-agents via the Agent tool,
+  read `./agents/subagent_delegation.md`.

--- a/agents/subagent_delegation.md
+++ b/agents/subagent_delegation.md
@@ -3,10 +3,14 @@
 If you are a sub-agent dispatching a nested sub-agent via the Agent tool, follow these rules:
 
 - **Use foreground (the default) when you need the results in the same turn.**
-  Do not set `run_in_background: true` for any sub-agent whose findings you will act on before returning.
-  Launching a sub-agent with `run_in_background: true` may force your turn to end before sub-agent results are available.
-  The Agent tool blocks until the sub-agent completes, so the results are available when the call returns.
-  A foreground sub-agent blocks the Agent tool call; you cannot exit before it finishes.
+  Do not set `run_in_background:
+  true` for any sub-agent whose findings you will act on before returning.
+  Launching a sub-agent with `run_in_background:
+  true` may force your turn to end before sub-agent results are available.
+  The Agent tool blocks until the sub-agent completes,
+  so the results are available when the call returns.
+  A foreground sub-agent blocks the Agent tool call;
+  you cannot exit before it finishes.
   The result is returned to you when the call returns--consume or record it, then exit.
 - **Use `run_in_background: true` only for fire-and-forget work whose results are not needed in the current turn.**
   If you are unsure whether you will need the results, use foreground.

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -6,23 +6,27 @@
 ## Purpose
 
 Route tasks to the right model tier.
-Score the six dimensions below, sum them, and map to a tier.
-Apply separately for the Author (implementation) and the Reviewer (code review), using the adjustments in the Reviewer section.
+Score the six dimensions below,
+sum them, and map to a tier.
+Apply separately for the Author (implementation)
+and the Reviewer (code review),
+using the adjustments in the Reviewer section.
 
 ## Dimensions
 
-| Dimension | 1: Low | 2: Medium | 3: High |
-|-----------|---------|------------|----------|
-| **Task type** | Boilerplate, formatting, simple config edit | Standard feature, bug fix, refactor | Architecture, novel algorithm, system design |
-| **Ambiguity** | Fully specified, clear acceptance criteria | Some interpretation needed | Underspecified, requires judgment or design |
-| **Context breadth** | Single file / self-contained | A few related files | Cross-cutting; large-codebase awareness needed |
-| **Domain depth** | Generic code or prose | Moderate domain knowledge | Specialized (GitHub Actions internals, Android build system, security, etc.) |
-| **Reasoning chain** | Single step, pattern match | Multi-step, some tradeoffs | Long chain, competing concerns, novel reasoning |
-| **Investigation** | Approach clear from the issue; at most a standard docs lookup | Some unknowns, resolvable via code inspection or documentation | Requires empirical investigation: undocumented API behavior, platform quirks that must be tested to understand |
+| Dimension           | 1: Low                                                        | 2: Medium                                                      | 3: High                                                                                                        |
+| ------------------- | ------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Task type**       | Boilerplate, formatting, simple config edit                   | Standard feature, bug fix, refactor                            | Architecture, novel algorithm, system design                                                                   |
+| **Ambiguity**       | Fully specified, clear acceptance criteria                    | Some interpretation needed                                     | Underspecified, requires judgment or design                                                                    |
+| **Context breadth** | Single file / self-contained                                  | A few related files                                            | Cross-cutting; large-codebase awareness needed                                                                 |
+| **Domain depth**    | Generic code or prose                                         | Moderate domain knowledge                                      | Specialized (GitHub Actions internals, Android build system, security, etc.)                                   |
+| **Reasoning chain** | Single step, pattern match                                    | Multi-step, some tradeoffs                                     | Long chain, competing concerns, novel reasoning                                                                |
+| **Investigation**   | Approach clear from the issue; at most a standard docs lookup | Some unknowns, resolvable via code inspection or documentation | Requires empirical investigation: undocumented API behavior, platform quirks that must be tested to understand |
 
 ## Author leveling
 
-Score **context breadth** on what a thorough resolution requires, not just the files named in the issue.
+Score **context breadth** on what a thorough resolution requires,
+not just the files named in the issue.
 
 ## Reviewer leveling
 
@@ -35,67 +39,108 @@ Same dimensions and tier ranges, with:
 
 ## Scoring → tier
 
-| Total | Tier | Model |
-|-------|------|-------|
-| 6-8 | 1 | Haiku |
-| 9-13 | 2 | Sonnet |
-| 14-18 | 3 | Opus |
+| Total | Tier | Model  |
+| ----- | ---- | ------ |
+| 6-8   | 1    | Haiku  |
+| 9-13  | 2    | Sonnet |
+| 14-18 | 3    | Opus   |
 
 ## GitHub labels
 
-| Model | Author | Reviewer |
-|------|--------|----------|
-| Haiku | `c-a-haiku` | `c-r-haiku` |
+| Model  | Author       | Reviewer     |
+| ------ | ------------ | ------------ |
+| Haiku  | `c-a-haiku`  | `c-r-haiku`  |
 | Sonnet | `c-a-sonnet` | `c-r-sonnet` |
-| Opus | `c-a-opus` | `c-r-opus` |
+| Opus   | `c-a-opus`   | `c-r-opus`   |
 
 ## General notes
 
-- Build system and CI configuration files (Makefiles, Dockerfiles, workflow YAMLs, Gradle scripts, etc.) should score **domain depth ≥ 2**; these systems have undocumented interactions and hidden complexity that is easy to underestimate.
-- Tasks limited to editing plain text or documents (policies, instructions, docs) with exact content provided typically score **6** (all 1s): Haiku territory.
+- Build system and CI configuration files (Makefiles,
+  Dockerfiles,
+  workflow YAMLs,
+  Gradle scripts,
+  etc.) should score **domain depth ≥ 2**;
+  these systems have undocumented interactions and hidden complexity that is easy to underestimate.
+- Tasks limited to editing plain text or documents (policies,
+  instructions,
+  docs)
+  with exact content provided typically score **6** (all 1s): Haiku territory.
 
 ## Calibration examples
 
-Scores are listed as: task type / ambiguity / context / domain / reasoning / investigation.
+Scores are listed as:
+task type / ambiguity / context / domain / reasoning / investigation.
 
 ### Tier 1: Haiku (6-8)
 
 **#254 / PR #269: Add reviewer rule: don't mention bylines** (Author: 6, Reviewer: 6)
-Single `agents/` file, exact wording provided, no reasoning required.
-Author: 1 / 1 / 1 / 1 / 1 / 1; Reviewer: 1 / 1 / 1 / 1 / 1 / 1
+Single `agents/` file,
+exact wording provided,
+no reasoning required.
+Author:
+1 / 1 / 1 / 1 / 1 / 1;
+Reviewer: 1 / 1 / 1 / 1 / 1 / 1
 
 **#250 / PR #251: Make `requests` import hard** (Author: 6, Reviewer: 6)
-Remove a soft-import guard in one Python file; change fully specified.
-Author: 1 / 1 / 1 / 1 / 1 / 1; Reviewer: 1 / 1 / 1 / 1 / 1 / 1
+Remove a soft-import guard in one Python file;
+change fully specified.
+Author:
+1 / 1 / 1 / 1 / 1 / 1;
+Reviewer: 1 / 1 / 1 / 1 / 1 / 1
 
 **#246 / PR #247: Re-open closed issues when CI detects recurrence** (Author: 8, Reviewer: 7)
-Two-step Python change (search API + reopen call) but fully specified and self-contained.
-Author: 2 / 1 / 1 / 1 / 2 / 1; Reviewer: 2 / 1 / 1 / 1 / 1 / 1 (investigation drops; reasoning is lighter once the code is written)
+Two-step Python change (search API + reopen call)
+but fully specified and self-contained.
+Author: 2 / 1 / 1 / 1 / 2 / 1;
+Reviewer:
+2 / 1 / 1 / 1 / 1 / 1 (investigation drops;
+reasoning is lighter once the code is written)
 
 ### Tier 2: Sonnet (9-13)
 
-**#237 / PR #238: Auto-filed issue format fixes** (Author: 9, Reviewer: 8 → Haiku)
-Four sub-tasks across a Python script and a workflow YAML, but each is well-specified.
+**#237 / PR #238: Auto-filed issue format fixes** (Author:
+9, Reviewer: 8 → Haiku)
+Four sub-tasks across a Python script and a workflow YAML,
+but each is well-specified.
 Reviewer score of 8 is at the floor (Author tier − 1), so Haiku applies.
-Author: 2 / 1 / 2 / 1 / 2 / 1; Reviewer: 2 / 1 / 2 / 1 / 1 / 1
+Author:
+2 / 1 / 2 / 1 / 2 / 1;
+Reviewer: 2 / 1 / 2 / 1 / 1 / 1
 
 **#257 / PR #262: Emit per-test markers in Gradle** (Author: 10, Reviewer: 10)
-New Gradle test listener + E2E marker emission; requires Kotlin DSL knowledge.
+New Gradle test listener + E2E marker emission;
+requires Kotlin DSL knowledge.
 Reviewer needs equal domain depth to evaluate correctness of the listener hook and JSON escaping.
-Author: 2 / 1 / 2 / 2 / 2 / 1; Reviewer: 2 / 1 / 2 / 2 / 2 / 1
+Author:
+2 / 1 / 2 / 2 / 2 / 1;
+Reviewer: 2 / 1 / 2 / 2 / 2 / 1
 
 **#225 / PR #226: Issue filer workflow not triggered** (Author: 11, Reviewer: 10)
-Root cause diagnosis required; involves `workflow_run` trigger semantics and permission model.
-Author: 2 / 2 / 2 / 2 / 2 / 1; Reviewer: 2 / 1 / 2 / 2 / 2 / 1 (ambiguity drops once implementation is written)
+Root cause diagnosis required;
+involves `workflow_run` trigger semantics and permission model.
+Author:
+2 / 2 / 2 / 2 / 2 / 1;
+Reviewer:
+2 / 1 / 2 / 2 / 2 / 1 (ambiguity drops once implementation is written)
 
 ### Tier 3: Opus (14-18)
 
 **#258 / PR #271: Stream per-test CI signals + extract monitor script** (Author: 17, Reviewer: 14)
-Two new parser systems, shell test infrastructure, cross-cutting changes; required empirical testing of partial-log API availability.
-Investigation drops from 3 to 2 for review; reasoning chain also lighter.
-Author: 3 / 2 / 3 / 3 / 3 / 3; Reviewer: 3 / 2 / 3 / 3 / 2 / 2
+Two new parser systems,
+shell test infrastructure,
+cross-cutting changes;
+required empirical testing of partial-log API availability.
+Investigation drops from 3 to 2 for review;
+reasoning chain also lighter.
+Author:
+3 / 2 / 3 / 3 / 3 / 3;
+Reviewer: 3 / 2 / 3 / 3 / 2 / 2
 
 **#236: CI monitor should surface failing tests (design)** (Author: 18, Reviewer: 16)
-Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
+Full system design with competing approaches;
+undocumented API behavior;
+5-file implementation plan.
 Investigation and ambiguity both drop for review.
-Author: 3 / 3 / 3 / 3 / 3 / 3; Reviewer: 3 / 2 / 3 / 3 / 3 / 2
+Author:
+3 / 3 / 3 / 3 / 3 / 3;
+Reviewer: 3 / 2 / 3 / 3 / 3 / 2

--- a/scripts/ci_monitor/CLAUDE.md
+++ b/scripts/ci_monitor/CLAUDE.md
@@ -1,2 +1,3 @@
 <!-- This file simply @ includes README.md. -->
+
 @README.md


### PR DESCRIPTION
## Markdown-lint options compared

This grid compares the four Markdown-lint candidates evaluated in this bake-off; each cell links to the GitHub diff between the two branches.

| | f | p | r | m |
|---:|---|---|---|---|
| [Flowmark](https://github.com/aunger/gallery-button-for-pixel-camera/pull/677) **f** | | [f : p](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/flowmark-markdown-formatter...claude/panache-markdown-formatter) | [f : r](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/flowmark-markdown-formatter...claude/rumdl-markdown-formatter) | [f : m](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/flowmark-markdown-formatter...claude/mdformat-markdown-formatter) |
| [Panache](https://github.com/aunger/gallery-button-for-pixel-camera/pull/678) **p** | [p : f](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/panache-markdown-formatter...claude/flowmark-markdown-formatter) | | [p : r](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/panache-markdown-formatter...claude/rumdl-markdown-formatter) | [p : m](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/panache-markdown-formatter...claude/mdformat-markdown-formatter) |
| [rumdl](https://github.com/aunger/gallery-button-for-pixel-camera/pull/679) **r** | [r : f](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/rumdl-markdown-formatter...claude/flowmark-markdown-formatter) | [r : p](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/rumdl-markdown-formatter...claude/panache-markdown-formatter) | | [r : m](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/rumdl-markdown-formatter...claude/mdformat-markdown-formatter) |
| [mdformat](https://github.com/aunger/gallery-button-for-pixel-camera/pull/680) **m** | [m : f](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/mdformat-markdown-formatter...claude/flowmark-markdown-formatter) | [m : p](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/mdformat-markdown-formatter...claude/panache-markdown-formatter) | [m : r](https://github.com/aunger/gallery-button-for-pixel-camera/compare/claude/mdformat-markdown-formatter...claude/rumdl-markdown-formatter) | |

---

## Summary

- Replace the `markdownlint-cli2` pre-commit hook with `mdformat`, installed from PyPI and wired in as a `local`/`language: system` hook, the same pattern the existing `ktlint` hook already uses. The old hook cloned `DavidAnson/markdownlint-cli2` directly, which this sandbox's git proxy blocks for any repo other than this one (see issue #551).
- Plugins enabled: `mdformat-sentencebreak` (sentence-boundary line wrap), `mdformat-frontmatter` (preserve YAML frontmatter), `mdformat-tables` (GFM pipe table support).
- Pin `mdformat==0.7.22` (not the current 1.0.0), `mdformat-sentencebreak==0.4.0`, `mdformat-frontmatter==2.1.2`, `mdformat-tables==1.0.0`, installed automatically at session start.
- Hook args: `--wrap keep --number`. `--wrap` must stay at `keep`: `--wrap no` or a fixed width crashes with `mdformat-sentencebreak` installed (see Known limitations).
- Exclude 13 files from the hook (see `.pre-commit-config.yaml`) because of a reproducible `mdformat-sentencebreak` bug that corrupts them (see Known limitations).
- Ran the hook across the repo's remaining Markdown and committed the resulting reformat.
- Removed `.markdownlint.yaml` since nothing reads it anymore.
- Verified `pre-commit run --all-files` passes locally, aside from one pre-existing, unrelated `ruff-format` finding on three Python scripts already present on `origin/main` and out of scope for this PR.

## Why mdformat, given the wrap-quality issues below

mdformat is in this bake-off specifically for its plugin architecture, not because its out-of-the-box wrap story is competitive with the other candidates. Its plugins (`mdformat-sentencebreak`, `mdformat-frontmatter`, `mdformat-tables` here, but also third-party or first-party ones for anything else) are real Python packages registered via `mdformat.parser_extension` / `mdformat.codeformatter` entry points, each able to override how mdformat renders a given node type. That is a materially different, more extensible architecture than Panache's (TOML config only, no way to add a new rule without patching Panache itself) or rumdl's (a fixed catalog of about 76 built-in rules you can enable or disable, but not extend with your own). If this repo ever wants a properly sentence-aware (rather than clause-aware) wrap rule, or any other custom Markdown transformation, mdformat is the only one of the three where that's a "write a small Python package" problem instead of a "fork or wait on the upstream maintainer" problem. This PR does not do that (see "Future improvement" below); it only evaluates what's available today.

## Known limitations

- **`mdformat-sentencebreak` breaks at commas and other mid-sentence punctuation, not just sentence endings.** Its break regex treats any of `]}.,;:!?)` as a candidate split point, so a single sentence with a few commas gets fragmented into several short lines, not just split at its own end. For example, "If participating in a PR or review (as Author, Reviewer, or Orchestrator), read `./agents/pr_participation.md`." (one sentence) becomes four lines in this PR's reformatted `AGENTS.md`. This is a real, demonstrated quality gap against Flowmark/Panache/rumdl's true sentence-boundary wrapping for the "split prose at sentence breaks" rule; it is not a bug, it is how the plugin is built (confirmed by reading its source: the regex has a `# TODO make this configurable` comment and is not, in fact, configurable today).
- **`mdformat-sentencebreak` can corrupt inline code spans containing a period.** Confirmed and reproduced directly: a code span such as `` `pr_creation.md` `` or `` `.claude/hooks/session-start.sh` `` gets split in half mid-token (for example, into `` `agents/pr_creat `` + a line break + `` ion.md` ``) whenever the surrounding sentence is long enough to reach a wrap point, because periods inside code spans are not protected from the break regex. This corrupts the file badly enough that mdformat's own render round-trip safety check refuses to write it (`Formatted Markdown renders to different HTML than input Markdown`). Verified against every real Markdown file in this repo, in both a single pass and repeated passes (some files only trip the bug on a second pass, once the first pass's rewrapping creates a new long-enough sentence): 13 of 21 files are affected (`agents/inaugurate.md`, `agents/pr_participation.md`, `agents/code_edit.md`, `agents/verification_planning.md`, `agents/pr_verify.md`, `agents/dev_orchestration.md`, `agents/pr_creation.md`, `.github/workflows/CLAUDE.md`, `SPEC.md`, `scripts/ci_monitor/README.md`, `.claude/agents/NOTES.md`, `.claude/environment.md`, `.claude/rules/github-mcp-authenticate.md`). These are excluded from the hook in `.pre-commit-config.yaml` rather than corrupted; they will not get sentence-wrap formatting from this tool until either the plugin is fixed upstream or the file's content changes enough to no longer trip it. No config option exists to adjust the plugin's break regexes; they are hardcoded in its source.
- **`mdformat-sentencebreak` pins the whole toolchain to `mdformat<0.8.0`.** Its own PyPI metadata requires `mdformat>=0.7.16,<0.8.0`, so this repo is on `mdformat==0.7.22` rather than the current `1.0.0`. `mdformat-frontmatter` and `mdformat-tables` have no such ceiling and would work fine with `1.0.0` on their own; the sentence-wrap plugin is specifically what holds the version back.
- **`mdformat-sentencebreak` maintenance risk.** Single release (`0.4.0`, 2022-09-26), no discoverable GitHub repository link in its PyPI metadata, and its own README lists unresolved `TODO` items (including ellipsis handling). Combined with the version ceiling and the two bugs above, this plugin should be treated as an unmaintained stopgap, not a long-term dependency.
- **Cannot reverse pre-existing curly quotes, em-dashes, or ellipsis characters back to ASCII, and does not introduce them either.** Verified empirically: feeding real curly-quote/em-dash/ellipsis characters, and separately their straight-ASCII equivalents, through `mdformat` (plus the three plugins above) passes both through byte-for-byte unchanged in either direction. Neither core `mdformat` nor any of the three plugins touches punctuation style at all. This repo's Markdown is already all-ASCII, so this is not an active problem today, but there is no backstop if curly punctuation gets pasted in later.
- **Does not enforce "no spaces around dashes or double-hyphens" at all.** Verified empirically: `word -- word` and `word --- word` pass through unchanged. No workaround hook was added for it.

## Future improvement

A properly sentence-aware (not clause/comma-aware) wrap plugin is the obvious next step for mdformat to be fully competitive on the word-wrap rule, either a fix upstream to `mdformat-sentencebreak` or a small first-party `mdformat.parser_extension` plugin written for this repo. That is deliberately out of scope for this PR: `mdformat-sentencebreak` is being evaluated as-is, as a stopgap, and no custom plugin is being built here.

## Parallel experiment

This is the fourth of four independent, parallel experiments replacing the `markdownlint-cli2` hook, each evaluated against this same repo's `.claude/rules/prose-style.md` rules and each replacing the same hook slot in mutually exclusive ways: this PR (mdformat), #677 (Flowmark), #678 (Panache), and #679 (rumdl). All four are meant for the user to compare and pick one (or none). Cross-review between candidates will follow once all four are ready.