### PR TITLE
Match ci_monitor --include-* patterns against suite as well as name

### DIFF
--- a/scripts/ci_monitor/README.md
+++ b/scripts/ci_monitor/README.md
@@ -44,14 +44,15 @@ Independent filter flags narrow or expand which per-test outcomes are streamed:
 
 | Flag | Effect |
 |---|---|
-| `--include-fail [PATTERN]` | Report FAIL markers (default); optionally restrict to those whose `name` matches PATTERN. |
+| `--include-fail [PATTERN]` | Report FAIL markers (default); optionally restrict to those whose `name` or `suite` matches PATTERN. |
 | `--no-include-fail` | Suppress all FAIL markers. |
-| `--include-skip [PATTERN]` | Report SKIP markers (default); optionally restrict to those whose `name` matches PATTERN. |
+| `--include-skip [PATTERN]` | Report SKIP markers (default); optionally restrict to those whose `name` or `suite` matches PATTERN. |
 | `--no-include-skip` | Suppress all SKIP markers. |
-| `--include-pass [PATTERN]` | Report PASS markers (not the default); optionally restrict to those whose `name` matches PATTERN. |
+| `--include-pass [PATTERN]` | Report PASS markers (not the default); optionally restrict to those whose `name` or `suite` matches PATTERN. |
 | `--no-include-pass` | Suppress all PASS markers (explicit form of the default). |
 
-Each `--include-*` flag takes an **optional regex** matched against the marker's `name` field.
+Each `--include-*` flag takes an **optional regex** matched against the marker's `name` field or its `suite` field: a marker is selected when the pattern matches *either* (issue #646).
+This lets a suite-shaped query like `--include-pass 'SetupActivityPermissionDialog'` surface a marker whose distinguishing text lives in `suite` rather than `name`.
 Supplied without a pattern it includes *all* markers of that outcome.
 The three outcomes keep their distinct labels in output: `--include-pass` never relabels a SKIP as PASS.
 

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -261,7 +261,10 @@ def parse_fails(
 
     `outcome_filters` is a dict mapping outcome names ('FAIL', 'PASS', 'SKIP') to
     (enabled, pattern) tuples, where `enabled` is a bool and `pattern` is either
-    None (match all) or a regex string (match only markers whose `name` matches).
+    None (match all) or a regex string. A non-None pattern matches a marker when
+    it matches either the marker's `name` or its `suite` field (issue #646), so a
+    suite-shaped query like 'SetupActivityPermissionDialog' surfaces a marker
+    whose distinguishing text lives in `suite` rather than `name`.
     Default behavior (outcome_filters=None): report all FAIL, all SKIP, no PASS.
 
     When `failed_tests` is a list, each emitted FAIL's "[suite] name" identifier
@@ -290,11 +293,14 @@ def parse_fails(
         enabled, pattern = outcome_filters[outcome]
         if not enabled:
             continue
-        # Pattern is matched against the marker's `name` field.
+        # Pattern is matched against the marker's `name` or `suite` field
+        # (issue #646): a suite-shaped query surfaces a marker whose
+        # distinguishing text lives in `suite` rather than `name`.
         name = m.get("name", "")
-        if pattern is not None and not re.search(pattern, name):
+        suite = m.get("suite", "")
+        if pattern is not None and not (re.search(pattern, name) or re.search(pattern, suite)):
             continue
-        key = m.get("suite", "") + "#" + name + "#" + outcome
+        key = suite + "#" + name + "#" + outcome
         if key in seen:
             continue
         seen.add(key)
@@ -833,7 +839,7 @@ def main(argv):
             nargs="?",
             default=None,  # sentinel: flag not supplied
             const="",  # supplied with no argument: match all
-            help="Include %s markers, optionally filtered by regex on name." % outcome.upper(),
+            help="Include %s markers, optionally filtered by regex on name or suite." % outcome.upper(),
         )
         parser.add_argument(
             "--no-include-%s" % outcome,

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -64,6 +64,10 @@ Covers:
   (aw) #650 _StripAuthOnCrossHostRedirect also strips Accept (another
        GitHub-specific header) on a cross-host redirect, while leaving an
        unrelated header untouched
+  (ax) #646 parse_fails: an --include-* PATTERN matches the marker's `suite`
+       field as well as its `name`, so a suite-shaped query surfaces a marker
+       whose distinguishing text lives in `suite` (name matching still works,
+       and a pattern in neither still suppresses)
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4565,6 +4569,97 @@ def main() -> int:
         cross_host_redirected is not None and cross_host_redirected.get_header("X-unrelated") == "keep-me",
         "cross-host redirect keeps a genuinely unrelated header",
         "cross-host redirect dropped an unrelated header unexpectedly",
+    )
+
+    # ── (ax) #646 parse_fails: an include pattern matches suite as well as name ────
+    print(
+        "\n=== (ax) #646 parse_fails: --include-* PATTERN matches the marker's suite, not only its name ==="
+    )
+
+    # Models the PR #644 synthesized PASS marker whose distinguishing text
+    # ("SetupActivityPermissionDialog") lives in the `suite` field, while its
+    # fixed `name` ("setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances")
+    # shares no substring with the suite-shaped validation query. Issue #601
+    # illustrated the intended query as `--include-pass 'SetupActivityPermissionDialog'`.
+    SUITE_MATCH_NDJSON = [
+        '##TEST## {"suite":"com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest","name":"setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances","outcome":"PASS","ms":50,"msg":"","trace":""}',
+        '##TEST## {"suite":"com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest","name":"setupFlow_deniesMediaPermission_andBlocks","outcome":"FAIL","ms":51,"msg":"boom","trace":""}',
+        '##TEST## {"suite":"com.gb4pc.e2e.UnrelatedE2ETest","name":"otherFlow_passes","outcome":"PASS","ms":10,"msg":"","trace":""}',
+    ]
+
+    # A suite-shaped --include-pass pattern surfaces the PASS marker via its
+    # `suite` field, even though the pattern matches nothing in the `name`.
+    out_ax_pass = ci_monitor.parse_fails(
+        SUITE_MATCH_NDJSON,
+        set(),
+        outcome_filters={
+            "FAIL": (False, None),
+            "SKIP": (False, None),
+            "PASS": (True, "SetupActivityPermissionDialog"),
+        },
+    )
+    out_ax_pass_str = "\n".join(out_ax_pass)
+    check(
+        "PASS [com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest] setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances:"
+        in out_ax_pass_str,
+        "--include-pass suite-shaped pattern matches the marker's suite field",
+        "--include-pass suite pattern: PASS not surfaced via suite; output: %r" % out_ax_pass,
+    )
+    check(
+        "UnrelatedE2ETest" not in out_ax_pass_str,
+        "--include-pass suite-shaped pattern excludes a non-matching suite",
+        "--include-pass suite pattern: non-matching suite leaked; output: %r" % out_ax_pass,
+    )
+
+    # Name matching still works: a pattern found only in `name` (never in `suite`)
+    # continues to select the marker, so the suite fallback is additive.
+    out_ax_name = ci_monitor.parse_fails(
+        SUITE_MATCH_NDJSON,
+        set(),
+        outcome_filters={
+            "FAIL": (False, None),
+            "SKIP": (False, None),
+            "PASS": (True, "grantsMediaPermissionViaSystemDialog"),
+        },
+    )
+    check(
+        "setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances" in "\n".join(out_ax_name),
+        "--include-pass name-shaped pattern still matches the marker's name field",
+        "--include-pass name pattern: PASS not surfaced via name; output: %r" % out_ax_name,
+    )
+
+    # A pattern present in neither `suite` nor `name` still suppresses the marker.
+    out_ax_none = ci_monitor.parse_fails(
+        SUITE_MATCH_NDJSON,
+        set(),
+        outcome_filters={
+            "FAIL": (False, None),
+            "SKIP": (False, None),
+            "PASS": (True, "NoSuchTokenAnywhere"),
+        },
+    )
+    check(
+        out_ax_none == [],
+        "--include-pass pattern matching neither suite nor name emits nothing",
+        "--include-pass no-match pattern: unexpected output: %r" % out_ax_none,
+    )
+
+    # Consistency: --include-fail matches the suite too (issue #646 asked for the
+    # suite fallback to apply to every include filter, not only PASS).
+    out_ax_fail = ci_monitor.parse_fails(
+        SUITE_MATCH_NDJSON,
+        set(),
+        outcome_filters={
+            "FAIL": (True, "SetupActivityPermissionDialog"),
+            "SKIP": (False, None),
+            "PASS": (False, None),
+        },
+    )
+    check(
+        "FAIL [com.gb4pc.e2e.SetupActivityPermissionDialogE2ETest] setupFlow_deniesMediaPermission_andBlocks:"
+        in "\n".join(out_ax_fail),
+        "--include-fail suite-shaped pattern matches the marker's suite field",
+        "--include-fail suite pattern: FAIL not surfaced via suite; output: %r" % out_ax_fail,
     )
 
     # ── Summary ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`ci_monitor.py`'s `parse_fails` matched an `--include-<outcome> PATTERN` regex only against a marker's `name` field, never its `suite`. As a result the suite-shaped validation query illustrated in issue #601 (`--include-pass 'SetupActivityPermissionDialog'`) silently matched nothing against the fixed `name` (`setupFlow_grantsMediaPermissionViaSystemDialog_andAdvances`), so the synthesized PASS marker added in PR #644 was never surfaced.

This PR extends the filter so a non-`None` pattern selects a marker when it matches **either** `name` **or** `suite`. A suite-shaped query now surfaces a marker whose distinguishing text lives in `suite`, matching the validation workflow envisioned in #601.

The change lives in the single shared filter path, so it applies uniformly to every include filter (`--include-fail`, `--include-skip`, `--include-pass`), as the issue requested for consistency.

## Changes

- `scripts/ci_monitor/ci_monitor.py`: `parse_fails` now matches the pattern against `name` or `suite`; docstring and `--include-*` argparse help updated.
- `scripts/ci_monitor/README.md`: the per-test-filter table and prose now document name-or-suite matching, with the #601 example.
- `scripts/test_ci_monitor.py`: new group `(ax)` covering suite matching (via `suite`), unchanged name matching, non-matching suppression, and the same behavior for `--include-fail`.

## Testing

- `python3 scripts/test_ci_monitor.py` -> 315 passed, 0 failed.

Fixes #646
