### PR TITLE
Collapse same-named check runs to the latest in ci_monitor

### DIFF
--- a/scripts/ci_monitor/README.md
+++ b/scripts/ci_monitor/README.md
@@ -37,6 +37,16 @@ In `--pr`/`--sha`/`--branch` modes, the Monitor discovers which workflow run(s) 
 It does not name a workflow or job; the run/job to follow is derived from the same check-runs data that produces the verdict.
 In `--run-id` mode, the run to track is simply the one named on the command line--no check-runs payload is consulted for this purpose.
 
+### Same-named check-run collapsing
+
+Before reading the verdict, summary, or run/job targets, the Monitor collapses the `/commits/{sha}/check-runs` payload so that each distinct check-run *name* keeps only its most recent run (issue #707).
+GitHub can attach several check runs with the same name to one commit when a workflow re-runs: for example, each PR-side label add/remove re-triggers `block-merge-on-blocking-labels.yml`, so the `No blocking labels` gate accumulates several entries against the same head commit, and a stale `failure` (from a blocking label that was since removed) can sit between two `success` runs.
+Recency is judged by the run's `started_at` (ISO 8601, lexically sortable), then its numeric check-run `id` as a monotonic tiebreak; the surviving run keeps the position of that name's first appearance so the summary's row order is otherwise unchanged.
+This mirrors GitHub's own `mergeable_state`, which judges a required check by its latest run per name.
+Without it, a superseded `failure` would outvote the authoritative later `success` and drive a spurious `Blocked` terminal, and the stale run's job would also be tracked for diagnostics.
+Runs with no usable `name` are passed through unchanged (each kept), since name-based identity does not apply to them and GitHub always names its own check runs.
+`--run-id` mode reads a single run object and so is unaffected.
+
 ## Per-test outcome filters
 
 By default the monitor reports **all FAIL markers**, **all SKIP markers**, and **no PASS markers**.

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -338,6 +338,74 @@ def parse_pr_terminal(pr_json):
     return ""
 
 
+def _check_run_recency_key(run):
+    """Return a sort key ordering check runs oldest-to-newest (issue #707).
+
+    GitHub can attach several check runs with the same `name` to one commit when
+    a workflow re-runs: e.g. each PR-side label add/remove re-triggers the
+    label-gate workflow, so that gate's check-run name accumulates several
+    entries against the same head commit, of which only the most recent
+    conclusion is authoritative (the earlier ones are stale).
+    Recency is judged by `started_at` (ISO 8601, so lexically sortable), then by
+    the numeric check-run `id` as a monotonic tiebreak (a re-run always gets a
+    higher id). A run missing both fields sorts oldest, so a run carrying real
+    recency data always outranks one that does not.
+    """
+    started = run.get("started_at") or ""
+    try:
+        run_id = int(run.get("id"))
+    except (TypeError, ValueError):
+        run_id = -1
+    return (started, run_id)
+
+
+def latest_check_runs(check_json):
+    """Collapse same-named check runs to the latest one each (issue #707).
+
+    Returns a shallow copy of `check_json` whose `check_runs` list keeps, for
+    each distinct non-empty check-run `name`, only the most recent run (by
+    `_check_run_recency_key`); the surviving run sits at the position of that
+    name's first appearance, so the summary's row order is otherwise preserved.
+    Runs with no usable `name` are passed through unchanged (each kept), since
+    name-based identity does not apply to them and GitHub always names its own
+    check runs; this also leaves the unnamed-Actions-run fixtures other tests
+    rely on untouched.
+
+    This mirrors GitHub's own `mergeable_state`, which judges a required check by
+    its latest run per name: without it, a stale `failure` from an earlier re-run
+    of a named check (e.g. a label-gate check that briefly saw a blocking label,
+    since removed) would outvote the authoritative later `success` and drive a
+    spurious `Blocked` terminal. Feeding the collapsed payload to the verdict,
+    the summary, and the Actions-target discovery keeps all three from latching
+    onto a superseded run. `total_count` is left as-is:
+    only its zero/non-zero distinction is load-bearing (parse_check_result's
+    "no checks registered" case), and collapsing never empties a non-empty list.
+    """
+    runs = check_json.get("check_runs", [])
+    winners = {}
+    for r in runs:
+        name = r.get("name")
+        if not name:
+            continue
+        current = winners.get(name)
+        if current is None or _check_run_recency_key(r) >= _check_run_recency_key(current):
+            winners[name] = r
+    kept = []
+    emitted = set()
+    for r in runs:
+        name = r.get("name")
+        if not name:
+            kept.append(r)
+            continue
+        if name in emitted:
+            continue
+        emitted.add(name)
+        kept.append(winners[name])
+    result = dict(check_json)
+    result["check_runs"] = kept
+    return result
+
+
 def parse_check_result(check_json):
     """Map a /commits/{sha}/check-runs response to an overall result token.
 
@@ -931,6 +999,12 @@ def main(argv):
                 check_json = _request(
                     "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
                 )
+                # Collapse same-named re-runs (issue #707) on the drain's own
+                # self-fetch too, so a stale run's jobs are not tracked; the
+                # main-loop caller already passes a collapsed check_json, and
+                # re-collapsing that is a no-op.
+                if check_json:
+                    check_json = latest_check_runs(check_json)
             targets = parse_actions_targets(check_json) if check_json else []
         if not targets:
             return emitted[0]
@@ -1127,6 +1201,14 @@ def main(argv):
             check_json = _request(
                 "%s/repos/%s/%s/commits/%s/check-runs" % (API_BASE, OWNER, REPO, sha), token
             )
+            # Collapse same-named check runs to the latest each (issue #707) so a
+            # stale conclusion from an earlier re-run of a named check does not
+            # outvote its authoritative latest run. The one collapsed payload
+            # then drives the verdict, the summary, and poll_signals' target
+            # discovery, keeping all three consistent with GitHub's own
+            # mergeable_state.
+            if check_json:
+                check_json = latest_check_runs(check_json)
             result = parse_check_result(check_json) if check_json else None
             summary_rows = (
                 parse_check_summary(check_json, label_gate_check_regex) if check_json else []

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -68,6 +68,14 @@ Covers:
        field as well as its `name`, so a suite-shaped query surfaces a marker
        whose distinguishing text lives in `suite` (name matching still works,
        and a pattern in neither still suppresses)
+  (ay) #707 latest_check_runs: same-named check runs collapse to the latest
+       each (by started_at then id); the raw payload's stale failure reads
+       Blocked while the collapsed one reads all_passed; distinct names and
+       unnamed runs are preserved; only the latest run is a diagnostic target
+  (az) #707 main(): a stale label-gate re-run (failure) between two successes
+       does not outvote the authoritative latest success -- the monitor
+       terminates Clear (mergeable_state=clean), lists the gate once, and polls
+       only the latest run's jobs/artifacts
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4679,6 +4687,235 @@ def main() -> int:
         "--include-fail suite-shaped pattern matches the marker's suite field",
         "--include-fail suite pattern: FAIL not surfaced via suite; output: %r" % out_ax_fail,
     )
+
+    # ── (ay) #707 latest_check_runs: same-named re-runs collapse to the latest ─────
+    print(
+        "\n=== (ay) #707 latest_check_runs: same-named check runs collapse to the latest each ==="
+    )
+
+    # The exact shape from issue #707: one named check ('No blocking labels')
+    # recurs three times against the same commit as a label was added then
+    # removed, leaving a stale middle 'failure' between two 'success' runs. Only
+    # the most recent (highest started_at / id) is authoritative.
+    LABEL_GATE_3 = {
+        "total_count": 3,
+        "check_runs": [
+            {
+                "id": 87686988990,
+                "name": "No blocking labels",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-07-16T16:57:43Z",
+                "app": {"slug": "github-actions"},
+                "details_url": "https://github.com/%s/%s/actions/runs/111" % (OWNER_T, REPO_T),
+            },
+            {
+                "id": 87687158072,
+                "name": "No blocking labels",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-07-16T16:58:25Z",
+                "app": {"slug": "github-actions"},
+                "details_url": "https://github.com/%s/%s/actions/runs/222" % (OWNER_T, REPO_T),
+            },
+            {
+                "id": 87688242514,
+                "name": "No blocking labels",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-07-16T17:02:58Z",
+                "app": {"slug": "github-actions"},
+                "details_url": "https://github.com/%s/%s/actions/runs/333" % (OWNER_T, REPO_T),
+            },
+        ],
+    }
+
+    # Before collapsing, the stale 'failure' makes the raw payload read Blocked --
+    # this is the bug in issue #707.
+    check(
+        ci_monitor.parse_check_result(LABEL_GATE_3) == "Blocked",
+        "raw payload (with the stale failure) still reads Blocked -- documents the bug",
+        "expected raw Blocked; got %r" % ci_monitor.parse_check_result(LABEL_GATE_3),
+    )
+
+    collapsed_ay = ci_monitor.latest_check_runs(LABEL_GATE_3)
+    check(
+        len(collapsed_ay["check_runs"]) == 1,
+        "the three same-named runs collapse to a single surviving run",
+        "expected 1 kept run; got %r" % (collapsed_ay["check_runs"],),
+    )
+    check(
+        collapsed_ay["check_runs"][0]["id"] == 87688242514
+        and collapsed_ay["check_runs"][0]["conclusion"] == "success",
+        "the surviving run is the most recent one (the authoritative success)",
+        "wrong surviving run; got %r" % (collapsed_ay["check_runs"][0],),
+    )
+    check(
+        ci_monitor.parse_check_result(collapsed_ay) == "all_passed",
+        "collapsed payload reads all_passed, matching GitHub's mergeable_state=clean",
+        "expected all_passed after collapse; got %r" % ci_monitor.parse_check_result(collapsed_ay),
+    )
+    rows_ay = ci_monitor.parse_check_summary(collapsed_ay, "No blocking labels")
+    check(
+        len(rows_ay) == 1 and not rows_ay[0]["blocking"],
+        "the collapsed summary shows one non-blocking row for the label gate",
+        "expected one non-blocking row; got %r" % (rows_ay,),
+    )
+    # parse_actions_targets on the collapsed payload discovers only the latest
+    # run, so the stale run's jobs are never polled for diagnostics either.
+    targets_ay = ci_monitor.parse_actions_targets(collapsed_ay)
+    check(
+        targets_ay == [("333", None)],
+        "only the latest run (333) is a diagnostic target; stale 111/222 are dropped",
+        "expected [('333', None)]; got %r" % (targets_ay,),
+    )
+
+    # started_at is the primary recency signal; the id is only a tiebreak. A run
+    # with a newer started_at wins even if its id is numerically lower.
+    STARTED_AT_WINS = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 999,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": 1,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-02T00:00:00Z",
+            },
+        ],
+    }
+    kept_started = ci_monitor.latest_check_runs(STARTED_AT_WINS)["check_runs"]
+    check(
+        len(kept_started) == 1 and kept_started[0]["conclusion"] == "success",
+        "a newer started_at wins over a numerically higher id",
+        "started_at tiebreak wrong; got %r" % (kept_started,),
+    )
+
+    # When started_at is absent/equal, the numeric id breaks the tie.
+    ID_TIEBREAK = {
+        "total_count": 2,
+        "check_runs": [
+            {"id": 5, "name": "gate", "status": "completed", "conclusion": "failure"},
+            {"id": 9, "name": "gate", "status": "completed", "conclusion": "success"},
+        ],
+    }
+    kept_id = ci_monitor.latest_check_runs(ID_TIEBREAK)["check_runs"]
+    check(
+        len(kept_id) == 1 and kept_id[0]["id"] == 9,
+        "with no started_at, the higher id wins the tiebreak",
+        "id tiebreak wrong; got %r" % (kept_id,),
+    )
+
+    # Distinct names are all preserved, in first-appearance order; unnamed runs
+    # (name missing/None) are each passed through unchanged (the unnamed-Actions
+    # fixtures other tests rely on must not collapse).
+    MIXED = {
+        "total_count": 5,
+        "check_runs": [
+            {"id": 1, "name": "alpha", "status": "completed", "conclusion": "success"},
+            {"id": 2, "status": "completed", "conclusion": "success"},  # unnamed
+            {"id": 3, "name": "beta", "status": "completed", "conclusion": "success"},
+            {"id": 4, "status": "completed", "conclusion": "success"},  # unnamed
+            {"id": 5, "name": "alpha", "status": "completed", "conclusion": "failure"},
+        ],
+    }
+    kept_mixed = ci_monitor.latest_check_runs(MIXED)["check_runs"]
+    names_mixed = [r.get("name") for r in kept_mixed]
+    check(
+        names_mixed == ["alpha", None, "beta", None],
+        "distinct names preserved in first-appearance order; both unnamed runs kept",
+        "mixed collapse wrong; got names %r" % (names_mixed,),
+    )
+    alpha_kept = [r for r in kept_mixed if r.get("name") == "alpha"]
+    check(
+        len(alpha_kept) == 1 and alpha_kept[0]["id"] == 5,
+        "the surviving 'alpha' is its latest (id 5) run, seated at alpha's first position",
+        "alpha collapse wrong; got %r" % (alpha_kept,),
+    )
+
+    # An empty payload collapses to an empty payload (no crash).
+    check(
+        ci_monitor.latest_check_runs({"total_count": 0, "check_runs": []})["check_runs"] == [],
+        "an empty check_runs list collapses to an empty list",
+        "empty payload collapse wrong",
+    )
+
+    # ── (az) #707 main(): a stale same-named re-run no longer drives Blocked ────────
+    print(
+        "\n=== (az) #707 main(): a stale label-gate re-run does not outvote the latest success ==="
+    )
+
+    # End-to-end reproduction of issue #707 in --pr mode: the head commit carries
+    # the three 'No blocking labels' runs (stale failure between two successes),
+    # and the PR's mergeable_state is 'clean'. The monitor must collapse to the
+    # latest success and terminate Clear, not Blocked. Only the latest run (333)
+    # is a diagnostic target, so exactly one jobs/artifacts pair is fetched --
+    # the stale 111/222 runs are never polled.
+    PR_AZ = {"head": {"sha": "707f1xed"}}
+    PR_MERGEABLE_AZ = {"mergeable_state": "clean", "merged": False, "state": "open"}
+    JOBS_EMPTY_AZ = {"jobs": [{"id": 333, "name": "No blocking labels", "steps": []}]}
+    ARTS_EMPTY_AZ = {"artifacts": []}
+
+    side_effects_az = collections.deque(
+        [
+            PR_AZ,  # pulls -> sha
+            LABEL_GATE_3,  # verdict check-runs (collapsed -> latest success; reused by poll_signals)
+            JOBS_EMPTY_AZ,  # run 333 jobs -> nothing to surface
+            ARTS_EMPTY_AZ,  # run 333 artifacts -> nothing (no zip)
+            PR_MERGEABLE_AZ,  # all_passed -> mergeable_state fetch -> clean -> Clear
+        ]
+    )
+
+    def fake_request_az(url, token, raw=False):
+        return side_effects_az.popleft()
+
+    buf_az = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_az),
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_az),
+    ):
+        rc_az = ci_monitor.main(["ci_monitor.py", "--pr", "707"])
+
+    out_az = buf_az.getvalue()
+    lines_az = out_az.splitlines()
+    check(
+        "PR#707: Clear (mergeable_state=clean)" in lines_az,
+        "the monitor terminates Clear, matching GitHub's mergeable_state=clean",
+        "expected Clear terminal; output: %r" % out_az,
+    )
+    check(
+        not any("Blocked" in ln for ln in lines_az),
+        "no Blocked terminal is emitted despite the stale failure re-run",
+        "unexpected Blocked line; output: %r" % out_az,
+    )
+    label_rows_az = [
+        ln for ln in lines_az if "No blocking labels" in ln and ln.startswith("PR#707:")
+    ]
+    check(
+        len(label_rows_az) == 1,
+        "the summary lists the label-gate check exactly once (stale duplicates collapsed)",
+        "expected 1 'No blocking labels' summary row; got %d: %r" % (len(label_rows_az), out_az),
+    )
+    check(
+        not any("[BLOCKING]" in ln for ln in label_rows_az),
+        "the surviving label-gate row is not marked [BLOCKING]",
+        "label-gate row wrongly marked blocking; output: %r" % out_az,
+    )
+    check(
+        len(side_effects_az) == 0,
+        "all 5 mocked requests consumed (only the latest run's jobs/artifacts fetched once)",
+        "request deque not drained; %d entries left" % len(side_effects_az),
+    )
+    check(rc_az == 0, "main() returned 0", "main() returned %r" % rc_az)
 
     # ── Summary ────────────────────────────────────────────────────────────────────
     print("\nResults: %d passed, %d failed." % (PASS, FAIL))


### PR DESCRIPTION
Fixes #707.

## Problem

A single named check can accumulate several check-run entries against one commit when its workflow re-runs. In issue #707, each PR-side label add/remove re-triggered `block-merge-on-blocking-labels.yml`, so the `No blocking labels` gate ended up with three runs on the same head commit: `success`, then a stale `failure` (from a blocking label that was briefly applied), then `success` again.

`ci_monitor.py` iterated *every* check run, so the stale `failure` outvoted the authoritative later `success`: the tool reported `Blocked by: No blocking labels [label gate]` even though GitHub's own `mergeable_state` for the same commit was `clean`. The per-check summary also listed the name three times, and the stale run's job was tracked for diagnostics.

## Fix

Add `latest_check_runs()`, which collapses the `/commits/{sha}/check-runs` payload so each distinct check-run *name* keeps only its most recent run. Recency is judged by `started_at` (ISO 8601, lexically sortable), then the numeric check-run `id` as a monotonic tiebreak; the surviving run keeps the position of that name's first appearance, so the summary's row order is otherwise unchanged.

The collapsed payload is then used for the verdict (`parse_check_result`), the summary (`parse_check_summary`), and the Actions run/job target discovery (`parse_actions_targets` via `poll_signals`), keeping all three consistent with each other and with `mergeable_state`. Runs with no usable `name` pass through unchanged (each kept), so the unnamed-Actions-run fixtures other paths rely on are untouched, and GitHub always names its own check runs anyway. `--run-id` mode reads a single run object and is unaffected.

This mirrors what GitHub's `mergeable_state` does: judge a required check by its latest run per name. It also stops the stale run's job from being polled for step/FAIL diagnostics.

The issue also floated surfacing Run IDs / Run Attempts and grouping output by Run ID. Collapsing to the latest run per name addresses the reported defect (the wrong verdict) directly and matches GitHub's own dedup semantics, rather than leaving the stale run visible for a human to disambiguate; I went with the collapse.

## Tests

Added to `scripts/test_ci_monitor.py`:

- `(ay)` unit coverage of `latest_check_runs`: the exact three-run shape from the issue reads `Blocked` raw and `all_passed` after collapse; `started_at` is primary and `id` is the tiebreak; distinct names and unnamed runs are preserved in order; only the latest run is a diagnostic target; empty payloads are handled.
- `(az)` an end-to-end `main()` run in `--pr` mode reproducing the issue: the stale `failure` between two `success` runs no longer drives `Blocked` -- the monitor terminates `Clear (mergeable_state=clean)`, lists the gate once, and polls only the latest run's jobs/artifacts.

Full suite: 332 passed, 0 failed. `scripts/lint.sh --check` is clean on the changed files.

🦀

