### PR TITLE
Document how to install uv for lint lockfile regeneration

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -63,6 +63,7 @@ The `ktlint` JAR is stored under `~/.local/lib/ktlint/`.
 
 `scripts/requirements-lint.txt` is a fully resolved lock: every package, top-level and transitive, is pinned to an exact version and a SHA-256 hash, and pip installs it with `--require-hashes` so a substituted or tampered wheel is rejected (issue #699).
 Edit the top-level pins in `scripts/requirements-lint.in` and regenerate the lock with the `uv pip compile` command recorded in that file's header.
+`uv` is not installed by the session-start hook; install it first with `pip install uv`.
 
 ### Checks run by `scripts/lint.sh`
 

--- a/scripts/requirements-lint.in
+++ b/scripts/requirements-lint.in
@@ -22,6 +22,9 @@
 #   uv pip compile --universal --python-version 3.10 --generate-hashes \
 #       scripts/requirements-lint.in -o scripts/requirements-lint.txt
 #
+# `uv` is not installed by the session-start hook. Install it first with
+# `pip install uv` (see .claude/environment.md).
+#
 # --universal + --python-version 3.10 make the lock a superset that covers
 # every interpreter the install sites use (system python3 in
 # .claude/hooks/session-start.sh, and setup-python's "3.x" in CI), so


### PR DESCRIPTION
Fixes #722

The lock-file regeneration instructions in `scripts/requirements-lint.in` and `.claude/environment.md` tell a contributor to run `uv pip compile ...`, but `uv` is not installed anywhere in this repo's dev environment and there was no pointer for how to get it.

This adds a one-line note next to each place the `uv pip compile` command is documented, pointing to `pip install uv`.

## Test plan

This is a documentation-only change (comment text in `scripts/requirements-lint.in` and prose in `.claude/environment.md`); there is no behavior to test. `scripts/lint.sh` passes on both changed files.