### PR TITLE
Rename "testing" label to "automated tests" in title-matching automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ changelog:
   exclude:
     labels:
       - ci
-      - testing
+      - automated tests
       - agents

--- a/scripts/label_by_title.py
+++ b/scripts/label_by_title.py
@@ -74,7 +74,7 @@ LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
         rf"|{_B}sub[\W_]?agent\w*",
         re.IGNORECASE,
     ),
-    "testing": re.compile(
+    "automated tests": re.compile(
         rf"{_B}e2e{_B}"
         rf"|{_B}unit{_B}"
         rf"|{_B}test\w*"

--- a/scripts/test_backfill_labels_by_title.py
+++ b/scripts/test_backfill_labels_by_title.py
@@ -25,13 +25,13 @@ class TestTrackedLabels(unittest.TestCase):
     def test_includes_every_rule_label(self):
         self.assertIn("ci", blt.TRACKED_LABELS)
         self.assertIn("agents", blt.TRACKED_LABELS)
-        self.assertIn("testing", blt.TRACKED_LABELS)
+        self.assertIn("automated tests", blt.TRACKED_LABELS)
 
     def test_has_no_extra_labels(self):
         # A label with no title-matching rule (e.g. "product") must not be
         # tracked: it could never appear in "matched", so it would sit in
         # "miss" forever, on every run, for every issue/PR that carries it.
-        self.assertEqual(blt.TRACKED_LABELS, frozenset({"ci", "agents", "testing"}))
+        self.assertEqual(blt.TRACKED_LABELS, frozenset({"ci", "agents", "automated tests"}))
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +132,7 @@ class TestBuildReport(unittest.TestCase):
 
 class TestApplyLabels(unittest.TestCase):
     def test_posts_once_per_issue(self):
-        to_apply = {1: ["ci"], 2: ["agents", "testing"]}
+        to_apply = {1: ["ci"], 2: ["agents", "automated tests"]}
         with patch.object(blt.label_by_title, "gh_api") as mock_api:
             result = blt.apply_labels(to_apply, "owner/repo", "tok")
         self.assertEqual(mock_api.call_count, 2)
@@ -259,8 +259,8 @@ class TestParseSkipMatches(unittest.TestCase):
         self.assertEqual(labels, frozenset({"ci", "agents"}))
 
     def test_whitespace_around_labels_is_stripped(self):
-        include_match, labels = blt.parse_skip_matches("ci, agents , testing")
-        self.assertEqual(labels, frozenset({"ci", "agents", "testing"}))
+        include_match, labels = blt.parse_skip_matches("ci, agents , automated tests")
+        self.assertEqual(labels, frozenset({"ci", "agents", "automated tests"}))
 
     def test_trailing_comma_does_not_add_empty_label(self):
         include_match, labels = blt.parse_skip_matches("ci,")
@@ -277,8 +277,8 @@ class TestParseSkipMatches(unittest.TestCase):
         self.assertEqual(labels, frozenset({"ci", "agents"}))
 
     def test_quotes_and_whitespace_together_are_stripped(self):
-        include_match, labels = blt.parse_skip_matches("\"ci\", agents , 'testing'")
-        self.assertEqual(labels, frozenset({"ci", "agents", "testing"}))
+        include_match, labels = blt.parse_skip_matches("\"ci\", agents , 'automated tests'")
+        self.assertEqual(labels, frozenset({"ci", "agents", "automated tests"}))
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -141,7 +141,7 @@ class TestFindConflictingPrefix(unittest.TestCase):
         self.assertIsNone(emxl.find_conflicting_prefix("ci"))
         self.assertIsNone(emxl.find_conflicting_prefix("p1"))
         self.assertIsNone(emxl.find_conflicting_prefix("bug"))
-        self.assertIsNone(emxl.find_conflicting_prefix("testing"))
+        self.assertIsNone(emxl.find_conflicting_prefix("automated tests"))
 
     def test_empty_string_returns_none(self):
         self.assertIsNone(emxl.find_conflicting_prefix(""))
@@ -201,20 +201,20 @@ class TestLabelsByPrefix(unittest.TestCase):
 
     def test_removes_test_failure_when_archive_added(self):
         result = emxl.labels_to_remove_by_prefix(
-            "test-failure-archive", ["test-failure", "testing"], "test-failure"
+            "test-failure-archive", ["test-failure", "automated tests"], "test-failure"
         )
         self.assertEqual(result, ["test-failure"])
 
     def test_removes_test_failure_archive_when_test_failure_added(self):
         result = emxl.labels_to_remove_by_prefix(
-            "test-failure", ["test-failure-archive", "testing"], "test-failure"
+            "test-failure", ["test-failure-archive", "automated tests"], "test-failure"
         )
         self.assertEqual(result, ["test-failure-archive"])
 
-    def test_test_failure_prefix_does_not_touch_testing_label(self):
-        """The 'testing' label shares no real prefix with 'test-failure' and must survive."""
+    def test_test_failure_prefix_does_not_touch_automated_tests_label(self):
+        """The 'automated tests' label shares no real prefix with 'test-failure' and must survive."""
         result = emxl.labels_to_remove_by_prefix(
-            "test-failure", ["testing", "ci"], "test-failure"
+            "test-failure", ["automated tests", "ci"], "test-failure"
         )
         self.assertEqual(result, [])
 
@@ -655,7 +655,7 @@ class TestMain(unittest.TestCase):
                 emxl,
                 "gh_api",
                 side_effect=[
-                    self._make_issue_response(["test-failure", "testing"]),
+                    self._make_issue_response(["test-failure", "automated tests"]),
                     None,  # DELETE test-failure
                 ],
             ) as mock_api:
@@ -673,7 +673,7 @@ class TestMain(unittest.TestCase):
                 emxl,
                 "gh_api",
                 side_effect=[
-                    self._make_issue_response(["test-failure-archive", "testing"]),
+                    self._make_issue_response(["test-failure-archive", "automated tests"]),
                     None,  # DELETE test-failure-archive
                 ],
             ) as mock_api:
@@ -684,13 +684,13 @@ class TestMain(unittest.TestCase):
         self.assertIn("test-failure-archive", delete_call[0][0])
         self.assertEqual(delete_call[1]["method"], "DELETE")
 
-    def test_test_failure_prefix_does_not_remove_testing_label(self):
-        """Enforcing the test-failure group must not touch the unrelated 'testing' label."""
+    def test_test_failure_prefix_does_not_remove_automated_tests_label(self):
+        """Enforcing the test-failure group must not touch the unrelated 'automated tests' label."""
         with patch.dict(os.environ, {"ADDED_LABEL": "test-failure"}):
             with patch.object(
                 emxl,
                 "gh_api",
-                side_effect=[self._make_issue_response(["testing", "ci"])],
+                side_effect=[self._make_issue_response(["automated tests", "ci"])],
             ) as mock_api:
                 result = emxl.main()
 

--- a/scripts/test_label_by_title.py
+++ b/scripts/test_label_by_title.py
@@ -198,32 +198,38 @@ class TestMatchingLabelsAgents(unittest.TestCase):
         self.assertIn("agents", lpt.matching_labels("Fix the sub_agent handoff"))
 
 
-class TestMatchingLabelsTesting(unittest.TestCase):
+class TestMatchingLabelsAutomatedTests(unittest.TestCase):
     def test_e2e_matches(self):
-        self.assertIn("testing", lpt.matching_labels("Add E2E instrumented test"))
+        self.assertIn("automated tests", lpt.matching_labels("Add E2E instrumented test"))
 
     def test_e2e_within_camel_case_identifier_does_not_match_the_plain_e2e_rule(self):
         # No boundary surrounds "E2E" inside "VisualE2Efixture", and it's
         # not followed by "Test", so neither e2e rule fires.
         self.assertEqual(lpt.matching_labels("Add VisualE2Efixture helper"), [])
 
-    def test_e2etest_camel_case_identifier_matches_testing(self):
+    def test_e2etest_camel_case_identifier_matches_automated_tests(self):
         # The dedicated e2etest identifier rule (both sides open) catches
         # what the plain \be2e\b rule can't reach inside CamelCase names.
-        self.assertIn("testing", lpt.matching_labels("Add GalleryButtonVisualE2ETest"))
+        self.assertIn("automated tests", lpt.matching_labels("Add GalleryButtonVisualE2ETest"))
 
-    def test_preflight_matches_testing(self):
+    def test_preflight_matches_automated_tests(self):
         self.assertIn(
-            "testing", lpt.matching_labels("CI pre-flight: MockCameraActivity ready signal")
+            "automated tests",
+            lpt.matching_labels("CI pre-flight: MockCameraActivity ready signal"),
         )
 
-    def test_preflight_with_suffix_matches_testing(self):
-        self.assertIn("testing", lpt.matching_labels("Stop preflighting on every retry"))
+    def test_preflight_with_suffix_matches_automated_tests(self):
+        self.assertIn(
+            "automated tests", lpt.matching_labels("Stop preflighting on every retry")
+        )
 
     def test_camel_case_test_suffix_matches_case_sensitively(self):
-        self.assertIn("testing", lpt.matching_labels("Add Gaussian-blur noise to ShapeMatcherTest"))
         self.assertIn(
-            "testing", lpt.matching_labels("Six instrumented (androidTest) classes are skipped")
+            "automated tests", lpt.matching_labels("Add Gaussian-blur noise to ShapeMatcherTest")
+        )
+        self.assertIn(
+            "automated tests",
+            lpt.matching_labels("Six instrumented (androidTest) classes are skipped"),
         )
 
     def test_lowercase_camel_test_identifier_does_not_match(self):
@@ -242,19 +248,22 @@ class TestMatchingLabelsTesting(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_unit_exact_word_matches(self):
-        self.assertIn("testing", lpt.matching_labels("Skip Python and shell unit tests"))
+        self.assertIn("automated tests", lpt.matching_labels("Skip Python and shell unit tests"))
 
     def test_units_does_not_match_unit_rule(self):
         # "units" alone (no "test") should not match the strict \bunit\b rule.
-        self.assertNotIn("testing", lpt.matching_labels("Convert distance units to metric"))
+        self.assertNotIn(
+            "automated tests", lpt.matching_labels("Convert distance units to metric")
+        )
 
     def test_test_suffixes_match(self):
-        self.assertIn("testing", lpt.matching_labels("Add noisy tests for coverage"))
-        self.assertIn("testing", lpt.matching_labels("Add :testgallery module"))
+        self.assertIn("automated tests", lpt.matching_labels("Add noisy tests for coverage"))
+        self.assertIn("automated tests", lpt.matching_labels("Add :testgallery module"))
 
     def test_test_prefixed_by_underscore_matches(self):
         self.assertIn(
-            "testing", lpt.matching_labels("Speed up ci_monitor's poll interval unit_tests")
+            "automated tests",
+            lpt.matching_labels("Speed up ci_monitor's poll interval unit_tests"),
         )
 
 
@@ -263,7 +272,7 @@ class TestMatchingLabelsCombined(unittest.TestCase):
         result = lpt.matching_labels("Add CiWatcher agent and fix Reviewer CI-polling loop")
         self.assertIn("ci", result)
         self.assertIn("agents", result)
-        self.assertNotIn("testing", result)
+        self.assertNotIn("automated tests", result)
 
     def test_no_match_returns_empty_list(self):
         self.assertEqual(lpt.matching_labels("Set overlay default position to y=75%"), [])


### PR DESCRIPTION
Fixes #643 (the code-automation portion; see below).

`automated tests` and `testing` are two distinct label objects in this repo, not one label that was renamed in place. This PR retargets the automation so it applies `automated tests` going forward:

- `scripts/label_by_title.py`: the `LABEL_PATTERNS` dict key `"testing"` is now `"automated tests"`.
- `.github/release.yml`: the `changelog.exclude.labels` entry `testing` is now `automated tests`.
- Updated the corresponding unit tests in `scripts/test_label_by_title.py`, `scripts/test_backfill_labels_by_title.py`, and `scripts/test_enforce_mutually_exclusive_labels.py` (including renaming test methods/classes that referenced the old label name).

`scripts/backfill_labels_by_title.py`'s `TRACKED_LABELS` derives from `label_by_title.LABEL_PATTERNS`, so it picks up the new name automatically. `scripts/test_label_existence_integration.py` derives its required-labels set from `.github/release.yml`, so it now checks for "automated tests" instead of "testing" against the real repo (which already has that label, applied independently of this PR).

### What this PR does not do

This PR does not delete or rename the `testing` label object, and does not retroactively relabel the 83 issues/PRs (mostly closed) that still carry it, including #682 (open, carrying both labels). Both are out-of-repo GitHub-administration actions that no script in this repo can perform. Tracked as a follow-up: #684.

### Test plan
- [x] `python3 -m unittest scripts/test_label_by_title.py scripts/test_backfill_labels_by_title.py scripts/test_enforce_mutually_exclusive_labels.py` — all pass.
- [ ] Delete the stale `testing` label from the repository (tracked in #684, not part of this PR).
