### PR TITLE
Bump ruff-pre-commit to v0.15.21 and reformat tree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: f0b5944bef86f50d875305821a0ab0d8c601e465 # v0.8.4
+    rev: 01a675ea018f2fb714478a5ffb83fcea8374bb06 # v0.15.21
     hooks:
       - id: ruff
         args: [--fix]

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -839,7 +839,8 @@ def main(argv):
             nargs="?",
             default=None,  # sentinel: flag not supplied
             const="",  # supplied with no argument: match all
-            help="Include %s markers, optionally filtered by regex on name or suite." % outcome.upper(),
+            help="Include %s markers, optionally filtered by regex on name or suite."
+            % outcome.upper(),
         )
         parser.add_argument(
             "--no-include-%s" % outcome,

--- a/scripts/file_test_failure_issues.py
+++ b/scripts/file_test_failure_issues.py
@@ -161,9 +161,7 @@ def make_summary_body(
     at the version that produced the failure.
     """
     ref = workflow_run_branch or "HEAD"
-    workflow_url = (
-        f"{github_server_url}/{github_repository}/blob/{ref}/{_WORKFLOW_FILE_PATH}"
-    )
+    workflow_url = f"{github_server_url}/{github_repository}/blob/{ref}/{_WORKFLOW_FILE_PATH}"
 
     return f"""\
 # Automated test failure
@@ -423,8 +421,7 @@ def process_failure(
 # ---------------------------------------------------------------------------
 
 _USAGE = (
-    "usage: file_test_failure_issues.py "
-    "<dir> --suite-label <name> [<dir> --suite-label <name> ...]"
+    "usage: file_test_failure_issues.py <dir> --suite-label <name> [<dir> --suite-label <name> ...]"
 )
 
 

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -1415,7 +1415,9 @@ def main() -> int:
     }
     # The artifact name mirrors build.yml's 'ci-monitor-feed-unit'; parse_new_artifacts
     # keys on the 'ci-monitor-feed-' prefix and id, so the real name is exercised.
-    ARTS_REAL_UNIT_P = {"artifacts": [{"id": 4243, "name": "ci-monitor-feed-unit", "expired": False}]}
+    ARTS_REAL_UNIT_P = {
+        "artifacts": [{"id": 4243, "name": "ci-monitor-feed-unit", "expired": False}]
+    }
 
     # Poll 1 (4): step delta, artifact not yet present. Poll 2 (5): step seen,
     # artifact appears -> real-shaped zip downloaded -> FAIL emitted. Poll 3 (4):
@@ -2270,7 +2272,11 @@ def main() -> int:
         ]
     }
     ARTS_EMPTY_T = {"artifacts": []}
-    ARTS_E2E_T = {"artifacts": [{"id": 5005, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}]}
+    ARTS_E2E_T = {
+        "artifacts": [
+            {"id": 5005, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}
+        ]
+    }
     ZIP_E2E_T = make_zip_ndjson(
         [
             '##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1a","outcome":"FAIL","ms":9,"msg":"java.lang.AssertionError: button not green","trace":""}',
@@ -2426,7 +2432,11 @@ def main() -> int:
         ]
     }
     ARTS_EMPTY_U = {"artifacts": []}
-    ARTS_E2E_U = {"artifacts": [{"id": 5006, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}]}
+    ARTS_E2E_U = {
+        "artifacts": [
+            {"id": 5006, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}
+        ]
+    }
     ZIP_E2E_U = make_zip_ndjson(
         [
             '##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1a","outcome":"FAIL","ms":9,"msg":"java.lang.AssertionError: button not green","trace":""}',
@@ -2626,7 +2636,11 @@ def main() -> int:
         ]
     }
     ARTS_EMPTY_W = {"artifacts": []}
-    ARTS_E2E_W = {"artifacts": [{"id": 5419, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}]}
+    ARTS_E2E_W = {
+        "artifacts": [
+            {"id": 5419, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}
+        ]
+    }
     ZIP_E2E_W = make_zip_ndjson(
         [
             '##GB4PC_TEST## {"suite":"com.gb4pc.e2e.GalleryButtonVisualE2ETest","name":"test1a","outcome":"FAIL","ms":9,"msg":"java.lang.AssertionError: button not green","trace":""}',
@@ -3153,7 +3167,9 @@ def main() -> int:
         ]
     }
     ARTS_BUILD_AD = {
-        "artifacts": [{"id": 8000, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}]
+        "artifacts": [
+            {"id": 8000, "name": "ci-monitor-feed-GalleryButtonVisualE2ETest", "expired": False}
+        ]
     }
     ZIP_BUILD_AD = make_zip_ndjson(
         [
@@ -3661,8 +3677,7 @@ def main() -> int:
         ["[com.gb4pc.e2e.GalleryButtonVisualE2ETest] test1a"],
     )
     check(
-        suffix_attr
-        == ' by: build-and-test (step "Gate on test failures" -> failure; '
+        suffix_attr == ' by: build-and-test (step "Gate on test failures" -> failure; '
         "test [com.gb4pc.e2e.GalleryButtonVisualE2ETest] test1a)",
         "blocking_suffix names the failing step and test for a substantive block",
         "attributed suffix wrong; got %r" % suffix_attr,
@@ -4194,9 +4209,7 @@ def main() -> int:
     check(rc_aq2 == 0, "main() returned 0", "main() returned %r" % rc_aq2)
 
     # ── (ar) #603 main(): --run-id mode scopes to the run object itself ────────────
-    print(
-        "\n=== (ar) #603 main(): --run-id mode Clear path (never fetches check-runs) ==="
-    )
+    print("\n=== (ar) #603 main(): --run-id mode Clear path (never fetches check-runs) ===")
 
     RUN_ID_AR = "778899"
     tag_ar = "RUN#%s" % RUN_ID_AR
@@ -4225,9 +4238,7 @@ def main() -> int:
     )
     check(rc_ar1 == 0, "main() returned 0", "main() returned %r" % rc_ar1)
 
-    print(
-        "\n=== (ar) #603 main(): --run-id mode Blocked path, scoped to this run's jobs only ==="
-    )
+    print("\n=== (ar) #603 main(): --run-id mode Blocked path, scoped to this run's jobs only ===")
 
     RUN_FAILURE_AR = {"status": "completed", "conclusion": "failure", "head_sha": "5eed1234"}
     JOBS_AR = {
@@ -4292,9 +4303,7 @@ def main() -> int:
 
     # ── (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry; ───
     # --pr's output format is unchanged by the multi-mode refactor
-    print(
-        "\n=== (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry ==="
-    )
+    print("\n=== (as) #603 regression: fetch_pr_with_retry delegates to fetch_with_retry ===")
 
     delegate_calls_as = []
 
@@ -4470,7 +4479,8 @@ def main() -> int:
     # Cross-host redirect (the real bug: api.github.com -> *.blob.core.windows.net,
     # a SAS-signed URL that itself rejects an unexpected bearer Authorization header).
     cross_host_req = ci_monitor.urllib.request.Request(
-        "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
+        "%s/repos/%s/%s/actions/artifacts/1/zip"
+        % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
     )
     cross_host_req.add_header("Authorization", "Bearer sekrit")
     cross_host_req.add_header("Accept", "application/vnd.github+json")
@@ -4484,7 +4494,8 @@ def main() -> int:
         "https://productionresultssa.blob.core.windows.net/artifacts/1.zip?sv=2021&sig=abc",
     )
     check(
-        cross_host_redirected is not None and cross_host_redirected.get_header("Authorization") is None,
+        cross_host_redirected is not None
+        and cross_host_redirected.get_header("Authorization") is None,
         "cross-host redirect strips the Authorization header",
         "cross-host redirect kept Authorization: %r"
         % (cross_host_redirected and cross_host_redirected.get_header("Authorization")),
@@ -4493,7 +4504,8 @@ def main() -> int:
     # Same-host redirect: Authorization is not the cross-host leak this guards
     # against, so it is left intact.
     same_host_req = ci_monitor.urllib.request.Request(
-        "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
+        "%s/repos/%s/%s/actions/artifacts/1/zip"
+        % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO)
     )
     same_host_req.add_header("Authorization", "Bearer sekrit")
     same_host_redirected = _redirect_handler.redirect_request(
@@ -4506,7 +4518,8 @@ def main() -> int:
         % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO),
     )
     check(
-        same_host_redirected is not None and same_host_redirected.get_header("Authorization") == "Bearer sekrit",
+        same_host_redirected is not None
+        and same_host_redirected.get_header("Authorization") == "Bearer sekrit",
         "same-host redirect keeps the Authorization header",
         "same-host redirect unexpectedly dropped Authorization",
     )
@@ -4527,15 +4540,19 @@ def main() -> int:
         def __exit__(self, *a):
             return False
 
-    with unittest.mock.patch.object(
-        ci_monitor._RAW_OPENER, "open", return_value=_FakeRawResp(b"PK\x03\x04fake-zip-bytes")
-    ) as mock_opener_open, unittest.mock.patch.object(
-        ci_monitor.urllib.request,
-        "urlopen",
-        side_effect=AssertionError("raw=True must not call urlopen directly"),
+    with (
+        unittest.mock.patch.object(
+            ci_monitor._RAW_OPENER, "open", return_value=_FakeRawResp(b"PK\x03\x04fake-zip-bytes")
+        ) as mock_opener_open,
+        unittest.mock.patch.object(
+            ci_monitor.urllib.request,
+            "urlopen",
+            side_effect=AssertionError("raw=True must not call urlopen directly"),
+        ),
     ):
         got_raw = ci_monitor._request(
-            "%s/repos/%s/%s/actions/artifacts/1/zip" % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO),
+            "%s/repos/%s/%s/actions/artifacts/1/zip"
+            % (ci_monitor.API_BASE, ci_monitor.OWNER, ci_monitor.REPO),
             "tok",
             raw=True,
         )
@@ -4566,7 +4583,8 @@ def main() -> int:
         % (cross_host_redirected and cross_host_redirected.get_header("Accept")),
     )
     check(
-        cross_host_redirected is not None and cross_host_redirected.get_header("X-unrelated") == "keep-me",
+        cross_host_redirected is not None
+        and cross_host_redirected.get_header("X-unrelated") == "keep-me",
         "cross-host redirect keeps a genuinely unrelated header",
         "cross-host redirect dropped an unrelated header unexpectedly",
     )

--- a/scripts/test_label_by_title.py
+++ b/scripts/test_label_by_title.py
@@ -219,9 +219,7 @@ class TestMatchingLabelsAutomatedTests(unittest.TestCase):
         )
 
     def test_preflight_with_suffix_matches_automated_tests(self):
-        self.assertIn(
-            "automated tests", lpt.matching_labels("Stop preflighting on every retry")
-        )
+        self.assertIn("automated tests", lpt.matching_labels("Stop preflighting on every retry"))
 
     def test_camel_case_test_suffix_matches_case_sensitively(self):
         self.assertIn(
@@ -252,9 +250,7 @@ class TestMatchingLabelsAutomatedTests(unittest.TestCase):
 
     def test_units_does_not_match_unit_rule(self):
         # "units" alone (no "test") should not match the strict \bunit\b rule.
-        self.assertNotIn(
-            "automated tests", lpt.matching_labels("Convert distance units to metric")
-        )
+        self.assertNotIn("automated tests", lpt.matching_labels("Convert distance units to metric"))
 
     def test_test_suffixes_match(self):
         self.assertIn("automated tests", lpt.matching_labels("Add noisy tests for coverage"))


### PR DESCRIPTION
Fixes #673.

Bumps `astral-sh/ruff-pre-commit` in `.pre-commit-config.yaml` from `v0.8.4` (pinned SHA `f0b5944bef86f50d875305821a0ab0d8c601e465`) to `v0.15.21` (pinned SHA `01a675ea018f2fb714478a5ffb83fcea8374bb06`), the current tag as of this PR. This was confirmed clean during review of PR #666: `ruff format` under the new version produces only mechanical line-wrap changes, and `ruff check` reports no lint failures.

Re-confirmed at implementation time: `ruff format` across the whole tree reformats 4 files (not the 3 originally observed during PR #666's review; the tree has changed since then). All changes are mechanical line-wrap adjustments with no behavior change:

- `scripts/ci_monitor/ci_monitor.py`
- `scripts/file_test_failure_issues.py`
- `scripts/test_ci_monitor.py`
- `scripts/test_label_by_title.py`

`ruff check .` passes with no findings.

## Coordination with #675

Of the three scripts #675 names as pre-existing format drift, this PR's tree-wide format already cleans two of them: `scripts/file_test_failure_issues.py` and `scripts/test_ci_monitor.py`. The third, `scripts/test_enforce_mutually_exclusive_labels.py`, is left unchanged by `ruff format` under `v0.15.21`, meaning it is already compliant at the new version. #675 can therefore reduce to its Markdown-only part (the `agents/pr_participation.md` fenced-code-block language tag).

## Test plan

- [x] `ruff format .` and `ruff check .` run locally under `ruff 0.15.21` (matching the new pin); only mechanical changes, no lint failures.
- [x] `python3 scripts/test_ci_monitor.py`, `scripts/test_label_by_title.py`, and `scripts/test_file_test_failure_issues.py` all pass locally.

