### PR TITLE
Always dispatch Programmers in worktrees, not only when parallel

### DIFF
--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -191,11 +191,10 @@ Routing on the Verification Agent's signal:
 ## Assigning a Programmer
 
 - Create a sub-agent at the Author model (see Model selection above)
-- Always dispatch the Programmer in its own git worktree (Agent tool `isolation: "worktree"`), whether or not this dispatch is parallel.
-  See "Always use worktrees" under Delegation rules below.
 - Create a dedicated per-issue branch for the Programmer to use.
   Branch names should follow the pattern `fix/issue-N-short-description` for bug fixes or `feature/issue-N-short-description` for new features.
   Never direct two Programmers for unrelated issues to the same branch.
+- Always dispatch the Programmer in its own git worktree (Agent tool `isolation: "worktree"`), whether or not this dispatch is parallel.
 - Dispatch using the dispatch template above, with the Programmer role assignment statement and the literal issue number and branch name tokens.
 
 When the Author returns, apply this transition.
@@ -370,10 +369,8 @@ Orchestrator-specific notes:
 
 ## Delegation rules
 
-- **Always use worktrees.** Dispatch every sub-agent in its own git worktree (Agent tool `isolation: "worktree"`), not only Programmers and not only when dispatching in parallel.
-  This covers the Programmer, Reviewer, Verification Planner, and Verification Agent alike.
-  Several of them mutate a checkout (the Programmer's commits, the Verification Agent's test-branch creation and push), and parallel conditions often go unnoticed, so applying worktrees unconditionally is safer than deciding case by case and keeps each task's checkout isolated.
 - If requested by the user, **dispatch in parallel** for independent issues. Parallel issues must each have their own branch.
+- **Always use worktrees.** Dispatch every sub-agent in its own git worktree (Agent tool `isolation: "worktree"`), not only Programmers and not only when dispatching in parallel.
 - **One branch per ticket.** Each issue gets its own dedicated branch.
 - **Separate subagents per ticket.** Each issue or PR gets its own independent Author and Reviewer agents.
 - **Report subagent timing.** Use the Bash tool to run `date -u` immediately before dispatching each subagent, and again immediately after it returns. Report both times to the user.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -370,8 +370,9 @@ Orchestrator-specific notes:
 
 ## Delegation rules
 
-- **Always use worktrees.** Dispatch every Programmer in its own git worktree (Agent tool `isolation: "worktree"`), not only when dispatching in parallel.
-  Parallel conditions often go unnoticed, so applying worktrees unconditionally is safer than deciding case by case, and it keeps each task's checkout isolated.
+- **Always use worktrees.** Dispatch every sub-agent in its own git worktree (Agent tool `isolation: "worktree"`), not only Programmers and not only when dispatching in parallel.
+  This covers the Programmer, Reviewer, Verification Planner, and Verification Agent alike.
+  Several of them mutate a checkout (the Programmer's commits, the Verification Agent's test-branch creation and push), and parallel conditions often go unnoticed, so applying worktrees unconditionally is safer than deciding case by case and keeps each task's checkout isolated.
 - If requested by the user, **dispatch in parallel** for independent issues. Parallel issues must each have their own branch.
 - **One branch per ticket.** Each issue gets its own dedicated branch.
 - **Separate subagents per ticket.** Each issue or PR gets its own independent Author and Reviewer agents.

--- a/agents/dev_orchestration.md
+++ b/agents/dev_orchestration.md
@@ -191,6 +191,8 @@ Routing on the Verification Agent's signal:
 ## Assigning a Programmer
 
 - Create a sub-agent at the Author model (see Model selection above)
+- Always dispatch the Programmer in its own git worktree (Agent tool `isolation: "worktree"`), whether or not this dispatch is parallel.
+  See "Always use worktrees" under Delegation rules below.
 - Create a dedicated per-issue branch for the Programmer to use.
   Branch names should follow the pattern `fix/issue-N-short-description` for bug fixes or `feature/issue-N-short-description` for new features.
   Never direct two Programmers for unrelated issues to the same branch.
@@ -368,7 +370,9 @@ Orchestrator-specific notes:
 
 ## Delegation rules
 
-- If requested by the user, **dispatch in parallel** for independent issues. Parallel issues must each have their own branch and worktree.
+- **Always use worktrees.** Dispatch every Programmer in its own git worktree (Agent tool `isolation: "worktree"`), not only when dispatching in parallel.
+  Parallel conditions often go unnoticed, so applying worktrees unconditionally is safer than deciding case by case, and it keeps each task's checkout isolated.
+- If requested by the user, **dispatch in parallel** for independent issues. Parallel issues must each have their own branch.
 - **One branch per ticket.** Each issue gets its own dedicated branch.
 - **Separate subagents per ticket.** Each issue or PR gets its own independent Author and Reviewer agents.
 - **Report subagent timing.** Use the Bash tool to run `date -u` immediately before dispatching each subagent, and again immediately after it returns. Report both times to the user.

--- a/agents/inaugurate.md
+++ b/agents/inaugurate.md
@@ -17,6 +17,7 @@ A session setup may specify a single "development branch." Treat this as context
 
 Use the dispatch template defined in `dev_orchestration.md`.
 Fill the branch name (following the naming pattern above) and the issue number (given by the user) as literal tokens.
+Dispatch each Programmer in its own git worktree, per "Always use worktrees" in `dev_orchestration.md`; this applies to every dispatch, not only parallel ones.
 Commit/PR duties and branch-isolation rules are discoverable by the sub-agent via CLAUDE.md and need not be re-narrated.
 
 ## Parallel dispatch

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -106,8 +106,6 @@ Do not delete any test branch; the closed PR preserves the run history as eviden
 
 ## Boundaries
 
-- You run in your own git worktree (the Orchestrator dispatches you with worktree isolation; see "Always use worktrees" in `dev_orchestration.md`).
-  The repository-changing actions below therefore happen inside that isolated checkout and never disturb a shared checkout or another agent's in-flight work.
 - Do not fix bugs, and do not modify any source files.
 - Do not merge any PR.
 - Do not communicate with the user during the run.
@@ -117,3 +115,5 @@ Do not delete any test branch; the closed PR preserves the run history as eviden
   - Creating a test PR for the test branch.
   - Filing comments and closing tracking issues.
   - Closing a test PR that was created for this verification.
+- You run in your own git worktree (the Orchestrator dispatches you with worktree isolation).
+  The repository-changing actions above therefore happen inside that isolated checkout and never disturb a shared checkout or another agent's in-flight work.

--- a/agents/pr_verify.md
+++ b/agents/pr_verify.md
@@ -106,6 +106,8 @@ Do not delete any test branch; the closed PR preserves the run history as eviden
 
 ## Boundaries
 
+- You run in your own git worktree (the Orchestrator dispatches you with worktree isolation; see "Always use worktrees" in `dev_orchestration.md`).
+  The repository-changing actions below therefore happen inside that isolated checkout and never disturb a shared checkout or another agent's in-flight work.
 - Do not fix bugs, and do not modify any source files.
 - Do not merge any PR.
 - Do not communicate with the user during the run.


### PR DESCRIPTION
Fixes #701

## Problem

Worktree isolation was advised only for parallel orchestrations (`dev_orchestration.md` Delegation rules tied "their own branch and worktree" to the parallel-dispatch case).
But parallel conditions are often unnoticed, so Orchestrators forgot to isolate a sub-agent's checkout when they did not recognize the dispatch as parallel.
The issue is worded generically about agents, and the risk is not limited to Programmers: the Verification Agent (`pr_verify.md`) also performs repository-changing git operations (creates a test branch and pushes it) that can collide with in-flight work on a shared checkout.

## Change

Make worktree isolation unconditional for every sub-agent the Orchestrator dispatches:

- `agents/dev_orchestration.md`
  - Delegation rules: replaced the parallel-only worktree advice with an **"Always use worktrees"** rule that dispatches **every sub-agent** in its own git worktree (Agent tool `isolation: "worktree"`), naming the Programmer, Reviewer, Verification Planner, and Verification Agent explicitly and identifying which of them mutate a checkout (Programmer commits, Verification Agent test-branch push). Rationale: unconditional application is safer than detecting the parallel case, which is easy to miss. The parallel-dispatch bullet now covers only the per-issue branch requirement.
  - Assigning a Programmer: added a step to always dispatch the Programmer in its own worktree, pointing to the Delegation rules statement.
- `agents/inaugurate.md`
  - Dispatching each Programmer: added that each Programmer is dispatched in its own worktree per the "Always use worktrees" rule, applying to every dispatch rather than only parallel ones.
- `agents/pr_verify.md`
  - Boundaries: added that the Verification Agent runs in its own worktree, so its enumerated repository-changing actions never disturb a shared checkout or another agent's in-flight work, with a cross-reference to the rule.

This is a documentation change to the `agents/` process instructions; there is no runtime behavior to add automated tests for. `scripts/lint.sh` passes on all three edited files.
