### PR TITLE
Enforce MD040 (fenced code blocks must name a language) via scripts/lint.sh

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,8 @@ jobs:
           pip install -r scripts/requirements-lint.txt
           echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
       - name: mdformat check
+        # Also runs scripts/check_md040.py (issue #689): MD040 (a fenced code
+        # block must name a language) is not something mdformat itself checks.
         run: scripts/lint.sh --check --only mdformat --all
 
   hygiene:

--- a/scripts/check_md040.py
+++ b/scripts/check_md040.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Check Markdown files for fenced code blocks with no declared language.
+
+MD040 (markdownlint's rule of the same name: "fenced code blocks should have a
+language specified") was enforced by markdownlint-cli2 until issue #688
+replaced it with mdformat. mdformat reformats a fence's contents but does not
+check whether the fence declares a language, so a new offender (a bare
+```` ``` ```` with nothing after it) would go uncaught. This script closes that
+gap: it runs as part of the mdformat family in scripts/lint.sh (the git
+pre-commit hook) and in .github/workflows/lint.yml's markdown-mdformat job, so
+the hook and CI share one definition of the check.
+
+Only the Python standard library is used, so this runs under the ambient
+`python3` with no dependency install step, the same way scripts/lint.sh invokes
+other first-party scripts (see e.g. scripts/check_non_docs_changes.sh). This
+also sidesteps scripts/lint.sh's $LINT_BIN_DIR indirection, which exists to
+resolve third-party tools installed from a trusted registry (issue #667) and
+does not apply to a first-party script checked out with the repo itself.
+
+The fence scanner is a lightweight, line-based approximation of CommonMark's
+fenced-code-block rules (opening delimiter of 3+ backticks or tildes, optional
+up to 3 spaces of indentation, closed only by a same-character delimiter at
+least as long): the mdformat and mdformat-gfm output this repo produces is
+plain, unindented fences at column 0 (`--wrap keep` normalizes prose but not
+fence indentation), so full blockquote/list-nesting fidelity is not needed.
+
+Usage:
+    scripts/check_md040.py FILE [FILE ...]
+
+Exit code:
+    0  no fenced code block is missing a language in any given file.
+    1  at least one fenced code block is missing a language; each is printed
+       to stderr as "path:line: fenced code block has no language (MD040)".
+    2  usage error (no files given).
+"""
+
+import re
+import sys
+
+# A fence opener/closer: up to 3 spaces of indentation, then 3+ of the same
+# fence character, then (for an opener) an optional info string.
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$")
+
+
+def find_violations(path: str) -> list[int]:
+    """Return the 1-based line numbers of fenced code blocks with no language in *path*."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    violations: list[int] = []
+    fence_char: str | None = None
+    fence_len = 0
+    for lineno, raw in enumerate(lines, start=1):
+        line = raw.rstrip("\n")
+        match = _FENCE_RE.match(line)
+        if fence_char is None:
+            if not match:
+                continue
+            marker, info = match.group(1), match.group(2)
+            char = marker[0]
+            # A backtick info string cannot itself contain a backtick in
+            # CommonMark (it would be ambiguous with inline code spans), so a
+            # line like that is not a valid opening fence.
+            if char == "`" and "`" in info:
+                continue
+            fence_char, fence_len = char, len(marker)
+            if not info.strip():
+                violations.append(lineno)
+        else:
+            # Inside a fence: only a same-character delimiter at least as long
+            # as the opener, with nothing else but trailing space, closes it.
+            close_re = re.compile(
+                r"^ {0,3}(" + re.escape(fence_char) + "{" + str(fence_len) + ",})[ \t]*$"
+            )
+            if close_re.match(line):
+                fence_char, fence_len = None, 0
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: check_md040.py FILE [FILE ...]", file=sys.stderr)
+        return 2
+
+    status = 0
+    for path in argv:
+        for lineno in find_violations(path):
+            print(f"{path}:{lineno}: fenced code block has no language (MD040)", file=sys.stderr)
+            status = 1
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -38,9 +38,14 @@
 # check-only mode, so they run as usual and their non-zero exit on any change
 # fails the run, without altering the pass/fail contract. On a clean tree check
 # mode writes nothing and exits 0.
+#
+# scripts/check_md040.py (mdformat family) is read-only in both modes: MD040
+# (a fenced code block must name a language) has no auto-fix, so it always
+# reports rather than rewriting (issue #689).
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT_BIN_DIR="${LINT_BIN_DIR:-$HOME/.local/bin}"
 
 usage() {
@@ -175,12 +180,20 @@ fi
 # --wrap keep preserves this repo's one-sentence-per-line prose (see
 # .claude/rules/prose-style.md); --number keeps ordered-list numbering
 # sequential. These match the retired .pre-commit-config.yaml mdformat args.
+#
+# mdformat does not enforce MD040 (fenced code blocks must name a language);
+# markdownlint-cli2 did, until issue #688 replaced it with mdformat. Run
+# check_md040.py alongside mdformat, in both fix and check mode, so a new
+# offender is still caught even though there is nothing to auto-fix (issue
+# #689). It is a first-party script, not a registry-installed tool, so it runs
+# under the ambient python3 rather than through $LINT_BIN_DIR.
 if want mdformat && [[ ${#MD[@]} -gt 0 ]]; then
     if [[ $CHECK -eq 1 ]]; then
         run "$LINT_BIN_DIR/mdformat" --check --wrap keep --number "${MD[@]}"
     else
         run "$LINT_BIN_DIR/mdformat" --wrap keep --number "${MD[@]}"
     fi
+    run python3 "$SCRIPT_DIR/check_md040.py" "${MD[@]}"
 fi
 
 # ktlint family: format Kotlin.

--- a/scripts/test_check_md040.py
+++ b/scripts/test_check_md040.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Unit tests for check_md040.py."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import check_md040  # noqa: E402
+
+
+def _write(tmpdir: str, name: str, content: str) -> str:
+    path = os.path.join(tmpdir, name)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+
+class TestFindViolations(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmpdir = self._tmp.name
+
+    def test_labeled_fence_is_not_a_violation(self):
+        path = _write(self.tmpdir, "ok.md", "# Title\n\n```python\nprint(1)\n```\n")
+        self.assertEqual(check_md040.find_violations(path), [])
+
+    def test_bare_backtick_fence_is_a_violation(self):
+        path = _write(self.tmpdir, "bad.md", "# Title\n\n```\nno language\n```\n")
+        self.assertEqual(check_md040.find_violations(path), [3])
+
+    def test_bare_tilde_fence_is_a_violation(self):
+        path = _write(self.tmpdir, "bad.md", "# Title\n\n~~~\nno language\n~~~\n")
+        self.assertEqual(check_md040.find_violations(path), [3])
+
+    def test_multiple_violations_are_all_reported(self):
+        content = "```\nfirst\n```\n\ntext\n\n```\nsecond\n```\n"
+        path = _write(self.tmpdir, "bad.md", content)
+        self.assertEqual(check_md040.find_violations(path), [1, 7])
+
+    def test_mixed_labeled_and_unlabeled_fences(self):
+        content = "```python\nok = 1\n```\n\n```\nbad\n```\n"
+        path = _write(self.tmpdir, "mixed.md", content)
+        self.assertEqual(check_md040.find_violations(path), [5])
+
+    def test_unlabeled_fence_nested_as_content_inside_a_labeled_fence(self):
+        # A longer, labeled outer fence containing a shorter bare ``` as
+        # literal content (e.g. documenting Markdown syntax) is not itself a
+        # violation: the inner ``` never opens a new fence because the outer
+        # fence is still open.
+        content = "````text\nExample:\n```\nbare, but just content here\n```\n````\n"
+        path = _write(self.tmpdir, "nested.md", content)
+        self.assertEqual(check_md040.find_violations(path), [])
+
+    def test_no_fences_at_all(self):
+        path = _write(self.tmpdir, "plain.md", "# Title\n\nJust prose.\n")
+        self.assertEqual(check_md040.find_violations(path), [])
+
+    def test_indented_code_block_is_not_a_fence(self):
+        # A 4-space-indented code block is CommonMark's other code-block
+        # syntax; it never declares a language and MD040 does not apply to it.
+        path = _write(self.tmpdir, "indented.md", "# Title\n\n    plain code\n")
+        self.assertEqual(check_md040.find_violations(path), [])
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmpdir = self._tmp.name
+
+    def test_no_files_is_a_usage_error(self):
+        self.assertEqual(check_md040.main([]), 2)
+
+    def test_clean_files_exit_zero(self):
+        path = _write(self.tmpdir, "ok.md", "# Title\n\n```python\nprint(1)\n```\n")
+        self.assertEqual(check_md040.main([path]), 0)
+
+    def test_dirty_file_exits_one(self):
+        path = _write(self.tmpdir, "bad.md", "```\nbad\n```\n")
+        self.assertEqual(check_md040.main([path]), 1)
+
+    def test_one_dirty_file_among_clean_ones_exits_one(self):
+        clean = _write(self.tmpdir, "ok.md", "```python\nprint(1)\n```\n")
+        dirty = _write(self.tmpdir, "bad.md", "```\nbad\n```\n")
+        self.assertEqual(check_md040.main([clean, dirty]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_lint_hook.sh
+++ b/scripts/test_lint_hook.sh
@@ -20,6 +20,8 @@
 #   (k) --only runs only the named tool family
 #   (l) a tracked file over 500 KB fails --all (--enforce-all), while the
 #       file-list (hook) path leaves an unlisted large file alone
+#   (m) an .md with an unlabeled fenced code block (MD040) blocks the commit,
+#       even though mdformat itself has nothing to fix
 #
 # The lint tools are resolved from $LINT_BIN_DIR (default $HOME/.local/bin),
 # exactly as scripts/lint.sh resolves them; .claude/hooks/session-start.sh
@@ -242,6 +244,28 @@ if [[ "$RC_ALL" -ne 0 ]]; then pass "--all flags a tracked 600 KB file"; else fa
 ( cd "$REPO" && "$LINT_SH" --only hygiene small.py >/dev/null 2>&1 )
 RC_HOOK=$?
 if [[ "$RC_HOOK" -eq 0 ]]; then pass "file-list path ignores an unlisted large file"; else fail "file-list path should not flag an unlisted large file, rc=$RC_HOOK"; fi
+
+# ── (m) unlabeled fenced code block (MD040) blocks the commit ───────────────
+echo ""
+echo "=== (m) MD040 (unlabeled fence) blocks ==="
+REPO="$(new_repo)"
+printf '# Title\n\n```\nno language here\n```\n' > "$REPO/md040.md"
+RC="$(attempt_commit "$REPO")"
+if [[ "$RC" -ne 0 ]]; then pass "MD040 (unlabeled fence) -> commit blocked"; else fail "MD040 (unlabeled fence) should block"; fi
+# mdformat has no fix for a missing language, so --check should flag it too,
+# and leave the fixture untouched (nothing to auto-fix).
+REPO="$(new_repo)"
+printf '# Title\n\n```\nno language here\n```\n' > "$REPO/md040.md"
+( cd "$REPO" && "$LINT_SH" --check --only mdformat md040.md >/dev/null 2>&1 )
+RC=$?
+if [[ "$RC" -ne 0 ]]; then pass "--check flags MD040 (unlabeled fence)"; else fail "--check should flag MD040 (unlabeled fence)"; fi
+if grep -q '^```$' "$REPO/md040.md"; then pass "MD040 fixture left unmodified (no auto-fix exists)"; else fail "MD040 fixture should be left unmodified"; fi
+# A labeled fence is not a violation.
+REPO="$(new_repo)"
+printf '# Title\n\n```python\nprint(1)\n```\n' > "$REPO/labeled.md"
+( cd "$REPO" && "$LINT_SH" --check --only mdformat labeled.md >/dev/null 2>&1 )
+RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "--check passes a labeled fence"; else fail "--check should pass a labeled fence, rc=$RC"; fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Fixes #689.

markdownlint-cli2 enforced MD040 (fenced code blocks must name a language) until PR #688 replaced it with mdformat, which reformats a fence's contents but does not check whether it declares a language. This left new MD040 offenders uncaught going forward.

## Changes

- `scripts/check_md040.py` (new): scans given Markdown files for fenced code blocks with no language, using a stdlib-only, CommonMark-approximating fence scanner. Handles both backtick and tilde fences, and correctly ignores a bare fence that appears as literal content nested inside a longer, labeled outer fence.
- `scripts/lint.sh`: wires the new check into the mdformat family, in both fix and check mode (there is nothing to auto-fix, so it always reports). This runs it identically at commit time (the git pre-commit hook) and in CI (`.github/workflows/lint.yml`'s `markdown-mdformat` job, added by #698/#706), per the sequencing note on the issue.
- `scripts/test_lint_hook.sh`: new end-to-end cases -- an unlabeled fence blocks a commit, `--check` flags it without modifying the file, and a labeled fence passes.
- `scripts/test_check_md040.py` (new): unit tests for the fence scanner (labeled/unlabeled, backtick/tilde, multiple violations, nested-as-content, indented code blocks, `main()`'s exit codes).

The tree has no existing MD040 offenders (confirmed by running the new check over every tracked `.md` file), so no reformatting was needed.

## Test plan

- [x] `scripts/lint.sh --check --all` passes on the full tree.
- [x] `bash scripts/test_lint_hook.sh` passes (22 cases, including the 3 new MD040 cases).
- [x] `python3 -m unittest scripts.test_check_md040` passes (12 cases).
- [x] `python3 -m unittest discover -s scripts -p "test_*.py"` shows no new failures (the 4 pre-existing errors are unrelated missing-dependency/environment issues in this sandbox, not caused by this change).

