### PR TITLE
Tag Review pattern code fence as `text` in pr_participation.md

### DIFF
--- a/agents/pr_participation.md
+++ b/agents/pr_participation.md
@@ -23,7 +23,7 @@
 
   (This is the PR-path mechanism. If the Author opened no PR, see "Reviewing an Author who declined to open a PR" below.)
 
-  ```
+  ```text
   (ReviewText, IsReviewApproval) := <review the diff; form your verdict and review text>
   post review: mcp__github__pull_request_review_write(ReviewText, IsReviewApproval)
   ```


### PR DESCRIPTION
Fixes #675.

## Changes

- `agents/pr_participation.md`: the fenced block under the "Review pattern:" heading opened with a bare triple-backtick and no language, which fails markdownlint's MD040 rule. Tagged it `text` since it is pseudo-code, not a real language. Verified with `markdownlint-cli2 v0.14.0` (the version currently pinned in `.pre-commit-config.yaml`) that this file now lints clean.

## The ruff-format part of #675 is a no-op

#675 also asked to run `ruff format` on `scripts/file_test_failure_issues.py`, `scripts/test_ci_monitor.py`, and `scripts/test_enforce_mutually_exclusive_labels.py` under ruff v0.15.21 (the version from #673), since they didn't match the older pinned `ruff-format` (v0.8.4) that was in place when the drift was first noticed.

By the time this PR was started, #673 had already merged as PR #686 ("Bump ruff-pre-commit to v0.15.21 and reformat tree"), which reformatted the whole tree, including these three files, under ruff-format v0.15.21. Running `ruff format --diff` against the pinned v0.15.21 on these three scripts now reports "3 files already formatted" with no changes, and `ruff format --diff .` / `ruff check .` report the whole tree clean. So no ruff-format changes were needed here; this PR reduces to the Markdown fix, as anticipated by the issue.

## Test plan

- [x] `python3 -m pytest scripts/test_ci_monitor.py scripts/test_enforce_mutually_exclusive_labels.py scripts/test_file_test_failure_issues.py` (154 passed)
- [x] `ruff format --diff .` and `ruff check .` (both clean, ruff 0.15.21)
- [x] `npx markdownlint-cli2@0.14.0 agents/pr_participation.md` (0 errors)

