### PR TITLE
Add a CI workflow enforcing lint.sh, with a --check/--only mode

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -172,49 +172,14 @@ fi
 
 # STEP 3a: ktlint (Kotlin formatter), from Maven Central.
 #
-# ktlint is fetched as the ktlint-cli fat JAR from Maven Central--the same
-# trusted, immutable, checksummed host Gradle already resolves this build
-# from--rather than from GitHub Releases, which this sandbox blocks with a 403
-# (issue #667).  The published SHA-256 is verified before the JAR is used, so a
-# proxy error page fails loudly here instead of masquerading as a corrupt
-# "binary" that only breaks later with an opaque Exec format error.  A small
-# wrapper on PATH runs the JAR via `java -jar`.
-#
-# When bumping KTLINT_VERSION, update KTLINT_SHA256 to the new release's
-# published checksum from
-# https://repo1.maven.org/maven2/com/pinterest/ktlint/ktlint-cli/<version>/ktlint-cli-<version>-all.jar.sha256
-KTLINT_VERSION="1.8.0"
-KTLINT_SHA256="369ad2b789f95a011f807e1fcb690ccef80bd7cd014fd139e73ae82dcc0baeab"
-KTLINT_JAR_DIR="$HOME/.local/lib/ktlint"
-KTLINT_JAR="$KTLINT_JAR_DIR/ktlint-cli-$KTLINT_VERSION-all.jar"
-KTLINT_BIN="$LOCAL_BIN/ktlint"
-if [[ -x "$KTLINT_BIN" && -f "$KTLINT_JAR" ]]; then
-    echo "[session-start] Step 3a: ktlint present--skip"
-else
-    echo "[session-start] Step 3a: installing ktlint $KTLINT_VERSION from Maven Central..."
-    mkdir -p "$KTLINT_JAR_DIR"
-    KTLINT_URL="https://repo1.maven.org/maven2/com/pinterest/ktlint/ktlint-cli/$KTLINT_VERSION/ktlint-cli-$KTLINT_VERSION-all.jar"
-    TMP_JAR=$(mktemp "$KTLINT_JAR_DIR/.download-XXXXXX")
-    trap 'rm -f "$TMP_JAR"' EXIT
-    # -f: fail on an HTTP error status instead of writing the error response
-    # body to the JAR as if it were the artifact (issue #667).
-    curl -fsSL "$KTLINT_URL" -o "$TMP_JAR"
-    ACTUAL_SHA=$(sha256sum "$TMP_JAR" | cut -d' ' -f1)
-    if [[ "$ACTUAL_SHA" != "$KTLINT_SHA256" ]]; then
-        echo "[session-start] Step 3a: ERROR: ktlint SHA-256 mismatch (refusing to install)" >&2
-        echo "[session-start]   expected $KTLINT_SHA256" >&2
-        echo "[session-start]   actual   $ACTUAL_SHA" >&2
-        exit 1
-    fi
-    mv "$TMP_JAR" "$KTLINT_JAR"
-    trap - EXIT
-    cat > "$KTLINT_BIN" << EOF
-#!/usr/bin/env bash
-exec java -jar "$KTLINT_JAR" "\$@"
-EOF
-    chmod +x "$KTLINT_BIN"
-    echo "[session-start] Step 3a: ktlint installed and SHA-256 verified"
-fi
+# The pinned, SHA-256-verified install lives in scripts/install-ktlint.sh, which
+# the CI ktlint lint job (.github/workflows/lint.yml) also runs, so both paths
+# provision the identical ktlint from one definition.  It installs the wrapper
+# into $HOME/.local/bin (the $LOCAL_BIN this step already put on PATH) and is
+# idempotent, so re-running is a fast no-op.  See that script for the rationale
+# on fetching the fat JAR from Maven Central rather than GitHub Releases.
+echo "[session-start] Step 3a: ensuring ktlint is installed..."
+"$REPO_ROOT/scripts/install-ktlint.sh"
 
 # STEP 3b: Python lint tools (ruff, pre-commit-hooks checks, mdformat), from PyPI.
 #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,85 @@
+name: Lint
+
+# CI enforcement of the repo's linters, so formatting and hygiene violations are
+# caught even when the commit-time git hook did not run (a local clone has no
+# hook, and `git commit --no-verify` bypasses it everywhere). CI is the one
+# enforcement point that cannot be locally skipped.
+#
+# Four independent jobs, one per tool family, run in parallel and pass or fail on
+# their own so each shows red or green individually. Each invokes scripts/lint.sh
+# --check --only <family> --all, so the git hook and CI share one definition of
+# how every tool runs. CI checks only; it never auto-fixes or pushes.
+#
+# This lives in its own workflow rather than build.yml: build.yml's build-and-test
+# job is skipped on docs-only PRs, but Markdown and hygiene linting must run
+# precisely there.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install Python lint tools
+        run: |
+          pip install -r scripts/requirements-lint.txt
+          echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
+      - name: Ruff check
+        run: scripts/lint.sh --check --only ruff --all
+
+  markdown-mdformat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install Python lint tools
+        run: |
+          pip install -r scripts/requirements-lint.txt
+          echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
+      - name: mdformat check
+        run: scripts/lint.sh --check --only mdformat --all
+
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install Python lint tools
+        run: |
+          pip install -r scripts/requirements-lint.txt
+          echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
+      - name: Hygiene checks
+        run: scripts/lint.sh --check --only hygiene --all
+
+  kotlin-ktlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Install ktlint
+        # Installs the pinned, SHA-256-verified ktlint into ~/.local/bin, which is
+        # scripts/lint.sh's default $LINT_BIN_DIR, so no LINT_BIN_DIR override is
+        # needed for the check step below.
+        run: scripts/install-ktlint.sh
+      - name: ktlint check
+        run: scripts/lint.sh --check --only ktlint --all

--- a/scripts/install-ktlint.sh
+++ b/scripts/install-ktlint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/install-ktlint.sh -- install the ktlint CLI, pinned and SHA-256 verified.
+#
+# Shared by .claude/hooks/session-start.sh (STEP 3a) and the CI ktlint lint job
+# (.github/workflows/lint.yml) so both provision the identical, integrity-checked
+# ktlint rather than duplicating the version, checksum, and download-and-verify
+# logic.
+#
+# ktlint is fetched as the ktlint-cli fat JAR from Maven Central--the same
+# trusted, immutable, checksummed host Gradle already resolves this build
+# from--rather than from GitHub Releases, which this sandbox blocks with a 403
+# (issue #667). The published SHA-256 is verified before the JAR is used, so a
+# proxy error page fails loudly here instead of masquerading as a corrupt
+# "binary" that only breaks later with an opaque Exec format error. A small
+# wrapper on PATH runs the JAR via `java -jar`.
+#
+# Install locations (override via the environment if needed):
+#   $KTLINT_BIN_DIR/ktlint            wrapper script on PATH (default ~/.local/bin)
+#   $KTLINT_JAR_DIR/ktlint-cli-*.jar  the verified JAR (default ~/.local/lib/ktlint)
+# Idempotent: if both already exist, it does nothing.
+#
+# When bumping KTLINT_VERSION, update KTLINT_SHA256 to the new release's
+# published checksum from
+# https://repo1.maven.org/maven2/com/pinterest/ktlint/ktlint-cli/<version>/ktlint-cli-<version>-all.jar.sha256
+
+set -euo pipefail
+
+KTLINT_VERSION="1.8.0"
+KTLINT_SHA256="369ad2b789f95a011f807e1fcb690ccef80bd7cd014fd139e73ae82dcc0baeab"
+
+KTLINT_BIN_DIR="${KTLINT_BIN_DIR:-$HOME/.local/bin}"
+KTLINT_JAR_DIR="${KTLINT_JAR_DIR:-$HOME/.local/lib/ktlint}"
+KTLINT_JAR="$KTLINT_JAR_DIR/ktlint-cli-$KTLINT_VERSION-all.jar"
+KTLINT_BIN="$KTLINT_BIN_DIR/ktlint"
+
+if [[ -x "$KTLINT_BIN" && -f "$KTLINT_JAR" ]]; then
+    echo "[install-ktlint] ktlint $KTLINT_VERSION present--skip"
+    exit 0
+fi
+
+echo "[install-ktlint] installing ktlint $KTLINT_VERSION from Maven Central..."
+mkdir -p "$KTLINT_JAR_DIR" "$KTLINT_BIN_DIR"
+KTLINT_URL="https://repo1.maven.org/maven2/com/pinterest/ktlint/ktlint-cli/$KTLINT_VERSION/ktlint-cli-$KTLINT_VERSION-all.jar"
+TMP_JAR=$(mktemp "$KTLINT_JAR_DIR/.download-XXXXXX")
+trap 'rm -f "$TMP_JAR"' EXIT
+# -f: fail on an HTTP error status instead of writing the error response body to
+# the JAR as if it were the artifact (issue #667).
+curl -fsSL "$KTLINT_URL" -o "$TMP_JAR"
+ACTUAL_SHA=$(sha256sum "$TMP_JAR" | cut -d' ' -f1)
+if [[ "$ACTUAL_SHA" != "$KTLINT_SHA256" ]]; then
+    echo "[install-ktlint] ERROR: ktlint SHA-256 mismatch (refusing to install)" >&2
+    echo "[install-ktlint]   expected $KTLINT_SHA256" >&2
+    echo "[install-ktlint]   actual   $ACTUAL_SHA" >&2
+    exit 1
+fi
+mv "$TMP_JAR" "$KTLINT_JAR"
+trap - EXIT
+cat > "$KTLINT_BIN" << EOF
+#!/usr/bin/env bash
+exec java -jar "$KTLINT_JAR" "\$@"
+EOF
+chmod +x "$KTLINT_BIN"
+echo "[install-ktlint] ktlint installed and SHA-256 verified"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -137,6 +137,14 @@ run() {
     "$@" || status=1
 }
 
+# check-added-large-files intersects its file-list argument with the staged
+# index unless --enforce-all is passed. Over a whole-tree (--all) run nothing is
+# staged, so without the flag it would check nothing; pass it there. On the
+# file-list (hook) path it must be omitted, or the check would flag pre-existing
+# large files the commit is not actually adding.
+declare -a LARGE_FILES_ARGS=()
+[[ $ALL -eq 1 ]] && LARGE_FILES_ARGS+=(--enforce-all)
+
 # hygiene family: the six generic pre-commit-hooks checks. These behave
 # identically in fix and check mode -- the read-only checks never write, and the
 # two whitespace fixers have no check-only mode, so they run as usual and fail
@@ -147,7 +155,7 @@ if want hygiene; then
         run "$LINT_BIN_DIR/end-of-file-fixer" "${TEXT[@]}"
     fi
     run "$LINT_BIN_DIR/check-merge-conflict" "${FILES[@]}"
-    run "$LINT_BIN_DIR/check-added-large-files" "${FILES[@]}"
+    run "$LINT_BIN_DIR/check-added-large-files" "${LARGE_FILES_ARGS[@]}" "${FILES[@]}"
     [[ ${#YAML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-yaml" "${YAML[@]}"
     [[ ${#TOML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-toml" "${TOML[@]}"
 fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,9 +5,16 @@
 #   scripts/lint.sh FILE [FILE ...]   lint the named files
 #   scripts/lint.sh --all             lint every tracked file in the tree
 #
+# Options (combine with either form above):
+#   --check                 run each tool in its check-only invocation and report,
+#                           rather than auto-fixing. See "Check mode" below.
+#   --only ruff|mdformat|ktlint|hygiene
+#                           run only one tool family, skipping the others.
+#
 # This is the single source of truth for "run the linters". The git pre-commit
-# hook (scripts/git-hooks/pre-commit) calls it with the staged file set; a
-# future CI job could call it with --all and reuse the exact same invocations.
+# hook (scripts/git-hooks/pre-commit) calls it with the staged file set; the CI
+# lint workflow (.github/workflows/lint.yml) calls it with --check --only <fam>
+# --all, so the hook and CI share one definition of how each tool runs.
 #
 # Each tool is resolved by explicit path under $LINT_BIN_DIR (default
 # $HOME/.local/bin), where .claude/hooks/session-start.sh installs it at
@@ -16,34 +23,69 @@
 # run time (issue #667). Point $LINT_BIN_DIR elsewhere to run against tools
 # installed in a different location (the test harness does this).
 #
-# The formatters run as auto-fixers where they support it (ruff --fix, ruff
-# format, mdformat, ktlint --format) and rewrite files in place. lint.sh exits
-# non-zero if any tool reports a problem (an unfixable violation, or a fixer
-# that had to change a file). Detecting which staged files a fixer touched, so
-# the commit can be aborted with a re-stage message, is the caller's job; see
-# scripts/git-hooks/pre-commit.
+# Default (fix) mode: the formatters run as auto-fixers where they support it
+# (ruff --fix, ruff format, mdformat, ktlint --format) and rewrite files in
+# place. lint.sh exits non-zero if any tool reports a problem (an unfixable
+# violation, or a fixer that had to change a file). Detecting which staged files
+# a fixer touched, so the commit can be aborted with a re-stage message, is the
+# caller's job; see scripts/git-hooks/pre-commit.
+#
+# Check mode (--check): each fixer runs in its check-only invocation instead:
+# `ruff check` (no --fix), `ruff format --check`, `mdformat --check`, and
+# `ktlint` (no --format). The read-only hygiene checks (check-yaml, check-toml,
+# check-merge-conflict, check-added-large-files) are unchanged. The two
+# whitespace fixers (trailing-whitespace-fixer, end-of-file-fixer) have no
+# check-only mode, so they run as usual and their non-zero exit on any change
+# fails the run, without altering the pass/fail contract. On a clean tree check
+# mode writes nothing and exits 0.
 
 set -uo pipefail
 
 LINT_BIN_DIR="${LINT_BIN_DIR:-$HOME/.local/bin}"
 
 usage() {
-    echo "usage: lint.sh FILE [FILE ...] | --all" >&2
+    echo "usage: lint.sh [--check] [--only ruff|mdformat|ktlint|hygiene] FILE [FILE ...] | --all" >&2
     exit 2
 }
 
 # ---------------------------------------------------------------------------
-# Resolve the target file list.
+# Parse options, then resolve the target file list.
 # ---------------------------------------------------------------------------
+CHECK=0
+ONLY=""
+ALL=0
 declare -a FILES=()
-if [[ "${1:-}" == "--all" ]]; then
-    [[ $# -eq 1 ]] || usage
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) CHECK=1; shift ;;
+        --only)
+            ONLY="${2:-}"
+            case "$ONLY" in
+                ruff | mdformat | ktlint | hygiene) ;;
+                *) usage ;;
+            esac
+            shift 2
+            ;;
+        --all) ALL=1; shift ;;
+        --) shift; FILES+=("$@"); break ;;
+        -*) usage ;;
+        *) FILES+=("$1"); shift ;;
+    esac
+done
+
+if [[ $ALL -eq 1 ]]; then
+    # --all lints the whole tree and takes no explicit file arguments.
+    [[ ${#FILES[@]} -eq 0 ]] || usage
     mapfile -d '' -t FILES < <(git ls-files -z)
-elif [[ $# -ge 1 ]]; then
-    FILES=("$@")
-else
+elif [[ ${#FILES[@]} -eq 0 ]]; then
     usage
 fi
+
+# want FAMILY -> true if that tool family should run, honoring --only. With no
+# --only, every family runs.
+want() {
+    [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
 
 # Keep only files that still exist as regular files. The pre-commit hook passes
 # the ACM (added/copied/modified) set, so deletions never reach here, but a
@@ -87,32 +129,59 @@ done
 
 # ---------------------------------------------------------------------------
 # Run each tool, resolved by explicit path. status becomes 1 if any tool fails,
-# but every tool still runs so a single pass applies all available fixes.
+# but every selected tool still runs so a single pass applies all available
+# fixes (fix mode) or reports every violation (check mode).
 # ---------------------------------------------------------------------------
 status=0
 run() {
     "$@" || status=1
 }
 
-if [[ ${#TEXT[@]} -gt 0 ]]; then
-    run "$LINT_BIN_DIR/trailing-whitespace-fixer" "${TEXT[@]}"
-    run "$LINT_BIN_DIR/end-of-file-fixer" "${TEXT[@]}"
+# hygiene family: the six generic pre-commit-hooks checks. These behave
+# identically in fix and check mode -- the read-only checks never write, and the
+# two whitespace fixers have no check-only mode, so they run as usual and fail
+# the run via their exit status if they change anything.
+if want hygiene; then
+    if [[ ${#TEXT[@]} -gt 0 ]]; then
+        run "$LINT_BIN_DIR/trailing-whitespace-fixer" "${TEXT[@]}"
+        run "$LINT_BIN_DIR/end-of-file-fixer" "${TEXT[@]}"
+    fi
+    run "$LINT_BIN_DIR/check-merge-conflict" "${FILES[@]}"
+    run "$LINT_BIN_DIR/check-added-large-files" "${FILES[@]}"
+    [[ ${#YAML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-yaml" "${YAML[@]}"
+    [[ ${#TOML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-toml" "${TOML[@]}"
 fi
-run "$LINT_BIN_DIR/check-merge-conflict" "${FILES[@]}"
-run "$LINT_BIN_DIR/check-added-large-files" "${FILES[@]}"
-[[ ${#YAML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-yaml" "${YAML[@]}"
-[[ ${#TOML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-toml" "${TOML[@]}"
 
-if [[ ${#PY[@]} -gt 0 ]]; then
-    run "$LINT_BIN_DIR/ruff" check --fix "${PY[@]}"
-    run "$LINT_BIN_DIR/ruff" format "${PY[@]}"
+# ruff family: lint + format Python.
+if want ruff && [[ ${#PY[@]} -gt 0 ]]; then
+    if [[ $CHECK -eq 1 ]]; then
+        run "$LINT_BIN_DIR/ruff" check "${PY[@]}"
+        run "$LINT_BIN_DIR/ruff" format --check "${PY[@]}"
+    else
+        run "$LINT_BIN_DIR/ruff" check --fix "${PY[@]}"
+        run "$LINT_BIN_DIR/ruff" format "${PY[@]}"
+    fi
 fi
 
+# mdformat family: format Markdown.
 # --wrap keep preserves this repo's one-sentence-per-line prose (see
 # .claude/rules/prose-style.md); --number keeps ordered-list numbering
 # sequential. These match the retired .pre-commit-config.yaml mdformat args.
-[[ ${#MD[@]} -gt 0 ]] && run "$LINT_BIN_DIR/mdformat" --wrap keep --number "${MD[@]}"
+if want mdformat && [[ ${#MD[@]} -gt 0 ]]; then
+    if [[ $CHECK -eq 1 ]]; then
+        run "$LINT_BIN_DIR/mdformat" --check --wrap keep --number "${MD[@]}"
+    else
+        run "$LINT_BIN_DIR/mdformat" --wrap keep --number "${MD[@]}"
+    fi
+fi
 
-[[ ${#KT[@]} -gt 0 ]] && run "$LINT_BIN_DIR/ktlint" --format "${KT[@]}"
+# ktlint family: format Kotlin.
+if want ktlint && [[ ${#KT[@]} -gt 0 ]]; then
+    if [[ $CHECK -eq 1 ]]; then
+        run "$LINT_BIN_DIR/ktlint" "${KT[@]}"
+    else
+        run "$LINT_BIN_DIR/ktlint" --format "${KT[@]}"
+    fi
+fi
 
 exit "$status"

--- a/scripts/test_lint_hook.sh
+++ b/scripts/test_lint_hook.sh
@@ -18,6 +18,8 @@
 #       on ktlint availability)
 #   (j) --check leaves the working tree unmodified
 #   (k) --only runs only the named tool family
+#   (l) a tracked file over 500 KB fails --all (--enforce-all), while the
+#       file-list (hook) path leaves an unlisted large file alone
 #
 # The lint tools are resolved from $LINT_BIN_DIR (default $HOME/.local/bin),
 # exactly as scripts/lint.sh resolves them; .claude/hooks/session-start.sh
@@ -218,6 +220,28 @@ RC_RUFF=$?
 RC_MD=$?
 if [[ "$RC_RUFF" -eq 0 ]]; then pass "--only ruff ignores a dirty .md"; else fail "--only ruff should ignore a dirty .md, rc=$RC_RUFF"; fi
 if [[ "$RC_MD" -ne 0 ]]; then pass "--only mdformat flags a dirty .md"; else fail "--only mdformat should flag a dirty .md"; fi
+
+# ── (l) large file fails --all, hook path unaffected ─────────────────────────
+echo ""
+echo "=== (l) large file fails --all (--enforce-all) ==="
+REPO="$(new_repo)"
+printf 'x = 1\n' > "$REPO/small.py"
+# A clean 600 KB text file: a single long line plus a trailing newline, so the
+# whitespace/eof fixers have nothing to change and only the size check can flag
+# it. Committed with --no-verify so the hook (which would block it) is bypassed
+# and it becomes a pre-existing tracked file.
+head -c 599999 /dev/zero | tr '\0' 'a' > "$REPO/big.txt"
+printf '\n' >> "$REPO/big.txt"
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "seed" --no-verify >/dev/null 2>&1
+( cd "$REPO" && "$LINT_SH" --check --only hygiene --all >/dev/null 2>&1 )
+RC_ALL=$?
+if [[ "$RC_ALL" -ne 0 ]]; then pass "--all flags a tracked 600 KB file"; else fail "--all should flag a tracked 600 KB file"; fi
+# The hook path lints only the files it is handed, without --enforce-all, so a
+# pre-existing large file it was not given must not be flagged.
+( cd "$REPO" && "$LINT_SH" --only hygiene small.py >/dev/null 2>&1 )
+RC_HOOK=$?
+if [[ "$RC_HOOK" -eq 0 ]]; then pass "file-list path ignores an unlisted large file"; else fail "file-list path should not flag an unlisted large file, rc=$RC_HOOK"; fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/test_lint_hook.sh
+++ b/scripts/test_lint_hook.sh
@@ -13,6 +13,11 @@
 #   (e) a format-dirty .kt blocks the commit (skipped when ktlint is absent)
 #   (f) invalid YAML blocks the commit
 #   (g) lint.sh --all runs over the whole tree
+#   (h) --check passes on a clean tree
+#   (i) --check fails on a lint-dirty .py, format-dirty .md, and .kt (.kt gated
+#       on ktlint availability)
+#   (j) --check leaves the working tree unmodified
+#   (k) --only runs only the named tool family
 #
 # The lint tools are resolved from $LINT_BIN_DIR (default $HOME/.local/bin),
 # exactly as scripts/lint.sh resolves them; .claude/hooks/session-start.sh
@@ -148,6 +153,71 @@ git -C "$REPO" add -A
 ( cd "$REPO" && "$LINT_SH" --all >/dev/null 2>&1 )
 RC=$?
 if [[ "$RC" -eq 0 ]]; then pass "lint.sh --all -> clean tree passes"; else fail "lint.sh --all should pass on a clean tree, rc=$RC"; fi
+
+# ── (h) --check passes on a clean tree ───────────────────────────────────────
+echo ""
+echo "=== (h) --check passes on a clean tree ==="
+REPO="$(new_repo)"
+printf 'x = 1\n' > "$REPO/clean.py"
+printf '# Title\n\nSome text.\n' > "$REPO/clean.md"
+# Normalise the fixtures through fix mode so they are fixed points, then assert
+# check mode is happy with them.
+( cd "$REPO" && "$LINT_SH" clean.py clean.md >/dev/null 2>&1 || true )
+( cd "$REPO" && "$LINT_SH" --check clean.py clean.md >/dev/null 2>&1 )
+RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "--check on clean fixtures passes"; else fail "--check should pass on clean fixtures, rc=$RC"; fi
+
+# ── (i) --check fails on dirty fixtures ──────────────────────────────────────
+echo ""
+echo "=== (i) --check fails on dirty fixtures ==="
+REPO="$(new_repo)"
+printf 'import os\nx=1\n' > "$REPO/bad.py"   # unused import (ruff F401) + spacing
+( cd "$REPO" && "$LINT_SH" --check --only ruff bad.py >/dev/null 2>&1 )
+RC=$?
+if [[ "$RC" -ne 0 ]]; then pass "--check flags a lint-dirty .py"; else fail "--check should flag a lint-dirty .py"; fi
+if grep -q 'import os' "$REPO/bad.py"; then pass "--check did not fix bad.py"; else fail "--check must not fix bad.py"; fi
+
+REPO="$(new_repo)"
+printf '#    Title\n\n\n\nsome   text\n' > "$REPO/doc.md"
+( cd "$REPO" && "$LINT_SH" --check --only mdformat doc.md >/dev/null 2>&1 )
+RC=$?
+if [[ "$RC" -ne 0 ]]; then pass "--check flags a format-dirty .md"; else fail "--check should flag a format-dirty .md"; fi
+
+if [[ $KTLINT_AVAILABLE -eq 1 ]]; then
+    REPO="$(new_repo)"
+    printf 'fun main( ){println( "hi" )}\n' > "$REPO/Main.kt"
+    ( cd "$REPO" && "$LINT_SH" --check --only ktlint Main.kt >/dev/null 2>&1 )
+    RC=$?
+    if [[ "$RC" -ne 0 ]]; then pass "--check flags a format-dirty .kt"; else fail "--check should flag a format-dirty .kt"; fi
+else
+    echo "  SKIP: ktlint not available under \$LINT_BIN_DIR ($LINT_BIN_DIR)"
+fi
+
+# ── (j) --check leaves the working tree unmodified ───────────────────────────
+echo ""
+echo "=== (j) --check leaves the tree unmodified ==="
+REPO="$(new_repo)"
+printf 'x = 1\n' > "$REPO/keep.py"
+printf '# Title\n\nText.\n' > "$REPO/keep.md"
+( cd "$REPO" && "$LINT_SH" keep.py keep.md >/dev/null 2>&1 || true )
+BEFORE="$( cd "$REPO" && sha256sum keep.py keep.md )"
+( cd "$REPO" && "$LINT_SH" --check keep.py keep.md >/dev/null 2>&1 )
+AFTER="$( cd "$REPO" && sha256sum keep.py keep.md )"
+if [[ "$BEFORE" == "$AFTER" ]]; then pass "--check did not modify the fixtures"; else fail "--check modified the fixtures"; fi
+
+# ── (k) --only isolates a tool family ────────────────────────────────────────
+echo ""
+echo "=== (k) --only isolates a tool family ==="
+REPO="$(new_repo)"
+printf '#    Title\n\n\n\nsome   text\n' > "$REPO/only.md"
+# The ruff family sees no .py, so a format-dirty .md is invisible to it...
+( cd "$REPO" && "$LINT_SH" --check --only ruff only.md >/dev/null 2>&1 )
+RC_RUFF=$?
+# ...but the mdformat family flags exactly this file.
+( cd "$REPO" && "$LINT_SH" --check --only mdformat only.md >/dev/null 2>&1 )
+RC_MD=$?
+if [[ "$RC_RUFF" -eq 0 ]]; then pass "--only ruff ignores a dirty .md"; else fail "--only ruff should ignore a dirty .md, rc=$RC_RUFF"; fi
+if [[ "$RC_MD" -ne 0 ]]; then pass "--only mdformat flags a dirty .md"; else fail "--only mdformat should flag a dirty .md"; fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Fixes #698.

Adds CI enforcement of the repo's linters so formatting and hygiene violations are caught even when the commit-time git hook did not run.
A local clone has no hook, and `git commit --no-verify` bypasses it everywhere, so CI is the one enforcement point that cannot be locally skipped.

The linters run as four independent jobs by tool family (python-ruff, markdown-mdformat, hygiene, kotlin-ktlint), in parallel, each passing or failing on its own so the checks show red or green individually.
Each job invokes `scripts/lint.sh --check --only <family> --all`, so the git hook and CI share one definition of how each tool runs and cannot drift apart.

## How it works

- `scripts/lint.sh` gains `--check` (run each tool in its check-only invocation: `ruff check` with no `--fix`, `ruff format --check`, `mdformat --check`, `ktlint` with no `--format`) and `--only ruff|mdformat|ktlint|hygiene` (run one family).
  The read-only hygiene checks are unchanged; the two whitespace fixers have no check-only mode, so they run as usual and fail the run via their exit status if they change anything.
  On a clean tree, check mode writes nothing.
  The existing default (fix-mode) behavior is unchanged, so the pre-commit hook is unaffected.
- The `check-added-large-files` handling is fixed to pass `--enforce-all` on the whole-tree (`--all`) run.
  Without it, nothing is staged on an `--all` run, so the size check checked nothing; the flag is omitted on the file-list (hook) path, or it would flag pre-existing large files a commit is not adding.
- ktlint provisioning (version, published SHA-256, download-and-verify) is extracted from `session-start.sh` into `scripts/install-ktlint.sh`, which both the hook and the CI ktlint job now run, so the SHA-verified install is defined once.
- `.github/workflows/lint.yml` runs the four jobs on `push`/`pull_request` to `main` and `workflow_dispatch`, with `permissions: contents: read`.
  The Python jobs reuse `scripts/requirements-lint.txt` for pinned versions; the ktlint job runs `scripts/install-ktlint.sh` after `actions/setup-java`.
  It lives in its own workflow rather than `build.yml`, whose `build-and-test` job is skipped on docs-only PRs where Markdown and hygiene linting must still run.

CI checks only; it never auto-fixes or pushes.

## Commits

1. Add `--check` and `--only` to `scripts/lint.sh` (+ tests).
2. Enforce `check-added-large-files` over the whole tree under `--all` (+ test).
3. Extract ktlint provisioning into `scripts/install-ktlint.sh` (behavior-preserving).
4. Add `.github/workflows/lint.yml`.

## Testing

`scripts/test_lint_hook.sh` is extended with cases for check mode, tool-family selection, check-mode non-mutation, and the large-files rule; it runs in CI via `build.yml`'s existing "Run shell script unit tests" step.
Locally the full suite passes (18/18), and each of the four CI commands (`scripts/lint.sh --check --only <family> --all`) exits 0 against a clean checkout.

## Out of scope

- Making these checks block merge (branch-protection configuration in GitHub settings) is deferred, per the issue.

🦀
