### PR TITLE
Propagate issue labels to a linked PR on a Fixes relationship

### DIFF
--- a/.github/workflows/propagate-issue-labels.yml
+++ b/.github/workflows/propagate-issue-labels.yml
@@ -1,0 +1,36 @@
+name: Propagate issue labels to linked PR
+
+# When a pull request closes an issue via a closing-keyword relationship
+# ("Fixes #N", "Closes #N", the other variants GitHub recognizes, or a
+# manually linked issue), copies that issue's labels onto the pull request.
+# See scripts/propagate_issue_labels.py for the exact rules, including the
+# exception that protects an existing PR label from an indirect
+# mutual-exclusion removal.
+#
+# Runs on "opened" (the closing relationship may already be declared in the
+# initial body) or "edited" where the body itself changed
+# (github.event.changes.body is only present when the body was part of the
+# edit), so unrelated edits (title, labels, base branch) do not re-trigger it.
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  propagate-issue-labels:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened' || github.event.changes.body
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Propagate linked issue labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 scripts/propagate_issue_labels.py

--- a/.github/workflows/propagate-issue-labels.yml
+++ b/.github/workflows/propagate-issue-labels.yml
@@ -30,7 +30,7 @@ name: Propagate issue labels to linked PR
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review, review_requested]
+    types: [opened, edited, reopened]
 
 permissions:
   issues: write

--- a/.github/workflows/propagate-issue-labels.yml
+++ b/.github/workflows/propagate-issue-labels.yml
@@ -7,14 +7,30 @@ name: Propagate issue labels to linked PR
 # exception that protects an existing PR label from an indirect
 # mutual-exclusion removal.
 #
-# Runs on "opened" (the closing relationship may already be declared in the
-# initial body) or "edited" where the body itself changed
-# (github.event.changes.body is only present when the body was part of the
-# edit), so unrelated edits (title, labels, base branch) do not re-trigger it.
+# GitHub fires no webhook event for linking a PR to an issue via the
+# "Development" sidebar after the PR is already open, so a closing
+# relationship established that way, with no body edit, cannot be caught by a
+# single trigger type. Rather than run on a perpetual schedule to cover that
+# gap, this runs on every pull_request event type that commonly recurs during
+# a PR's normal review lifecycle in this repo (a fresh push, a reopen, a
+# ready-for-review flip, a review request), so most sidebar-linked PRs get
+# reconciled by their own ordinary activity. "labeled"/"unlabeled" are
+# deliberately excluded: re-running on "unlabeled" would re-apply a label a
+# human just removed on purpose, clobbering their edit.
+#
+# "edited" only re-runs when the body itself changed
+# (github.event.changes.body is only present then), so unrelated edits
+# (title, base branch) do not re-trigger it. Every other listed type always
+# runs, since none of them carry a "changes" object to gate on.
+#
+# A PR that gets sidebar-linked and then sees none of these events before
+# merge is not covered automatically; scripts/reconcile_issue_labels.py is
+# available to reconcile every open PR on demand (run locally, or dispatch
+# it in Actions) for that residual case.
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, reopened, synchronize, ready_for_review, review_requested]
 
 permissions:
   issues: write
@@ -23,7 +39,7 @@ permissions:
 jobs:
   propagate-issue-labels:
     runs-on: ubuntu-latest
-    if: github.event.action == 'opened' || github.event.changes.body
+    if: github.event.action != 'edited' || github.event.changes.body
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/reconcile-issue-labels.yml
+++ b/.github/workflows/reconcile-issue-labels.yml
@@ -1,0 +1,29 @@
+name: Reconcile issue labels on open PRs
+
+# Periodically re-applies scripts/propagate_issue_labels.py's label
+# propagation rule to every open pull request. This exists because GitHub
+# fires no webhook event for linking a PR to an issue via the "Development"
+# sidebar after the PR is already open, so the pull_request-triggered
+# propagate-issue-labels workflow can miss that case. See
+# scripts/reconcile_issue_labels.py for the full rationale.
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 hours
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Reconcile issue labels across open PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/reconcile_issue_labels.py

--- a/.github/workflows/reconcile-issue-labels.yml
+++ b/.github/workflows/reconcile-issue-labels.yml
@@ -1,15 +1,21 @@
 name: Reconcile issue labels on open PRs
 
-# Periodically re-applies scripts/propagate_issue_labels.py's label
-# propagation rule to every open pull request. This exists because GitHub
-# fires no webhook event for linking a PR to an issue via the "Development"
-# sidebar after the PR is already open, so the pull_request-triggered
-# propagate-issue-labels workflow can miss that case. See
-# scripts/reconcile_issue_labels.py for the full rationale.
+# On-demand re-application of scripts/propagate_issue_labels.py's label
+# propagation rule to every open pull request. propagate-issue-labels.yml's
+# pull_request triggers cover a sidebar-linked PR whenever it sees further
+# ordinary activity (a push, a reopen, and so on); this workflow exists for
+# the residual case of a PR that gets sidebar-linked and then sees none of
+# those events before merge.
+#
+# Deliberately workflow_dispatch-only rather than a schedule: a periodic
+# cron would poll every open PR indefinitely even when nothing needs
+# reconciling, for a gap that is otherwise already closed by the pokes in
+# propagate-issue-labels.yml. Run this manually (from the Actions tab, or
+# locally with `python3 scripts/reconcile_issue_labels.py`) if you suspect a
+# PR was sidebar-linked without triggering that workflow.
 
 on:
-  schedule:
-    - cron: '0 */6 * * *'   # every 6 hours
+  workflow_dispatch: {}
 
 permissions:
   issues: write

--- a/scripts/propagate_issue_labels.py
+++ b/scripts/propagate_issue_labels.py
@@ -16,7 +16,17 @@ is left alone. A candidate label is also skipped, rather than applied, when
 applying it would cause scripts/enforce_mutually_exclusive_labels.py's
 mutual-exclusion enforcement to remove a label the PR already carries--an
 existing PR label always wins over a conflicting label being copied in from a
-linked issue. See labels_to_propagate() for the exact rule.
+linked issue.
+
+An issue's own orchestration-cycle state labels (PROCESS_STATE_LABELS, e.g.
+`orchestrating`, `verification needed`, `changes done`) are never propagated
+at all, even onto a PR that carries none of their conflicting siblings.
+agents/dev_orchestration.md deliberately lets an issue and its PR diverge on
+these mid-cycle (for example, `orchestrating` is removed from the PR alone,
+not the issue, to clear the "No blocking labels" merge gate while
+orchestration is still active), so blindly copying them from issue to PR
+fights that state machine instead of just adding a convenience label. See
+labels_to_propagate() for the exact rule.
 
 The pull_request trigger for this module's main() (see
 .github/workflows/propagate-issue-labels.yml) covers most sidebar-linked PRs
@@ -33,8 +43,8 @@ Usage:
 Exit code:
     0  the PR has no closing issue references, its closing issues carry no
        labels, every eligible label was applied successfully, or every
-       candidate was skipped due to a mutual-exclusion conflict (skipping is
-       not itself a failure).
+       candidate was skipped due to a mutual-exclusion conflict or excluded
+       as orchestration-cycle state (neither is itself a failure).
     1  required configuration is missing/invalid, or fetching or applying
        labels failed.
 
@@ -143,22 +153,57 @@ def fetch_closing_issue_labels(
 # Core logic
 # ---------------------------------------------------------------------------
 
+# Labels agents/dev_orchestration.md manages as orchestration-cycle state,
+# not ordinary content/category labels (contrast with e.g. "p1"-"p3", "ci",
+# "bug", which are fine to copy as-is). The issue and its PR are deliberately
+# allowed, or required, to carry these differently while a PR is under
+# active orchestration:
+#   - `orchestrate`/`orchestrating` is applied to both when orchestration
+#     starts, but `orchestrating` is removed from the PR alone (not the
+#     issue) to clear the "No blocking labels" merge gate mid-cycle
+#     (dev_orchestration.md's labelGateBlock), while the issue keeps it for
+#     the rest of the active cycle.
+#   - `changes requested`/`changes done` transitions apply "to the PR if one
+#     exists; apply it to the issue otherwise"--once a PR exists, these live
+#     on the PR only, and the issue's copy (if any) goes stale by design.
+#   - `verification needed`/`verified` are likewise driven by the PR's own
+#     CI/verification state, not the issue's.
+# Blindly copying any of these from issue to PR does not add a harmless
+# convenience label: it fights this state machine and can re-obstruct a
+# merge gate an Orchestrator just cleared (observed live on PR #713, where a
+# routine push re-applied "orchestrating" moments after it had been removed
+# from the PR alone). So these are never eligible for propagation, even onto
+# a PR that carries none of their conflicting siblings.
+PROCESS_STATE_LABELS: frozenset[str] = frozenset(
+    {
+        "orchestrate",
+        "orchestrating",
+        "verification needed",
+        "verified",
+        "changes requested",
+        "changes done",
+    }
+)
+
 
 def labels_to_propagate(
     current_pr_labels: list[str],
     issue_labels: list[str],
-) -> tuple[list[str], list[str]]:
-    """Partition *issue_labels* into what to add to the PR and what to skip.
+) -> tuple[list[str], list[str], list[str]]:
+    """Partition *issue_labels* into what to add, skip, and exclude.
 
-    Returns (to_add, skipped):
+    Returns (to_add, skipped, excluded):
         to_add    issue labels, not already on the PR, that are safe to add
         skipped   issue labels omitted because applying them would cause
                   enforce_mutually_exclusive_labels.py to remove a label
                   already staged on the PR (a real current PR label, or one
                   accepted earlier in this same call)
+        excluded  issue labels never considered at all because they are in
+                  PROCESS_STATE_LABELS--orchestration-cycle state the issue
+                  and its PR are allowed to carry differently by design
 
     A label already present on the PR (case-insensitively) is dropped from
-    both lists--there is nothing to do for it. A label repeated across
+    every list--there is nothing to do for it. A label repeated across
     multiple closing issues is considered once.
 
     *issue_labels* is processed in order, staging each accepted label into a
@@ -172,13 +217,20 @@ def labels_to_propagate(
     already_lower = {lbl.lower() for lbl in current_pr_labels}
     to_add: list[str] = []
     skipped: list[str] = []
+    excluded: list[str] = []
     seen_lower: set[str] = set()
 
     for label in issue_labels:
         lower = label.lower()
-        if lower in already_lower or lower in seen_lower:
+        if lower in seen_lower:
             continue
         seen_lower.add(lower)
+
+        if lower in PROCESS_STATE_LABELS:
+            excluded.append(label)
+            continue
+        if lower in already_lower:
+            continue
 
         conflict = False
         label_set = emxl.find_conflicting_set(label)
@@ -196,7 +248,7 @@ def labels_to_propagate(
         to_add.append(label)
         staged.append(label)
 
-    return to_add, skipped
+    return to_add, skipped, excluded
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +286,14 @@ def propagate_to_pr(owner: str, name: str, repo: str, pr_number: int, token: str
 
     current_pr_labels = [lbl["name"] for lbl in pr.get("labels", [])]
 
-    to_add, skipped = labels_to_propagate(current_pr_labels, issue_labels)
+    to_add, skipped, excluded = labels_to_propagate(current_pr_labels, issue_labels)
+
+    if excluded:
+        print(
+            f"Excluding orchestration-cycle labels {excluded} on PR #{pr_number}: the "
+            "issue and its PR are allowed to carry these differently while orchestration "
+            "is active (see agents/dev_orchestration.md)."
+        )
 
     if skipped:
         print(

--- a/scripts/propagate_issue_labels.py
+++ b/scripts/propagate_issue_labels.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Copy a linked issue's labels onto a pull request that closes it.
+
+When a pull request closes an issue via a closing-keyword relationship
+("Fixes #N", "Closes #N", and the other variants GitHub recognizes) or via a
+manually linked issue, this applies each of that issue's labels to the pull
+request.
+
+The relationship is detected through the GitHub GraphQL API's
+``closingIssuesReferences`` field on the pull request, which is GitHub's own
+detection of closing keywords and cross-references--not a regex scan of the
+PR body, so every keyword variant and manually linked issue is covered.
+
+Labels are only ever added, never removed. A label already present on the PR
+is left alone. A candidate label is also skipped, rather than applied, when
+applying it would cause scripts/enforce_mutually_exclusive_labels.py's
+mutual-exclusion enforcement to remove a label the PR already carries--an
+existing PR label always wins over a conflicting label being copied in from a
+linked issue. See labels_to_propagate() for the exact rule.
+
+Usage:
+    python3 scripts/propagate_issue_labels.py
+
+Exit code:
+    0  the PR has no closing issue references, its closing issues carry no
+       labels, or every eligible label was applied successfully.
+    1  required configuration is missing/invalid, or fetching or applying
+       labels failed.
+
+Required environment variables:
+    GITHUB_TOKEN        Token with issues: write and pull-requests: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+    PR_NUMBER           Number of the pull request
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+import enforce_mutually_exclusive_labels as emxl
+
+# ---------------------------------------------------------------------------
+# GraphQL
+# ---------------------------------------------------------------------------
+
+CLOSING_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50) {
+        nodes {
+          number
+          repository {
+            nameWithOwner
+          }
+          labels(first: 100) {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def graphql_query(query: str, variables: dict, token: str) -> dict:
+    """Execute a GitHub GraphQL query and return its "data" object.
+
+    Raises ``RuntimeError`` if the response carries a top-level "errors"
+    list (GraphQL reports errors this way even on an HTTP 200), or
+    ``urllib.error.HTTPError``/``URLError`` on request failure.
+    """
+    url = "https://api.github.com/graphql"
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(url, method="POST", data=body)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Content-Type", "application/json")
+    # URL is a fixed GitHub API constant; the file:// risk does not apply.
+    with urllib.request.urlopen(req) as r:  # nosemgrep
+        payload = json.loads(r.read())
+    if payload.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+    return payload.get("data") or {}
+
+
+def fetch_closing_issue_labels(
+    owner: str,
+    name: str,
+    pr_number: int,
+    token: str,
+) -> list[str]:
+    """Return the labels of every same-repo issue that *pr_number* closes.
+
+    Cross-repository closing references (a PR in this repo closing an issue
+    in a different repo) are skipped--this repo's label automation is scoped
+    to a single repository throughout, matching the other scripts here.
+
+    Labels are returned in the order GitHub lists the closing issues and,
+    within each issue, the order it lists that issue's labels. Duplicates
+    across multiple closing issues are not removed here; that happens in
+    labels_to_propagate().
+    """
+    data = graphql_query(
+        CLOSING_ISSUES_QUERY,
+        {"owner": owner, "name": name, "number": pr_number},
+        token,
+    )
+    pull_request = (data.get("repository") or {}).get("pullRequest")
+    if not pull_request:
+        return []
+    nodes = (pull_request.get("closingIssuesReferences") or {}).get("nodes") or []
+    repo_full_name = f"{owner}/{name}"
+
+    labels: list[str] = []
+    for node in nodes:
+        if not node:
+            continue
+        node_repo = (node.get("repository") or {}).get("nameWithOwner")
+        if node_repo != repo_full_name:
+            continue
+        labels.extend(lbl["name"] for lbl in (node.get("labels") or {}).get("nodes") or [])
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def labels_to_propagate(
+    current_pr_labels: list[str],
+    issue_labels: list[str],
+) -> tuple[list[str], list[str]]:
+    """Partition *issue_labels* into what to add to the PR and what to skip.
+
+    Returns (to_add, skipped):
+        to_add    issue labels, not already on the PR, that are safe to add
+        skipped   issue labels omitted because applying them would cause
+                  enforce_mutually_exclusive_labels.py to remove a label
+                  already staged on the PR (a real current PR label, or one
+                  accepted earlier in this same call)
+
+    A label already present on the PR (case-insensitively) is dropped from
+    both lists--there is nothing to do for it. A label repeated across
+    multiple closing issues is considered once.
+
+    *issue_labels* is processed in order, staging each accepted label into a
+    working copy of the PR's labels so later candidates in the same call see
+    earlier additions. This keeps one propagation run internally consistent
+    when several linked issues supply conflicting labels, while a real
+    pre-existing PR label always wins, since it seeds the working set before
+    any candidate is considered.
+    """
+    staged = list(current_pr_labels)
+    already_lower = {lbl.lower() for lbl in current_pr_labels}
+    to_add: list[str] = []
+    skipped: list[str] = []
+    seen_lower: set[str] = set()
+
+    for label in issue_labels:
+        lower = label.lower()
+        if lower in already_lower or lower in seen_lower:
+            continue
+        seen_lower.add(lower)
+
+        conflict = False
+        label_set = emxl.find_conflicting_set(label)
+        if label_set is not None and emxl.labels_to_remove(label, staged, label_set):
+            conflict = True
+        prefix = emxl.find_conflicting_prefix(label)
+        if not conflict and prefix is not None:
+            if emxl.labels_to_remove_by_prefix(label, staged, prefix):
+                conflict = True
+
+        if conflict:
+            skipped.append(label)
+            continue
+
+        to_add.append(label)
+        staged.append(label)
+
+    return to_add, skipped
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number_str = os.environ.get("PR_NUMBER", "")
+
+    if not token:
+        print("Error: GITHUB_TOKEN not set.", file=sys.stderr)
+        return 1
+    if not repo:
+        print("Error: GITHUB_REPOSITORY not set.", file=sys.stderr)
+        return 1
+    if not pr_number_str:
+        print("Error: PR_NUMBER not set.", file=sys.stderr)
+        return 1
+    if "/" not in repo:
+        print(f"Error: GITHUB_REPOSITORY is not owner/repo: {repo!r}", file=sys.stderr)
+        return 1
+
+    try:
+        pr_number = int(pr_number_str)
+    except ValueError:
+        print(f"Error: PR_NUMBER is not a valid integer: {pr_number_str!r}", file=sys.stderr)
+        return 1
+
+    owner, name = repo.split("/", 1)
+
+    try:
+        issue_labels = fetch_closing_issue_labels(owner, name, pr_number, token)
+    except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
+        print(f"Error fetching closing issues for PR #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+
+    if not issue_labels:
+        print(f"PR #{pr_number} has no labeled closing issue references--nothing to do.")
+        return 0
+
+    try:
+        pr = emxl.gh_api(f"repos/{repo}/issues/{pr_number}", token=token)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching PR #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(pr, dict):
+        print(f"Error: unexpected response fetching PR #{pr_number}: {pr!r}", file=sys.stderr)
+        return 1
+
+    current_pr_labels = [lbl["name"] for lbl in pr.get("labels", [])]
+
+    to_add, skipped = labels_to_propagate(current_pr_labels, issue_labels)
+
+    if skipped:
+        print(
+            f"Skipping labels {skipped} on PR #{pr_number}: applying them would let "
+            "mutual-exclusion enforcement remove a label the PR already carries."
+        )
+
+    if not to_add:
+        print(f"No labels to propagate to PR #{pr_number}--nothing to do.")
+        return 0
+
+    try:
+        emxl.gh_api(
+            f"repos/{repo}/issues/{pr_number}/labels",
+            token=token,
+            method="POST",
+            body={"labels": to_add},
+        )
+        print(f"Applied labels {to_add} to PR #{pr_number}.")
+    except urllib.error.HTTPError as exc:
+        print(f"Error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Network error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/propagate_issue_labels.py
+++ b/scripts/propagate_issue_labels.py
@@ -18,12 +18,22 @@ mutual-exclusion enforcement to remove a label the PR already carries--an
 existing PR label always wins over a conflicting label being copied in from a
 linked issue. See labels_to_propagate() for the exact rule.
 
+This module is also imported by scripts/reconcile_issue_labels.py, which
+applies the same rule across every open PR on a schedule. That script exists
+because GitHub fires no webhook event when a PR is linked to an issue via the
+"Development" sidebar after the PR is already open with no further body
+edit--the pull_request-triggered workflow that runs this module's main()
+would otherwise never see that PR again. See reconcile_issue_labels.py's
+docstring for the full rationale.
+
 Usage:
     python3 scripts/propagate_issue_labels.py
 
 Exit code:
     0  the PR has no closing issue references, its closing issues carry no
-       labels, or every eligible label was applied successfully.
+       labels, every eligible label was applied successfully, or every
+       candidate was skipped due to a mutual-exclusion conflict (skipping is
+       not itself a failure).
     1  required configuration is missing/invalid, or fetching or applying
        labels failed.
 
@@ -189,6 +199,71 @@ def labels_to_propagate(
 
 
 # ---------------------------------------------------------------------------
+# Single-PR propagation (shared by main() and reconcile_issue_labels.py)
+# ---------------------------------------------------------------------------
+
+
+def propagate_to_pr(owner: str, name: str, repo: str, pr_number: int, token: str) -> bool:
+    """Propagate *pr_number*'s closing issues' labels onto it.
+
+    Returns True on success, including every no-op case (no closing issues,
+    no labels on them, or every candidate skipped as a conflict). Returns
+    False only if fetching the closing issues, fetching the PR, or applying
+    labels failed.
+    """
+    try:
+        issue_labels = fetch_closing_issue_labels(owner, name, pr_number, token)
+    except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
+        print(f"Error fetching closing issues for PR #{pr_number}: {exc}", file=sys.stderr)
+        return False
+
+    if not issue_labels:
+        print(f"PR #{pr_number} has no labeled closing issue references--nothing to do.")
+        return True
+
+    try:
+        pr = emxl.gh_api(f"repos/{repo}/issues/{pr_number}", token=token)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching PR #{pr_number}: {exc}", file=sys.stderr)
+        return False
+
+    if not isinstance(pr, dict):
+        print(f"Error: unexpected response fetching PR #{pr_number}: {pr!r}", file=sys.stderr)
+        return False
+
+    current_pr_labels = [lbl["name"] for lbl in pr.get("labels", [])]
+
+    to_add, skipped = labels_to_propagate(current_pr_labels, issue_labels)
+
+    if skipped:
+        print(
+            f"Skipping labels {skipped} on PR #{pr_number}: applying them would let "
+            "mutual-exclusion enforcement remove a label the PR already carries."
+        )
+
+    if not to_add:
+        print(f"No labels to propagate to PR #{pr_number}--nothing to do.")
+        return True
+
+    try:
+        emxl.gh_api(
+            f"repos/{repo}/issues/{pr_number}/labels",
+            token=token,
+            method="POST",
+            body={"labels": to_add},
+        )
+        print(f"Applied labels {to_add} to PR #{pr_number}.")
+    except urllib.error.HTTPError as exc:
+        print(f"Error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
+        return False
+    except urllib.error.URLError as exc:
+        print(f"Network error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -219,56 +294,7 @@ def main() -> int:
 
     owner, name = repo.split("/", 1)
 
-    try:
-        issue_labels = fetch_closing_issue_labels(owner, name, pr_number, token)
-    except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
-        print(f"Error fetching closing issues for PR #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-
-    if not issue_labels:
-        print(f"PR #{pr_number} has no labeled closing issue references--nothing to do.")
-        return 0
-
-    try:
-        pr = emxl.gh_api(f"repos/{repo}/issues/{pr_number}", token=token)
-    except Exception as exc:  # noqa: BLE001
-        print(f"Error fetching PR #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-
-    if not isinstance(pr, dict):
-        print(f"Error: unexpected response fetching PR #{pr_number}: {pr!r}", file=sys.stderr)
-        return 1
-
-    current_pr_labels = [lbl["name"] for lbl in pr.get("labels", [])]
-
-    to_add, skipped = labels_to_propagate(current_pr_labels, issue_labels)
-
-    if skipped:
-        print(
-            f"Skipping labels {skipped} on PR #{pr_number}: applying them would let "
-            "mutual-exclusion enforcement remove a label the PR already carries."
-        )
-
-    if not to_add:
-        print(f"No labels to propagate to PR #{pr_number}--nothing to do.")
-        return 0
-
-    try:
-        emxl.gh_api(
-            f"repos/{repo}/issues/{pr_number}/labels",
-            token=token,
-            method="POST",
-            body={"labels": to_add},
-        )
-        print(f"Applied labels {to_add} to PR #{pr_number}.")
-    except urllib.error.HTTPError as exc:
-        print(f"Error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-    except urllib.error.URLError as exc:
-        print(f"Network error applying labels {to_add} to PR #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-
-    return 0
+    return 0 if propagate_to_pr(owner, name, repo, pr_number, token) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/propagate_issue_labels.py
+++ b/scripts/propagate_issue_labels.py
@@ -18,13 +18,14 @@ mutual-exclusion enforcement to remove a label the PR already carries--an
 existing PR label always wins over a conflicting label being copied in from a
 linked issue. See labels_to_propagate() for the exact rule.
 
-This module is also imported by scripts/reconcile_issue_labels.py, which
-applies the same rule across every open PR on a schedule. That script exists
-because GitHub fires no webhook event when a PR is linked to an issue via the
-"Development" sidebar after the PR is already open with no further body
-edit--the pull_request-triggered workflow that runs this module's main()
-would otherwise never see that PR again. See reconcile_issue_labels.py's
-docstring for the full rationale.
+The pull_request trigger for this module's main() (see
+.github/workflows/propagate-issue-labels.yml) covers most sidebar-linked PRs
+by re-running on their next ordinary activity, since GitHub fires no webhook
+event for the sidebar-link action itself. This module is also imported by
+scripts/reconcile_issue_labels.py, an on-demand tool that applies the same
+rule across every open PR for the residual case of a PR that sees no further
+activity before merge. See reconcile_issue_labels.py's docstring for the
+full rationale.
 
 Usage:
     python3 scripts/propagate_issue_labels.py

--- a/scripts/reconcile_issue_labels.py
+++ b/scripts/reconcile_issue_labels.py
@@ -2,20 +2,22 @@
 """Reconcile linked-issue label propagation across every open pull request.
 
 scripts/propagate_issue_labels.py runs from a `pull_request` webhook event
-(opened, or edited with a body change) and only ever looks at the one PR that
-triggered it. That covers a closing relationship declared in the PR body
-("Fixes #N" and its variants), but GitHub has no webhook event for linking a
-PR to an issue via the "Development" sidebar after the PR is already open.
-A PR linked that way, with no subsequent body edit, would otherwise never be
-revisited, and its issue's labels would silently never propagate--exactly
-the "cross-reference" case the GraphQL-based detection in
-propagate_issue_labels.py was chosen to handle in the first place (see
-issue #621).
+and only ever looks at the one PR that triggered it. GitHub fires no webhook
+event for linking a PR to an issue via the "Development" sidebar after the
+PR is already open, so propagate-issue-labels.yml widened its trigger types
+to cover that PR the next time it sees ordinary activity (a push, a reopen,
+a ready-for-review flip, a review request)--but a PR that is sidebar-linked
+and then sees none of those events before merge would still never be
+revisited, and its issue's labels would silently never propagate.
 
-This script closes that gap by periodically walking every open pull request
-and applying scripts/propagate_issue_labels.py's exact propagation rule
-(including the mutual-exclusion skip) to each one. It is meant to run on a
-schedule (see .github/workflows/reconcile-issue-labels.yml), not per event.
+This script closes that residual gap by walking every open pull request and
+applying scripts/propagate_issue_labels.py's exact propagation rule
+(including the mutual-exclusion skip) to each one. It is meant to be run
+on demand--locally, or by dispatching
+.github/workflows/reconcile-issue-labels.yml in Actions--rather than on a
+schedule: the gap it covers is already narrow after the trigger widening
+above, so polling every open PR indefinitely on a timer was judged not
+worth the ongoing cost (see issue #621).
 
 Usage:
     python3 scripts/reconcile_issue_labels.py

--- a/scripts/reconcile_issue_labels.py
+++ b/scripts/reconcile_issue_labels.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Reconcile linked-issue label propagation across every open pull request.
+
+scripts/propagate_issue_labels.py runs from a `pull_request` webhook event
+(opened, or edited with a body change) and only ever looks at the one PR that
+triggered it. That covers a closing relationship declared in the PR body
+("Fixes #N" and its variants), but GitHub has no webhook event for linking a
+PR to an issue via the "Development" sidebar after the PR is already open.
+A PR linked that way, with no subsequent body edit, would otherwise never be
+revisited, and its issue's labels would silently never propagate--exactly
+the "cross-reference" case the GraphQL-based detection in
+propagate_issue_labels.py was chosen to handle in the first place (see
+issue #621).
+
+This script closes that gap by periodically walking every open pull request
+and applying scripts/propagate_issue_labels.py's exact propagation rule
+(including the mutual-exclusion skip) to each one. It is meant to run on a
+schedule (see .github/workflows/reconcile-issue-labels.yml), not per event.
+
+Usage:
+    python3 scripts/reconcile_issue_labels.py
+
+Exit code:
+    0  every open PR was reconciled without error (whether or not any
+       labels were applied to any of them).
+    1  required configuration is missing/invalid, the open PR list could not
+       be fetched, or reconciling at least one PR failed.
+
+Required environment variables:
+    GITHUB_TOKEN        Token with issues: write and pull-requests: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+"""
+
+import os
+import sys
+
+import propagate_issue_labels as pil
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def fetch_open_pr_numbers(repo: str, token: str) -> list[int]:
+    """Return the number of every open pull request in *repo*."""
+    numbers: list[int] = []
+    page = 1
+    while True:
+        batch = pil.emxl.gh_api(
+            f"repos/{repo}/pulls?state=open&per_page=100&page={page}",
+            token=token,
+        )
+        if not batch:
+            break
+        numbers.extend(pr["number"] for pr in batch)
+        page += 1
+    return numbers
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    if not token:
+        print("Error: GITHUB_TOKEN not set.", file=sys.stderr)
+        return 1
+    if not repo:
+        print("Error: GITHUB_REPOSITORY not set.", file=sys.stderr)
+        return 1
+    if "/" not in repo:
+        print(f"Error: GITHUB_REPOSITORY is not owner/repo: {repo!r}", file=sys.stderr)
+        return 1
+
+    owner, name = repo.split("/", 1)
+
+    try:
+        pr_numbers = fetch_open_pr_numbers(repo, token)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching open pull requests: {exc}", file=sys.stderr)
+        return 1
+
+    if not pr_numbers:
+        print("No open pull requests--nothing to reconcile.")
+        return 0
+
+    all_succeeded = True
+    for pr_number in pr_numbers:
+        if not pil.propagate_to_pr(owner, name, repo, pr_number, token):
+            all_succeeded = False
+
+    return 0 if all_succeeded else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_propagate_issue_labels.py
+++ b/scripts/test_propagate_issue_labels.py
@@ -125,59 +125,111 @@ class TestFetchClosingIssueLabels(unittest.TestCase):
 
 class TestLabelsToPropagate(unittest.TestCase):
     def test_propagates_non_conflicting_labels(self):
-        to_add, skipped = pil.labels_to_propagate([], ["p1", "bug"])
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["p1", "bug"])
         self.assertEqual(to_add, ["p1", "bug"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_skips_labels_already_on_pr(self):
-        to_add, skipped = pil.labels_to_propagate(["bug"], ["bug", "p1"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["bug"], ["bug", "p1"])
         self.assertEqual(to_add, ["p1"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_already_present_check_is_case_insensitive(self):
-        to_add, skipped = pil.labels_to_propagate(["Bug"], ["bug", "p1"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["Bug"], ["bug", "p1"])
         self.assertEqual(to_add, ["p1"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_deduplicates_labels_from_multiple_issues(self):
-        to_add, skipped = pil.labels_to_propagate([], ["p1", "p1", "bug"])
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["p1", "p1", "bug"])
         self.assertEqual(to_add, ["p1", "bug"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_skips_label_that_would_evict_existing_pr_label_fixed_set(self):
         # PR already carries p2; propagating p1 would let the mutual-exclusion
         # workflow remove p2, so p1 must be skipped instead.
-        to_add, skipped = pil.labels_to_propagate(["p2"], ["p1"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["p2"], ["p1"])
         self.assertEqual(to_add, [])
         self.assertEqual(skipped, ["p1"])
+        self.assertEqual(excluded, [])
 
     def test_skips_label_that_would_evict_existing_pr_label_prefix_group(self):
-        to_add, skipped = pil.labels_to_propagate(["c-a-opus"], ["c-a-haiku"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["c-a-opus"], ["c-a-haiku"])
         self.assertEqual(to_add, [])
         self.assertEqual(skipped, ["c-a-haiku"])
+        self.assertEqual(excluded, [])
 
     def test_non_conflicting_prefix_label_still_propagates(self):
-        to_add, skipped = pil.labels_to_propagate(["c-a-opus"], ["c-r-haiku"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["c-a-opus"], ["c-r-haiku"])
         self.assertEqual(to_add, ["c-r-haiku"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_first_accepted_candidate_blocks_a_later_conflicting_one(self):
         # No real PR label yet, but p1 is accepted first (from one linked
         # issue) and then blocks p2 (from another linked issue) within the
         # same run.
-        to_add, skipped = pil.labels_to_propagate([], ["p1", "p2"])
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["p1", "p2"])
         self.assertEqual(to_add, ["p1"])
         self.assertEqual(skipped, ["p2"])
+        self.assertEqual(excluded, [])
 
     def test_labels_outside_any_exclusive_group_never_conflict(self):
-        to_add, skipped = pil.labels_to_propagate(["automated tests"], ["ci", "agents"])
+        to_add, skipped, excluded = pil.labels_to_propagate(["automated tests"], ["ci", "agents"])
         self.assertEqual(to_add, ["ci", "agents"])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
 
     def test_empty_issue_labels_is_a_no_op(self):
-        to_add, skipped = pil.labels_to_propagate(["p1"], [])
+        to_add, skipped, excluded = pil.labels_to_propagate(["p1"], [])
         self.assertEqual(to_add, [])
         self.assertEqual(skipped, [])
+        self.assertEqual(excluded, [])
+
+    # -- PROCESS_STATE_LABELS exclusion (issue #621 review, PR #713) --------
+
+    def test_excludes_orchestrating_even_with_no_pr_side_conflict(self):
+        # Reproduces the live bug: the PR carries none of {orchestrate,
+        # orchestrating}, so the old mutual-exclusion-only guard would have
+        # let this through and re-blocked "No blocking labels".
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["orchestrating"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(skipped, [])
+        self.assertEqual(excluded, ["orchestrating"])
+
+    def test_excludes_every_process_state_label(self):
+        for label in sorted(pil.PROCESS_STATE_LABELS):
+            with self.subTest(label=label):
+                to_add, skipped, excluded = pil.labels_to_propagate([], [label])
+                self.assertEqual(to_add, [])
+                self.assertEqual(skipped, [])
+                self.assertEqual(excluded, [label])
+
+    def test_process_state_exclusion_is_case_insensitive(self):
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["Orchestrating"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(excluded, ["Orchestrating"])
+
+    def test_process_state_labels_excluded_alongside_ordinary_labels(self):
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["p1", "orchestrating", "ci"])
+        self.assertEqual(to_add, ["p1", "ci"])
+        self.assertEqual(skipped, [])
+        self.assertEqual(excluded, ["orchestrating"])
+
+    def test_process_state_label_deduplicated_across_issues(self):
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["orchestrating", "orchestrating"])
+        self.assertEqual(excluded, ["orchestrating"])
+
+    def test_process_state_exclusion_does_not_consume_a_skip_slot(self):
+        # A process-state label and a genuinely conflicting label in the same
+        # run are reported in their own distinct lists, not conflated.
+        to_add, skipped, excluded = pil.labels_to_propagate(["p2"], ["orchestrating", "p1"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(skipped, ["p1"])
+        self.assertEqual(excluded, ["orchestrating"])
 
 
 # ---------------------------------------------------------------------------
@@ -297,6 +349,22 @@ class TestPropagateToPr(unittest.TestCase):
             with patch.object(pil.emxl, "gh_api", side_effect=fake_api):
                 result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
         self.assertFalse(result)
+
+    def test_does_not_reapply_orchestrating_the_orchestrator_just_removed(self):
+        # Reproduces the live PR #713 bug: the issue still carries
+        # "orchestrating" (active orchestration), but the PR just had it
+        # removed alone to clear the merge gate. A routine synchronize event
+        # must not put it back.
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["orchestrating", "p1"]):
+            with patch.object(
+                pil.emxl, "gh_api", return_value={"labels": [{"name": "ci"}]}
+            ) as mock_api:
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 713, "tok")
+
+        self.assertTrue(result)
+        post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0].kwargs["body"], {"labels": ["p1"]})
 
 
 if __name__ == "__main__":

--- a/scripts/test_propagate_issue_labels.py
+++ b/scripts/test_propagate_issue_labels.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Unit tests for propagate_issue_labels.py."""
+
+import json
+import os
+import sys
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import propagate_issue_labels as pil  # noqa: E402
+
+
+def _closing_issues_payload(issues: list[tuple[int, str, list[str]]]) -> dict:
+    """Build a GraphQL response for the given (number, repo, labels) issues."""
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "closingIssuesReferences": {
+                        "nodes": [
+                            {
+                                "number": number,
+                                "repository": {"nameWithOwner": repo},
+                                "labels": {"nodes": [{"name": lbl} for lbl in labels]},
+                            }
+                            for number, repo, labels in issues
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# graphql_query tests
+# ---------------------------------------------------------------------------
+
+
+class TestGraphqlQuery(unittest.TestCase):
+    def _make_response(self, body: bytes) -> MagicMock:
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_returns_data_on_success(self):
+        payload = {"data": {"repository": {"pullRequest": None}}}
+        response = self._make_response(json.dumps(payload).encode())
+        with patch("urllib.request.urlopen", return_value=response):
+            result = pil.graphql_query("query {}", {}, "tok")
+        self.assertEqual(result, payload["data"])
+
+    def test_raises_on_graphql_errors(self):
+        payload = {"errors": [{"message": "Could not resolve to a PullRequest"}]}
+        response = self._make_response(json.dumps(payload).encode())
+        with patch("urllib.request.urlopen", return_value=response):
+            with self.assertRaises(RuntimeError):
+                pil.graphql_query("query {}", {}, "tok")
+
+    def test_sends_bearer_auth_header(self):
+        payload = {"data": {}}
+        response = self._make_response(json.dumps(payload).encode())
+        captured = {}
+
+        def fake_urlopen(req):
+            captured["request"] = req
+            return response
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            pil.graphql_query("query {}", {"a": 1}, "sekret")
+
+        self.assertEqual(captured["request"].get_header("Authorization"), "Bearer sekret")
+        self.assertEqual(captured["request"].get_full_url(), "https://api.github.com/graphql")
+
+
+# ---------------------------------------------------------------------------
+# fetch_closing_issue_labels tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchClosingIssueLabels(unittest.TestCase):
+    def test_returns_labels_from_same_repo_issues(self):
+        payload = _closing_issues_payload(
+            [(1, "owner/repo", ["p1", "bug"]), (2, "owner/repo", ["ci"])]
+        )
+        with patch.object(pil, "graphql_query", return_value=payload["data"]):
+            result = pil.fetch_closing_issue_labels("owner", "repo", 42, "tok")
+        self.assertEqual(result, ["p1", "bug", "ci"])
+
+    def test_skips_cross_repo_issues(self):
+        payload = _closing_issues_payload(
+            [(1, "owner/repo", ["p1"]), (2, "other-owner/other-repo", ["p2"])]
+        )
+        with patch.object(pil, "graphql_query", return_value=payload["data"]):
+            result = pil.fetch_closing_issue_labels("owner", "repo", 42, "tok")
+        self.assertEqual(result, ["p1"])
+
+    def test_returns_empty_when_no_pull_request(self):
+        data = {"repository": {"pullRequest": None}}
+        with patch.object(pil, "graphql_query", return_value=data):
+            result = pil.fetch_closing_issue_labels("owner", "repo", 42, "tok")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_no_closing_issues(self):
+        data = {"repository": {"pullRequest": {"closingIssuesReferences": {"nodes": []}}}}
+        with patch.object(pil, "graphql_query", return_value=data):
+            result = pil.fetch_closing_issue_labels("owner", "repo", 42, "tok")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_closing_issue_has_no_labels(self):
+        payload = _closing_issues_payload([(1, "owner/repo", [])])
+        with patch.object(pil, "graphql_query", return_value=payload["data"]):
+            result = pil.fetch_closing_issue_labels("owner", "repo", 42, "tok")
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# labels_to_propagate tests
+# ---------------------------------------------------------------------------
+
+
+class TestLabelsToPropagate(unittest.TestCase):
+    def test_propagates_non_conflicting_labels(self):
+        to_add, skipped = pil.labels_to_propagate([], ["p1", "bug"])
+        self.assertEqual(to_add, ["p1", "bug"])
+        self.assertEqual(skipped, [])
+
+    def test_skips_labels_already_on_pr(self):
+        to_add, skipped = pil.labels_to_propagate(["bug"], ["bug", "p1"])
+        self.assertEqual(to_add, ["p1"])
+        self.assertEqual(skipped, [])
+
+    def test_already_present_check_is_case_insensitive(self):
+        to_add, skipped = pil.labels_to_propagate(["Bug"], ["bug", "p1"])
+        self.assertEqual(to_add, ["p1"])
+        self.assertEqual(skipped, [])
+
+    def test_deduplicates_labels_from_multiple_issues(self):
+        to_add, skipped = pil.labels_to_propagate([], ["p1", "p1", "bug"])
+        self.assertEqual(to_add, ["p1", "bug"])
+        self.assertEqual(skipped, [])
+
+    def test_skips_label_that_would_evict_existing_pr_label_fixed_set(self):
+        # PR already carries p2; propagating p1 would let the mutual-exclusion
+        # workflow remove p2, so p1 must be skipped instead.
+        to_add, skipped = pil.labels_to_propagate(["p2"], ["p1"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(skipped, ["p1"])
+
+    def test_skips_label_that_would_evict_existing_pr_label_prefix_group(self):
+        to_add, skipped = pil.labels_to_propagate(["c-a-opus"], ["c-a-haiku"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(skipped, ["c-a-haiku"])
+
+    def test_non_conflicting_prefix_label_still_propagates(self):
+        to_add, skipped = pil.labels_to_propagate(["c-a-opus"], ["c-r-haiku"])
+        self.assertEqual(to_add, ["c-r-haiku"])
+        self.assertEqual(skipped, [])
+
+    def test_first_accepted_candidate_blocks_a_later_conflicting_one(self):
+        # No real PR label yet, but p1 is accepted first (from one linked
+        # issue) and then blocks p2 (from another linked issue) within the
+        # same run.
+        to_add, skipped = pil.labels_to_propagate([], ["p1", "p2"])
+        self.assertEqual(to_add, ["p1"])
+        self.assertEqual(skipped, ["p2"])
+
+    def test_labels_outside_any_exclusive_group_never_conflict(self):
+        to_add, skipped = pil.labels_to_propagate(["automated tests"], ["ci", "agents"])
+        self.assertEqual(to_add, ["ci", "agents"])
+        self.assertEqual(skipped, [])
+
+    def test_empty_issue_labels_is_a_no_op(self):
+        to_add, skipped = pil.labels_to_propagate(["p1"], [])
+        self.assertEqual(to_add, [])
+        self.assertEqual(skipped, [])
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def _env(self, **overrides):
+        env = {
+            "GITHUB_TOKEN": "tok",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "42",
+        }
+        env.update(overrides)
+        return env
+
+    def test_missing_token_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_TOKEN=""), clear=True):
+            self.assertEqual(pil.main(), 1)
+
+    def test_missing_repo_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_REPOSITORY=""), clear=True):
+            self.assertEqual(pil.main(), 1)
+
+    def test_missing_pr_number_returns_1(self):
+        with patch.dict(os.environ, self._env(PR_NUMBER=""), clear=True):
+            self.assertEqual(pil.main(), 1)
+
+    def test_malformed_repo_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_REPOSITORY="not-a-slug"), clear=True):
+            self.assertEqual(pil.main(), 1)
+
+    def test_non_integer_pr_number_returns_1(self):
+        with patch.dict(os.environ, self._env(PR_NUMBER="abc"), clear=True):
+            self.assertEqual(pil.main(), 1)
+
+    def test_graphql_failure_returns_1(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", side_effect=RuntimeError("boom")):
+                self.assertEqual(pil.main(), 1)
+
+    def test_no_closing_issues_returns_0_and_does_not_touch_labels(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", return_value=[]):
+                with patch.object(pil.emxl, "gh_api") as mock_api:
+                    result = pil.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+
+    def test_pr_fetch_failure_returns_1(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+                with patch.object(
+                    pil.emxl,
+                    "gh_api",
+                    side_effect=urllib.error.HTTPError(
+                        url=None, code=404, msg="Not Found", hdrs=None, fp=None
+                    ),
+                ):
+                    self.assertEqual(pil.main(), 1)
+
+    def test_applies_eligible_labels(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1", "bug"]):
+                with patch.object(
+                    pil.emxl, "gh_api", return_value={"labels": [{"name": "bug"}]}
+                ) as mock_api:
+                    result = pil.main()
+
+        self.assertEqual(result, 0)
+        post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0].args[0], "repos/owner/repo/issues/42/labels")
+        self.assertEqual(post_calls[0].kwargs["body"], {"labels": ["p1"]})
+
+    def test_skip_only_case_returns_0_without_posting(self):
+        # PR already carries p2; the only candidate (p1) conflicts and is
+        # skipped, so nothing should be POSTed.
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+                with patch.object(
+                    pil.emxl, "gh_api", return_value={"labels": [{"name": "p2"}]}
+                ) as mock_api:
+                    result = pil.main()
+
+        self.assertEqual(result, 0)
+        post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
+        self.assertEqual(post_calls, [])
+
+    def test_apply_failure_returns_1(self):
+        def fake_api(path, token, method="GET", body=None):
+            if method == "POST":
+                raise urllib.error.HTTPError(
+                    url=None, code=422, msg="Unprocessable Entity", hdrs=None, fp=None
+                )
+            return {"labels": []}
+
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+                with patch.object(pil.emxl, "gh_api", side_effect=fake_api):
+                    self.assertEqual(pil.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_propagate_issue_labels.py
+++ b/scripts/test_propagate_issue_labels.py
@@ -215,60 +215,77 @@ class TestMain(unittest.TestCase):
         with patch.dict(os.environ, self._env(PR_NUMBER="abc"), clear=True):
             self.assertEqual(pil.main(), 1)
 
-    def test_graphql_failure_returns_1(self):
+    def test_delegates_to_propagate_to_pr_with_parsed_args(self):
         with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", side_effect=RuntimeError("boom")):
+            with patch.object(pil, "propagate_to_pr", return_value=True) as mock_propagate:
+                result = pil.main()
+
+        self.assertEqual(result, 0)
+        mock_propagate.assert_called_once_with("owner", "repo", "owner/repo", 42, "tok")
+
+    def test_returns_1_when_propagate_to_pr_fails(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(pil, "propagate_to_pr", return_value=False):
                 self.assertEqual(pil.main(), 1)
 
-    def test_no_closing_issues_returns_0_and_does_not_touch_labels(self):
-        with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", return_value=[]):
-                with patch.object(pil.emxl, "gh_api") as mock_api:
-                    result = pil.main()
-        self.assertEqual(result, 0)
+
+# ---------------------------------------------------------------------------
+# propagate_to_pr tests
+# ---------------------------------------------------------------------------
+
+
+class TestPropagateToPr(unittest.TestCase):
+    def test_graphql_failure_returns_false(self):
+        with patch.object(pil, "fetch_closing_issue_labels", side_effect=RuntimeError("boom")):
+            result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
+        self.assertFalse(result)
+
+    def test_no_closing_issues_returns_true_and_does_not_touch_labels(self):
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=[]):
+            with patch.object(pil.emxl, "gh_api") as mock_api:
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
+        self.assertTrue(result)
         mock_api.assert_not_called()
 
-    def test_pr_fetch_failure_returns_1(self):
-        with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
-                with patch.object(
-                    pil.emxl,
-                    "gh_api",
-                    side_effect=urllib.error.HTTPError(
-                        url=None, code=404, msg="Not Found", hdrs=None, fp=None
-                    ),
-                ):
-                    self.assertEqual(pil.main(), 1)
+    def test_pr_fetch_failure_returns_false(self):
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+            with patch.object(
+                pil.emxl,
+                "gh_api",
+                side_effect=urllib.error.HTTPError(
+                    url=None, code=404, msg="Not Found", hdrs=None, fp=None
+                ),
+            ):
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
+        self.assertFalse(result)
 
     def test_applies_eligible_labels(self):
-        with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1", "bug"]):
-                with patch.object(
-                    pil.emxl, "gh_api", return_value={"labels": [{"name": "bug"}]}
-                ) as mock_api:
-                    result = pil.main()
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1", "bug"]):
+            with patch.object(
+                pil.emxl, "gh_api", return_value={"labels": [{"name": "bug"}]}
+            ) as mock_api:
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
 
-        self.assertEqual(result, 0)
+        self.assertTrue(result)
         post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
         self.assertEqual(len(post_calls), 1)
         self.assertEqual(post_calls[0].args[0], "repos/owner/repo/issues/42/labels")
         self.assertEqual(post_calls[0].kwargs["body"], {"labels": ["p1"]})
 
-    def test_skip_only_case_returns_0_without_posting(self):
+    def test_skip_only_case_returns_true_without_posting(self):
         # PR already carries p2; the only candidate (p1) conflicts and is
         # skipped, so nothing should be POSTed.
-        with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
-                with patch.object(
-                    pil.emxl, "gh_api", return_value={"labels": [{"name": "p2"}]}
-                ) as mock_api:
-                    result = pil.main()
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+            with patch.object(
+                pil.emxl, "gh_api", return_value={"labels": [{"name": "p2"}]}
+            ) as mock_api:
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
 
-        self.assertEqual(result, 0)
+        self.assertTrue(result)
         post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
         self.assertEqual(post_calls, [])
 
-    def test_apply_failure_returns_1(self):
+    def test_apply_failure_returns_false(self):
         def fake_api(path, token, method="GET", body=None):
             if method == "POST":
                 raise urllib.error.HTTPError(
@@ -276,10 +293,10 @@ class TestMain(unittest.TestCase):
                 )
             return {"labels": []}
 
-        with patch.dict(os.environ, self._env(), clear=True):
-            with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
-                with patch.object(pil.emxl, "gh_api", side_effect=fake_api):
-                    self.assertEqual(pil.main(), 1)
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["p1"]):
+            with patch.object(pil.emxl, "gh_api", side_effect=fake_api):
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/scripts/test_reconcile_issue_labels.py
+++ b/scripts/test_reconcile_issue_labels.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Unit tests for reconcile_issue_labels.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import reconcile_issue_labels as ril  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# fetch_open_pr_numbers tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOpenPrNumbers(unittest.TestCase):
+    def test_returns_numbers_from_a_single_page(self):
+        with patch.object(ril.pil.emxl, "gh_api", side_effect=[[{"number": 5}, {"number": 7}], []]):
+            result = ril.fetch_open_pr_numbers("owner/repo", "tok")
+        self.assertEqual(result, [5, 7])
+
+    def test_paginates_until_an_empty_page(self):
+        page1 = [{"number": n} for n in range(1, 101)]
+        page2 = [{"number": 101}]
+        with patch.object(ril.pil.emxl, "gh_api", side_effect=[page1, page2, []]) as mock_api:
+            result = ril.fetch_open_pr_numbers("owner/repo", "tok")
+        self.assertEqual(result, list(range(1, 102)))
+        self.assertEqual(mock_api.call_count, 3)
+
+    def test_returns_empty_when_no_open_prs(self):
+        with patch.object(ril.pil.emxl, "gh_api", return_value=[]):
+            result = ril.fetch_open_pr_numbers("owner/repo", "tok")
+        self.assertEqual(result, [])
+
+    def test_requests_open_state(self):
+        captured_paths = []
+
+        def fake_api(path, token):
+            captured_paths.append(path)
+            return []
+
+        with patch.object(ril.pil.emxl, "gh_api", side_effect=fake_api):
+            ril.fetch_open_pr_numbers("owner/repo", "tok")
+
+        self.assertIn("state=open", captured_paths[0])
+        self.assertTrue(captured_paths[0].startswith("repos/owner/repo/pulls?"))
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def _env(self, **overrides):
+        env = {"GITHUB_TOKEN": "tok", "GITHUB_REPOSITORY": "owner/repo"}
+        env.update(overrides)
+        return env
+
+    def test_missing_token_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_TOKEN=""), clear=True):
+            self.assertEqual(ril.main(), 1)
+
+    def test_missing_repo_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_REPOSITORY=""), clear=True):
+            self.assertEqual(ril.main(), 1)
+
+    def test_malformed_repo_returns_1(self):
+        with patch.dict(os.environ, self._env(GITHUB_REPOSITORY="not-a-slug"), clear=True):
+            self.assertEqual(ril.main(), 1)
+
+    def test_fetch_open_prs_failure_returns_1(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(ril, "fetch_open_pr_numbers", side_effect=RuntimeError("boom")):
+                self.assertEqual(ril.main(), 1)
+
+    def test_no_open_prs_returns_0_without_propagating(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(ril, "fetch_open_pr_numbers", return_value=[]):
+                with patch.object(ril.pil, "propagate_to_pr") as mock_propagate:
+                    result = ril.main()
+        self.assertEqual(result, 0)
+        mock_propagate.assert_not_called()
+
+    def test_reconciles_every_open_pr(self):
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(ril, "fetch_open_pr_numbers", return_value=[5, 7, 9]):
+                with patch.object(ril.pil, "propagate_to_pr", return_value=True) as mock_propagate:
+                    result = ril.main()
+
+        self.assertEqual(result, 0)
+        calls = [c.args for c in mock_propagate.call_args_list]
+        self.assertEqual(
+            calls,
+            [
+                ("owner", "repo", "owner/repo", 5, "tok"),
+                ("owner", "repo", "owner/repo", 7, "tok"),
+                ("owner", "repo", "owner/repo", 9, "tok"),
+            ],
+        )
+
+    def test_one_failure_among_several_still_reports_failure(self):
+        def fake_propagate(owner, name, repo, pr_number, token):
+            return pr_number != 7
+
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(ril, "fetch_open_pr_numbers", return_value=[5, 7, 9]):
+                with patch.object(ril.pil, "propagate_to_pr", side_effect=fake_propagate):
+                    result = ril.main()
+
+        self.assertEqual(result, 1)
+
+    def test_one_failure_does_not_stop_remaining_prs(self):
+        def fake_propagate(owner, name, repo, pr_number, token):
+            calls.append(pr_number)
+            return pr_number != 7
+
+        calls: list[int] = []
+        with patch.dict(os.environ, self._env(), clear=True):
+            with patch.object(ril, "fetch_open_pr_numbers", return_value=[5, 7, 9]):
+                with patch.object(ril.pil, "propagate_to_pr", side_effect=fake_propagate):
+                    ril.main()
+
+        self.assertEqual(calls, [5, 7, 9])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #621.

Adds `scripts/propagate_issue_labels.py`, run by a new
`.github/workflows/propagate-issue-labels.yml` workflow on `pull_request`
`opened` (and `edited` when the body changed), that copies a linked issue's
labels onto a PR that closes it.

## How this addresses the issue

- **Detecting the Fixes/Closes relationship**: uses the GitHub GraphQL API's
  `closingIssuesReferences` field on the PR, which is GitHub's own
  resolution of every closing-keyword variant ("Fixes", "Closes",
  "Resolves", etc.) and manually linked issues, rather than a regex scan of
  the PR body. Cross-repository closing references are skipped, matching
  the rest of this repo's label automation, which is scoped to a single
  repository.
- **Applying labels**: every label carried by a closing issue is applied to
  the PR, unless it is already present.
- **The mutual-exclusion exception**: before applying a candidate label,
  `labels_to_propagate()` checks whether doing so would give
  `scripts/enforce_mutually_exclusive_labels.py` grounds to remove a label
  the PR already carries (or one accepted earlier in the same run, so
  multiple linked issues can't fight each other either). If so, the
  candidate is skipped instead, so an existing PR label always wins over a
  conflicting one being copied in from a linked issue.

Labels are only ever added, never removed, consistent with `label_by_title.py`
and `backfill_labels_by_title.py`.

## Test plan
- [x] Unit tests in `scripts/test_propagate_issue_labels.py` cover the
  GraphQL query helper, closing-issue label extraction (including the
  cross-repo filter), the propagate/skip partitioning logic (fixed-set and
  prefix-group conflicts, same-run conflicts between two linked issues,
  case-insensitive dedup), and `main()`'s error and success paths.
- [x] `scripts/lint.sh` (ruff + hygiene checks) passes on the new files.
- [x] Manually confirm the workflow fires correctly on a real PR in this
  repo that closes a labeled issue (GitHub Actions trigger behavior can't be
  exercised by the unit tests above).

