### PR TITLE
Increase test-name toast duration to 3 seconds

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityDeniedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityDeniedE2ETest.kt
@@ -105,12 +105,13 @@ class SetupActivityDeniedE2ETest {
 
     @get:Rule
     val ruleChain: RuleChain =
-        // testNameToastRule is innermost, running after the activity launch, so its ~1s toast
+        // testNameToastRule is innermost, running after the activity launch, so its ~3s toast
         // delay does not push the keyguard-dismissal-then-launch sequence into a re-engaged
         // keyguard. issue #604's first CI run reproduced exactly that regression with the toast
         // rule placed outermost: this suite failed its very first assertIsDisplayed() (the
         // RESUMED-then-PAUSED-45ms-later symptom described above), because the extra ~1s delay
-        // ahead of keyguardDismiss gave the keyguard time to reassert itself again.
+        // (the toast's duration at the time) ahead of keyguardDismiss gave the keyguard time to
+        // reassert itself again.
         RuleChain.outerRule(keyguardDismiss).around(composeRule).around(testNameToastRule)
 
     @Test

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityGrantedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityGrantedE2ETest.kt
@@ -71,7 +71,7 @@ class SetupActivityGrantedE2ETest {
 
     @get:Rule
     val ruleChain: RuleChain =
-        // testNameToastRule is innermost, running after the activity launch, so its ~1s toast
+        // testNameToastRule is innermost, running after the activity launch, so its ~3s toast
         // delay does not push the keyguard-dismissal-then-launch sequence into a re-engaged
         // keyguard (see SetupActivityDeniedE2ETest's class doc for that race).
         RuleChain.outerRule(keyguardDismiss).around(composeRule).around(testNameToastRule)

--- a/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/SetupActivityPermissionDialogE2ETest.kt
@@ -101,7 +101,7 @@ class SetupActivityPermissionDialogE2ETest {
 
     @get:Rule
     val ruleChain: RuleChain =
-        // testNameToastRule is innermost, running after the activity launch, so its ~1s toast
+        // testNameToastRule is innermost, running after the activity launch, so its ~3s toast
         // delay does not push the keyguard-dismissal-then-launch sequence into a re-engaged
         // keyguard (see SetupActivityDeniedE2ETest's class doc for that race).
         RuleChain.outerRule(keyguardDismiss).around(composeRule).around(testNameToastRule)

--- a/app/src/androidTest/java/com/gb4pc/e2e/TestNameToastRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/TestNameToastRule.kt
@@ -58,7 +58,7 @@ class TestNameToastRule : TestWatcher() {
     /**
      * Shows [testName] in a toast on the main thread, waits [TOAST_DURATION_MS] so it is visible
      * for a predictable duration, then cancels it explicitly rather than relying on the
-     * platform's own (less precise) toast duration to elapse.
+     * platform's own (longer and less precise) toast duration to elapse.
      */
     private fun showAndClearToast(testName: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/gb4pc/e2e/TestNameToastRule.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/TestNameToastRule.kt
@@ -10,7 +10,7 @@ import org.junit.runner.Description
  * JUnit [TestWatcher] rule that toasts the name of each test as it starts, so anyone watching a
  * screen recording or the live emulator can tell which test is currently running (issue #604).
  *
- * [starting] shows a short toast built from the same `"<ClassName>_<methodName>"` prefix
+ * [starting] shows a toast built from the same `"<ClassName>_<methodName>"` prefix
  * [ScreenshotTestRule] already computes ([ScreenshotNaming.buildPrefix]), then blocks the test
  * thread for [TOAST_DURATION_MS] before explicitly cancelling the toast. Blocking--rather than
  * merely showing the toast and moving on--delays the start of the test body until the toast has
@@ -29,7 +29,7 @@ import org.junit.runner.Description
  * For classes that assemble a [org.junit.rules.RuleChain] (to sequence keyguard dismissal ahead of
  * a compose rule, for example), add this as the *innermost* link, after the activity is launched,
  * rather than the outermost one. Putting it outermost would delay the keyguard-dismissal-then-
- * launch sequence by this rule's ~1s toast duration, which is long enough to let the emulator's
+ * launch sequence by this rule's ~3s toast duration, which is long enough to let the emulator's
  * keyguard reassert itself before the compose rule's activity launch--exactly the race those
  * suites' keyguard-dismissal rules exist to avoid:
  * ```kotlin
@@ -42,7 +42,7 @@ class TestNameToastRule : TestWatcher() {
         private const val TAG = "TestNameToastRule"
 
         /** How long the toast stays visible before the test body is allowed to start. */
-        private const val TOAST_DURATION_MS = 1_000L
+        private const val TOAST_DURATION_MS = 3_000L
     }
 
     override fun starting(description: Description) {
@@ -57,8 +57,8 @@ class TestNameToastRule : TestWatcher() {
 
     /**
      * Shows [testName] in a toast on the main thread, waits [TOAST_DURATION_MS] so it is visible
-     * for a predictable, short duration, then cancels it explicitly rather than relying on the
-     * platform's own (longer and less precise) toast duration to elapse.
+     * for a predictable duration, then cancels it explicitly rather than relying on the
+     * platform's own (less precise) toast duration to elapse.
      */
     private fun showAndClearToast(testName: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -66,7 +66,7 @@ class TestNameToastRule : TestWatcher() {
         var toast: Toast? = null
         try {
             instrumentation.runOnMainSync {
-                toast = Toast.makeText(context, testName, Toast.LENGTH_SHORT)
+                toast = Toast.makeText(context, testName, Toast.LENGTH_LONG)
                 toast?.show()
             }
         } catch (e: Exception) {


### PR DESCRIPTION
Fixes #682.

`TestNameToastRule` shows a toast naming the current test before each E2E test case starts, then blocks the test thread for `TOAST_DURATION_MS` before explicitly cancelling it. That delay was 1 second and used `Toast.LENGTH_SHORT`.

This PR:
- Bumps `TOAST_DURATION_MS` from `1_000L` to `3_000L`.
- Switches the toast's own length from `Toast.LENGTH_SHORT` to `Toast.LENGTH_LONG`.
- Updates the doc comments in `TestNameToastRule.kt` and the `~1s toast delay` references in `SetupActivityDeniedE2ETest.kt`, `SetupActivityGrantedE2ETest.kt`, and `SetupActivityPermissionDialogE2ETest.kt` (which sequence this rule around keyguard dismissal) to reflect the new ~3s duration. The historical note in `SetupActivityDeniedE2ETest.kt` about issue #604's original regression keeps its `~1s` figure, since that CI run happened while the duration was still 1 second, and is now annotated as "the toast's duration at the time" for clarity.

### Test plan

- [x] `./scripts/lint.sh --only ktlint` passes on the changed files.
- [x] `:app:compileDebugAndroidTestKotlin` compiles cleanly.
- [x] `:app:testDebugUnitTest` passes (this change does not touch unit-tested code, but the full suite was run as a regression check).

