### PR TITLE
Rename lint.sh's tool families to language names

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           pip install -r scripts/requirements-lint.txt
           echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
       - name: Ruff check
-        run: scripts/lint.sh --check --only ruff --all
+        run: scripts/lint.sh --check --only python --all
 
   markdown-mdformat:
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
       - name: mdformat check
         # Also runs scripts/check_md040.py (issue #689): MD040 (a fenced code
         # block must name a language) is not something mdformat itself checks.
-        run: scripts/lint.sh --check --only mdformat --all
+        run: scripts/lint.sh --check --only markdown --all
 
   hygiene:
     runs-on: ubuntu-latest
@@ -84,4 +84,4 @@ jobs:
         # needed for the check step below.
         run: scripts/install-ktlint.sh
       - name: ktlint check
-        run: scripts/lint.sh --check --only ktlint --all
+        run: scripts/lint.sh --check --only kotlin --all

--- a/scripts/check_md040.py
+++ b/scripts/check_md040.py
@@ -6,7 +6,7 @@ language specified") was enforced by markdownlint-cli2 until issue #688
 replaced it with mdformat. mdformat reformats a fence's contents but does not
 check whether the fence declares a language, so a new offender (a bare
 ```` ``` ```` with nothing after it) would go uncaught. This script closes that
-gap: it runs as part of the mdformat family in scripts/lint.sh (the git
+gap: it runs as part of the markdown family in scripts/lint.sh (the git
 pre-commit hook) and in .github/workflows/lint.yml's markdown-mdformat job, so
 the hook and CI share one definition of the check.
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,7 +8,7 @@
 # Options (combine with either form above):
 #   --check                 run each tool in its check-only invocation and report,
 #                           rather than auto-fixing. See "Check mode" below.
-#   --only ruff|mdformat|ktlint|hygiene
+#   --only python|markdown|kotlin|hygiene
 #                           run only one tool family, skipping the others.
 #
 # This is the single source of truth for "run the linters". The git pre-commit
@@ -39,7 +39,7 @@
 # fails the run, without altering the pass/fail contract. On a clean tree check
 # mode writes nothing and exits 0.
 #
-# scripts/check_md040.py (mdformat family) is read-only in both modes: MD040
+# scripts/check_md040.py (markdown family) is read-only in both modes: MD040
 # (a fenced code block must name a language) has no auto-fix, so it always
 # reports rather than rewriting (issue #689).
 
@@ -49,7 +49,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LINT_BIN_DIR="${LINT_BIN_DIR:-$HOME/.local/bin}"
 
 usage() {
-    echo "usage: lint.sh [--check] [--only ruff|mdformat|ktlint|hygiene] FILE [FILE ...] | --all" >&2
+    echo "usage: lint.sh [--check] [--only python|markdown|kotlin|hygiene] FILE [FILE ...] | --all" >&2
     exit 2
 }
 
@@ -66,7 +66,7 @@ while [[ $# -gt 0 ]]; do
         --only)
             ONLY="${2:-}"
             case "$ONLY" in
-                ruff | mdformat | ktlint | hygiene) ;;
+                python | markdown | kotlin | hygiene) ;;
                 *) usage ;;
             esac
             shift 2
@@ -165,8 +165,8 @@ if want hygiene; then
     [[ ${#TOML[@]} -gt 0 ]] && run "$LINT_BIN_DIR/check-toml" "${TOML[@]}"
 fi
 
-# ruff family: lint + format Python.
-if want ruff && [[ ${#PY[@]} -gt 0 ]]; then
+# python family: lint + format Python.
+if want python && [[ ${#PY[@]} -gt 0 ]]; then
     if [[ $CHECK -eq 1 ]]; then
         run "$LINT_BIN_DIR/ruff" check "${PY[@]}"
         run "$LINT_BIN_DIR/ruff" format --check "${PY[@]}"
@@ -176,7 +176,7 @@ if want ruff && [[ ${#PY[@]} -gt 0 ]]; then
     fi
 fi
 
-# mdformat family: format Markdown.
+# markdown family: format Markdown.
 # --wrap keep preserves this repo's one-sentence-per-line prose (see
 # .claude/rules/prose-style.md); --number keeps ordered-list numbering
 # sequential. These match the retired .pre-commit-config.yaml mdformat args.
@@ -187,7 +187,7 @@ fi
 # offender is still caught even though there is nothing to auto-fix (issue
 # #689). It is a first-party script, not a registry-installed tool, so it runs
 # under the ambient python3 rather than through $LINT_BIN_DIR.
-if want mdformat && [[ ${#MD[@]} -gt 0 ]]; then
+if want markdown && [[ ${#MD[@]} -gt 0 ]]; then
     if [[ $CHECK -eq 1 ]]; then
         run "$LINT_BIN_DIR/mdformat" --check --wrap keep --number "${MD[@]}"
     else
@@ -196,8 +196,8 @@ if want mdformat && [[ ${#MD[@]} -gt 0 ]]; then
     run python3 "$SCRIPT_DIR/check_md040.py" "${MD[@]}"
 fi
 
-# ktlint family: format Kotlin.
-if want ktlint && [[ ${#KT[@]} -gt 0 ]]; then
+# kotlin family: format Kotlin.
+if want kotlin && [[ ${#KT[@]} -gt 0 ]]; then
     if [[ $CHECK -eq 1 ]]; then
         run "$LINT_BIN_DIR/ktlint" "${KT[@]}"
     else

--- a/scripts/test_lint_hook.sh
+++ b/scripts/test_lint_hook.sh
@@ -176,21 +176,21 @@ echo ""
 echo "=== (i) --check fails on dirty fixtures ==="
 REPO="$(new_repo)"
 printf 'import os\nx=1\n' > "$REPO/bad.py"   # unused import (ruff F401) + spacing
-( cd "$REPO" && "$LINT_SH" --check --only ruff bad.py >/dev/null 2>&1 )
+( cd "$REPO" && "$LINT_SH" --check --only python bad.py >/dev/null 2>&1 )
 RC=$?
 if [[ "$RC" -ne 0 ]]; then pass "--check flags a lint-dirty .py"; else fail "--check should flag a lint-dirty .py"; fi
 if grep -q 'import os' "$REPO/bad.py"; then pass "--check did not fix bad.py"; else fail "--check must not fix bad.py"; fi
 
 REPO="$(new_repo)"
 printf '#    Title\n\n\n\nsome   text\n' > "$REPO/doc.md"
-( cd "$REPO" && "$LINT_SH" --check --only mdformat doc.md >/dev/null 2>&1 )
+( cd "$REPO" && "$LINT_SH" --check --only markdown doc.md >/dev/null 2>&1 )
 RC=$?
 if [[ "$RC" -ne 0 ]]; then pass "--check flags a format-dirty .md"; else fail "--check should flag a format-dirty .md"; fi
 
 if [[ $KTLINT_AVAILABLE -eq 1 ]]; then
     REPO="$(new_repo)"
     printf 'fun main( ){println( "hi" )}\n' > "$REPO/Main.kt"
-    ( cd "$REPO" && "$LINT_SH" --check --only ktlint Main.kt >/dev/null 2>&1 )
+    ( cd "$REPO" && "$LINT_SH" --check --only kotlin Main.kt >/dev/null 2>&1 )
     RC=$?
     if [[ "$RC" -ne 0 ]]; then pass "--check flags a format-dirty .kt"; else fail "--check should flag a format-dirty .kt"; fi
 else
@@ -214,14 +214,14 @@ echo ""
 echo "=== (k) --only isolates a tool family ==="
 REPO="$(new_repo)"
 printf '#    Title\n\n\n\nsome   text\n' > "$REPO/only.md"
-# The ruff family sees no .py, so a format-dirty .md is invisible to it...
-( cd "$REPO" && "$LINT_SH" --check --only ruff only.md >/dev/null 2>&1 )
-RC_RUFF=$?
-# ...but the mdformat family flags exactly this file.
-( cd "$REPO" && "$LINT_SH" --check --only mdformat only.md >/dev/null 2>&1 )
+# The python family sees no .py, so a format-dirty .md is invisible to it...
+( cd "$REPO" && "$LINT_SH" --check --only python only.md >/dev/null 2>&1 )
+RC_PY=$?
+# ...but the markdown family flags exactly this file.
+( cd "$REPO" && "$LINT_SH" --check --only markdown only.md >/dev/null 2>&1 )
 RC_MD=$?
-if [[ "$RC_RUFF" -eq 0 ]]; then pass "--only ruff ignores a dirty .md"; else fail "--only ruff should ignore a dirty .md, rc=$RC_RUFF"; fi
-if [[ "$RC_MD" -ne 0 ]]; then pass "--only mdformat flags a dirty .md"; else fail "--only mdformat should flag a dirty .md"; fi
+if [[ "$RC_PY" -eq 0 ]]; then pass "--only python ignores a dirty .md"; else fail "--only python should ignore a dirty .md, rc=$RC_PY"; fi
+if [[ "$RC_MD" -ne 0 ]]; then pass "--only markdown flags a dirty .md"; else fail "--only markdown should flag a dirty .md"; fi
 
 # ── (l) large file fails --all, hook path unaffected ─────────────────────────
 echo ""
@@ -256,14 +256,14 @@ if [[ "$RC" -ne 0 ]]; then pass "MD040 (unlabeled fence) -> commit blocked"; els
 # and leave the fixture untouched (nothing to auto-fix).
 REPO="$(new_repo)"
 printf '# Title\n\n```\nno language here\n```\n' > "$REPO/md040.md"
-( cd "$REPO" && "$LINT_SH" --check --only mdformat md040.md >/dev/null 2>&1 )
+( cd "$REPO" && "$LINT_SH" --check --only markdown md040.md >/dev/null 2>&1 )
 RC=$?
 if [[ "$RC" -ne 0 ]]; then pass "--check flags MD040 (unlabeled fence)"; else fail "--check should flag MD040 (unlabeled fence)"; fi
 if grep -q '^```$' "$REPO/md040.md"; then pass "MD040 fixture left unmodified (no auto-fix exists)"; else fail "MD040 fixture should be left unmodified"; fi
 # A labeled fence is not a violation.
 REPO="$(new_repo)"
 printf '# Title\n\n```python\nprint(1)\n```\n' > "$REPO/labeled.md"
-( cd "$REPO" && "$LINT_SH" --check --only mdformat labeled.md >/dev/null 2>&1 )
+( cd "$REPO" && "$LINT_SH" --check --only markdown labeled.md >/dev/null 2>&1 )
 RC=$?
 if [[ "$RC" -eq 0 ]]; then pass "--check passes a labeled fence"; else fail "--check should pass a labeled fence, rc=$RC"; fi
 


### PR DESCRIPTION
Fixes #711.

`scripts/lint.sh --only` grouped its checks under values named after the primary tool in each group (`ruff`, `mdformat`, `ktlint`, `hygiene`). Since #709, the `mdformat` family also runs `scripts/check_md040.py`, so asking for that family now runs more than just mdformat. A tool-named family is misleading once it can contain more than one tool.

This renames the families to their main language instead, per the issue's suggestion:

- `ruff` -> `python`
- `mdformat` -> `markdown`
- `ktlint` -> `kotlin`
- `hygiene` -> `hygiene` (unchanged; it is not language-specific)

Updated:

- `scripts/lint.sh`: the `--only` argument parsing, usage text, and the `want <family>` calls/comments for each block.
- `.github/workflows/lint.yml`: the `--only` flag passed by each per-family CI job (job IDs are left as-is, e.g. `python-ruff`, since they already lead with the language name).
- `scripts/test_lint_hook.sh`: the `--only` values used in the test fixtures that exercise family isolation.
- `scripts/check_md040.py`: a comment referencing the old family name.

## Test plan

Covered by the existing automated suite (`scripts/test_lint_hook.sh`, exercised via the git hook and CI); no manual verification is needed. Ran the suite locally with the lint tools provisioned into a throwaway venv (plus the already-installed `ktlint`): all 22 assertions pass. Also ran `scripts/lint.sh --check --only <family> --all` for each of the four new family names directly against the tree, and confirmed an old/unknown family name (e.g. `ruff`) is now rejected by the usage error.
