### PR TITLE
Remove stale ktlint JARs on a KTLINT_VERSION bump

### DIFF
--- a/scripts/install-ktlint.sh
+++ b/scripts/install-ktlint.sh
@@ -17,7 +17,16 @@
 # Install locations (override via the environment if needed):
 #   $KTLINT_BIN_DIR/ktlint            wrapper script on PATH (default ~/.local/bin)
 #   $KTLINT_JAR_DIR/ktlint-cli-*.jar  the verified JAR (default ~/.local/lib/ktlint)
-# Idempotent: if both already exist, it does nothing.
+# Idempotent: if both already exist, it does nothing (beyond the stale-JAR
+# cleanup below).
+#
+# On a KTLINT_VERSION bump, the previous version's JAR is not overwritten (the
+# filename is version-suffixed) and the wrapper is simply repointed at the new
+# one, so the old JAR would otherwise be left behind in $KTLINT_JAR_DIR forever
+# (issue #700). cleanup_stale_jars() removes every ktlint-cli-*-all.jar in that
+# directory other than the one this script's KTLINT_VERSION currently names,
+# once that current JAR is confirmed present, whether this run just verified
+# and installed it or found it already there.
 #
 # When bumping KTLINT_VERSION, update KTLINT_SHA256 to the new release's
 # published checksum from
@@ -33,8 +42,25 @@ KTLINT_JAR_DIR="${KTLINT_JAR_DIR:-$HOME/.local/lib/ktlint}"
 KTLINT_JAR="$KTLINT_JAR_DIR/ktlint-cli-$KTLINT_VERSION-all.jar"
 KTLINT_BIN="$KTLINT_BIN_DIR/ktlint"
 
+# Remove any previously installed ktlint-cli-*-all.jar other than the current
+# KTLINT_VERSION's, left behind by an earlier version bump. Only called once
+# the current JAR is confirmed on disk, so a failed download never costs us
+# the previously working install.
+cleanup_stale_jars() {
+    local jar
+    [[ -d "$KTLINT_JAR_DIR" ]] || return 0
+    shopt -s nullglob
+    for jar in "$KTLINT_JAR_DIR"/ktlint-cli-*-all.jar; do
+        [[ "$jar" == "$KTLINT_JAR" ]] && continue
+        echo "[install-ktlint] removing stale $(basename "$jar")"
+        rm -f "$jar"
+    done
+    shopt -u nullglob
+}
+
 if [[ -x "$KTLINT_BIN" && -f "$KTLINT_JAR" ]]; then
     echo "[install-ktlint] ktlint $KTLINT_VERSION present--skip"
+    cleanup_stale_jars
     exit 0
 fi
 
@@ -60,4 +86,5 @@ cat > "$KTLINT_BIN" << EOF
 exec java -jar "$KTLINT_JAR" "\$@"
 EOF
 chmod +x "$KTLINT_BIN"
+cleanup_stale_jars
 echo "[install-ktlint] ktlint installed and SHA-256 verified"

--- a/scripts/test_install_ktlint.sh
+++ b/scripts/test_install_ktlint.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test_install_ktlint.sh: unit tests for scripts/install-ktlint.sh's stale-JAR
+# cleanup (issue #700).
+#
+# On a KTLINT_VERSION bump, the previous version's JAR is version-suffixed and
+# never overwritten, so it would otherwise sit in $KTLINT_JAR_DIR forever.
+# install-ktlint.sh now removes every ktlint-cli-*-all.jar other than the
+# current KTLINT_VERSION's, once that current JAR is confirmed present.
+#
+# These tests exercise the script's "already installed--skip" fast path only,
+# by pre-seeding fake JAR/wrapper files under isolated KTLINT_BIN_DIR /
+# KTLINT_JAR_DIR temp directories. That path performs no network I/O, so it
+# runs unconditionally in CI and locally without depending on Maven Central
+# reachability; the real download-and-verify path is already covered by every
+# session-start.sh run and the kotlin-ktlint CI job.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/install-ktlint.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# The script's own KTLINT_VERSION is the source of truth here, so these tests
+# keep working across a version bump without edits.
+CURRENT_VERSION="$(sed -n 's/^KTLINT_VERSION="\(.*\)"$/\1/p' "$INSTALL_SH")"
+if [[ -z "$CURRENT_VERSION" ]]; then
+    echo "FAIL: could not parse KTLINT_VERSION out of $INSTALL_SH"
+    exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Set up isolated bin/jar dirs with the current version already "installed"
+# (fake, network-free), plus whatever extra jar files the caller lists as
+# additional args, and run install-ktlint.sh over them.
+run_case() {
+    local case_dir="$1"
+    shift
+    local bin_dir="$case_dir/bin"
+    local jar_dir="$case_dir/jar"
+    mkdir -p "$bin_dir" "$jar_dir"
+    printf '#!/usr/bin/env bash\nexec java -jar fake "$@"\n' > "$bin_dir/ktlint"
+    chmod +x "$bin_dir/ktlint"
+    printf 'fake-jar' > "$jar_dir/ktlint-cli-$CURRENT_VERSION-all.jar"
+    local extra
+    for extra in "$@"; do
+        printf 'fake-jar' > "$jar_dir/$extra"
+    done
+    KTLINT_BIN_DIR="$bin_dir" KTLINT_JAR_DIR="$jar_dir" "$INSTALL_SH" > "$case_dir/out.log" 2>&1
+    echo $?
+}
+
+# ── (a) a stale older-version JAR is removed ─────────────────────────────────
+echo ""
+echo "=== (a) stale older-version JAR is removed ==="
+CASE="$TMP/a"
+mkdir -p "$CASE"
+RC="$(run_case "$CASE" "ktlint-cli-1.6.0-all.jar")"
+if [[ "$RC" -eq 0 ]]; then pass "install-ktlint.sh exits 0"; else fail "install-ktlint.sh should exit 0, rc=$RC"; fi
+if [[ ! -f "$CASE/jar/ktlint-cli-1.6.0-all.jar" ]]; then
+    pass "stale ktlint-cli-1.6.0-all.jar was removed"
+else
+    fail "stale ktlint-cli-1.6.0-all.jar should have been removed"
+fi
+if [[ -f "$CASE/jar/ktlint-cli-$CURRENT_VERSION-all.jar" ]]; then
+    pass "current-version JAR was kept"
+else
+    fail "current-version JAR should have been kept"
+fi
+
+# ── (b) multiple stale JARs are all removed ──────────────────────────────────
+echo ""
+echo "=== (b) multiple stale JARs are all removed ==="
+CASE="$TMP/b"
+mkdir -p "$CASE"
+RC="$(run_case "$CASE" "ktlint-cli-1.5.0-all.jar" "ktlint-cli-1.6.0-all.jar" "ktlint-cli-1.7.0-all.jar")"
+if [[ "$RC" -eq 0 ]]; then pass "install-ktlint.sh exits 0"; else fail "install-ktlint.sh should exit 0, rc=$RC"; fi
+REMAINING="$(find "$CASE/jar" -maxdepth 1 -name 'ktlint-cli-*-all.jar' | wc -l | tr -d ' ')"
+if [[ "$REMAINING" -eq 1 ]]; then
+    pass "only the current-version JAR remains"
+else
+    fail "expected exactly 1 JAR to remain, found $REMAINING"
+fi
+
+# ── (c) no stale JARs: idempotent no-op ──────────────────────────────────────
+echo ""
+echo "=== (c) no stale JARs is a no-op ==="
+CASE="$TMP/c"
+mkdir -p "$CASE"
+RC="$(run_case "$CASE")"
+if [[ "$RC" -eq 0 ]]; then pass "install-ktlint.sh exits 0"; else fail "install-ktlint.sh should exit 0, rc=$RC"; fi
+if [[ -f "$CASE/jar/ktlint-cli-$CURRENT_VERSION-all.jar" ]]; then
+    pass "current-version JAR is untouched"
+else
+    fail "current-version JAR should still be present"
+fi
+
+# ── (d) an unrelated file in the JAR dir is left alone ───────────────────────
+echo ""
+echo "=== (d) unrelated file is left alone ==="
+CASE="$TMP/d"
+mkdir -p "$CASE"
+RC="$(run_case "$CASE" "ktlint-cli-1.6.0-all.jar")"
+printf 'keep me' > "$CASE/jar/notes.txt"
+KTLINT_BIN_DIR="$CASE/bin" KTLINT_JAR_DIR="$CASE/jar" "$INSTALL_SH" > "$CASE/out2.log" 2>&1
+RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "install-ktlint.sh exits 0"; else fail "install-ktlint.sh should exit 0, rc=$RC"; fi
+if [[ -f "$CASE/jar/notes.txt" ]]; then
+    pass "unrelated file was left alone"
+else
+    fail "unrelated file should not have been removed"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed."
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Fixes #700.

`scripts/install-ktlint.sh` (extracted from `.claude/hooks/session-start.sh` STEP 3a by #698) names its JAR with a version suffix, `ktlint-cli-$KTLINT_VERSION-all.jar`. On a `KTLINT_VERSION` bump, the new JAR installs under its own new name and the `ktlint` wrapper is correctly regenerated to point at it, but the previous version's JAR is never removed, so it accumulates as disk residue in `$KTLINT_JAR_DIR` (`~/.local/lib/ktlint/` by default) indefinitely.

This adds `cleanup_stale_jars()` to `install-ktlint.sh`, which removes every `ktlint-cli-*-all.jar` in that directory other than the one the script's current `KTLINT_VERSION` names. It runs only after the current version's JAR is confirmed present, whether this run just downloaded and SHA-256-verified it or found it already installed, so a failed download never costs the previously working install. Since both the git hook and the CI `kotlin-ktlint` job call this one shared script, the cleanup applies uniformly to both.

New coverage in `scripts/test_install_ktlint.sh` exercises the network-free "already installed" fast path: a lone stale JAR removed, several stale JARs all removed, a no-op when there is nothing stale, and an unrelated file in the same directory left alone. The real download-and-verify path continues to run for real on every `session-start.sh` invocation and in the `kotlin-ktlint` CI job, so it did not need a separate network-dependent test.

## Test plan

- [x] `scripts/test_install_ktlint.sh` passes locally.
- [x] `scripts/test_lint_hook.sh` still passes (unaffected by this change).
- [x] `scripts/lint.sh --check scripts/install-ktlint.sh scripts/test_install_ktlint.sh` is clean.
- [x] Ran `scripts/install-ktlint.sh` for real against an already-installed ktlint; confirmed it still exits via the fast path with no unwanted deletions.

