### PR TITLE
Rank a queued re-run above an older same-named completion in ci_monitor

### DIFF
--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -346,17 +346,29 @@ def _check_run_recency_key(run):
     label-gate workflow, so that gate's check-run name accumulates several
     entries against the same head commit, of which only the most recent
     conclusion is authoritative (the earlier ones are stale).
-    Recency is judged by `started_at` (ISO 8601, so lexically sortable), then by
-    the numeric check-run `id` as a monotonic tiebreak (a re-run always gets a
-    higher id). A run missing both fields sorts oldest, so a run carrying real
-    recency data always outranks one that does not.
+
+    A not-yet-completed run (`status` other than `completed`, i.e. `queued` or
+    `in_progress`) is a re-run currently superseding any completed run of the
+    same name, so it sorts above every completed run regardless of timestamps
+    (issue #719). GitHub leaves `started_at` null until a run actually starts, so
+    without this a freshly-queued re-run would sort oldest by `started_at` and be
+    collapsed away in favor of the stale completed run it supersedes; the verdict
+    would then read that stale completion instead of `in_progress`. `True` sorts
+    above `False`, so the `pending` flag leads the key.
+    Among runs sharing a completion state, recency is judged by `started_at`
+    (ISO 8601, so lexically sortable), then by the numeric check-run `id` as a
+    monotonic tiebreak (a re-run always gets a higher id). Among completed runs
+    the `pending` flag is uniformly `False`, so their order is unchanged: a run
+    missing both timestamp and id sorts oldest, and a run carrying real recency
+    data always outranks one that does not.
     """
     started = run.get("started_at") or ""
     try:
         run_id = int(run.get("id"))
     except (TypeError, ValueError):
         run_id = -1
-    return (started, run_id)
+    pending = run.get("status") != "completed"
+    return (pending, started, run_id)
 
 
 def latest_check_runs(check_json):
@@ -366,6 +378,11 @@ def latest_check_runs(check_json):
     each distinct non-empty check-run `name`, only the most recent run (by
     `_check_run_recency_key`); the surviving run sits at the position of that
     name's first appearance, so the summary's row order is otherwise preserved.
+    A pending (queued/in_progress) re-run is never collapsed away in favor of an
+    older completed run of the same name, even before GitHub populates its
+    `started_at` (issue #719), so the verdict keeps reading `in_progress` while a
+    required check's re-run is still pending rather than latching onto the stale
+    completion it supersedes.
     Runs with no usable `name` are passed through unchanged (each kept), since
     name-based identity does not apply to them and GitHub always names its own
     check runs; this also leaves the unnamed-Actions-run fixtures other tests

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -76,6 +76,13 @@ Covers:
        does not outvote the authoritative latest success -- the monitor
        terminates Clear (mergeable_state=clean), lists the gate once, and polls
        only the latest run's jobs/artifacts
+  (ba) #719 latest_check_runs: a queued/in_progress re-run (started_at null)
+       outranks an older completed run of the same name, so the collapsed
+       payload reads in_progress (not all_passed / not Blocked) while the re-run
+       is pending; the #707 all-completed fixtures still collapse unchanged
+  (bb) #719 main(): in --sha mode (no mergeable_state backstop) a queued re-run
+       of a required check does not fire a premature Clear -- the monitor keeps
+       polling and terminates Clear only once the re-run completes
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4916,6 +4923,164 @@ def main() -> int:
         "request deque not drained; %d entries left" % len(side_effects_az),
     )
     check(rc_az == 0, "main() returned 0", "main() returned %r" % rc_az)
+
+    # ── (ba) #719 a queued re-run is not collapsed away by an older completion ──────
+    print(
+        "\n=== (ba) #719 latest_check_runs: a queued re-run outranks an older same-named"
+        " completion ==="
+    )
+
+    # A required check has an old completed 'success' plus a freshly-queued
+    # re-run of the same name. GitHub leaves started_at null until a run starts,
+    # so by the old (started_at, id) key the queued re-run ("") sorted oldest and
+    # was collapsed away, leaving only the stale 'success' -- so parse_check_result
+    # read 'all_passed' instead of 'in_progress' during that window (issue #719).
+    QUEUED_RERUN_SUCCESS = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 1,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            # Freshly queued re-run: started_at absent, higher id.
+            {"id": 2, "name": "gate", "status": "queued"},
+        ],
+    }
+    kept_ba = ci_monitor.latest_check_runs(QUEUED_RERUN_SUCCESS)["check_runs"]
+    check(
+        len(kept_ba) == 1 and kept_ba[0]["id"] == 2,
+        "the queued re-run (id 2) survives the collapse, not the older completed success",
+        "expected the queued run kept; got %r" % (kept_ba,),
+    )
+    check(
+        ci_monitor.parse_check_result(ci_monitor.latest_check_runs(QUEUED_RERUN_SUCCESS))
+        == "in_progress",
+        "collapsed payload reads in_progress (not all_passed) while the re-run is pending",
+        "expected in_progress; got %r"
+        % ci_monitor.parse_check_result(ci_monitor.latest_check_runs(QUEUED_RERUN_SUCCESS)),
+    )
+
+    # Symmetric #707 variant: a stale completed 'failure' plus a queued re-run of
+    # the same name. The queued run must win so the verdict is in_progress, not a
+    # spurious Blocked from the superseded failure.
+    QUEUED_RERUN_FAILURE = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 10,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {"id": 11, "name": "gate", "status": "queued", "started_at": None},
+        ],
+    }
+    kept_ba_fail = ci_monitor.latest_check_runs(QUEUED_RERUN_FAILURE)["check_runs"]
+    check(
+        len(kept_ba_fail) == 1 and kept_ba_fail[0]["id"] == 11,
+        "the queued re-run (id 11) survives over the stale completed failure",
+        "expected the queued run kept; got %r" % (kept_ba_fail,),
+    )
+    check(
+        ci_monitor.parse_check_result(ci_monitor.latest_check_runs(QUEUED_RERUN_FAILURE))
+        == "in_progress",
+        "collapsed payload reads in_progress (not Blocked) while the re-run supersedes a failure",
+        "expected in_progress; got %r"
+        % ci_monitor.parse_check_result(ci_monitor.latest_check_runs(QUEUED_RERUN_FAILURE)),
+    )
+
+    # The pending discriminator only leads the key; among completed runs the
+    # existing (started_at, id) ordering is untouched. Re-assert the #707
+    # fixtures collapse exactly as before.
+    check(
+        ci_monitor.latest_check_runs(LABEL_GATE_3)["check_runs"][0]["id"] == 87688242514,
+        "#707 three-completed-run collapse is unchanged (latest success still wins)",
+        "regression in the three-completed-run collapse",
+    )
+    check(
+        ci_monitor.latest_check_runs(STARTED_AT_WINS)["check_runs"][0]["conclusion"] == "success",
+        "#707 STARTED_AT_WINS unchanged (newer started_at still beats a higher id)",
+        "regression in STARTED_AT_WINS",
+    )
+    check(
+        ci_monitor.latest_check_runs(ID_TIEBREAK)["check_runs"][0]["id"] == 9,
+        "#707 ID_TIEBREAK unchanged (higher id still wins with no started_at)",
+        "regression in ID_TIEBREAK",
+    )
+    kept_mixed_ba = ci_monitor.latest_check_runs(MIXED)["check_runs"]
+    check(
+        [r.get("name") for r in kept_mixed_ba] == ["alpha", None, "beta", None]
+        and [r for r in kept_mixed_ba if r.get("name") == "alpha"][0]["id"] == 5,
+        "#707 MIXED collapse unchanged (names, order, and alpha's latest id 5)",
+        "regression in MIXED",
+    )
+
+    # ── (bb) #719 main(): a queued re-run in --sha mode does not terminate Clear ────
+    print(
+        "\n=== (bb) #719 main(): --sha mode keeps polling while a queued re-run supersedes an"
+        " old success ==="
+    )
+
+    # End-to-end reproduction of the user-visible defect: in --sha mode there is
+    # no mergeable_state backstop, so a premature all_passed would fire Clear and
+    # break the loop while a required re-run is still pending. First poll carries
+    # the old completed success plus a queued re-run of the same name; the second
+    # poll shows the re-run finished success. The monitor must NOT Clear on the
+    # first poll (it must keep polling), then Clear once the re-run completes.
+    SHA_BB = "719cafef00d5"
+    tag_bb = "SHA#%s" % SHA_BB[:7]
+    CHECK_PENDING_BB = QUEUED_RERUN_SUCCESS
+    CHECK_DONE_BB = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 1,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "gate",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-01T00:05:00Z",
+            },
+        ],
+    }
+    # Poll 1: pending (in_progress, keeps polling). Poll 2: all_passed -> Clear.
+    # Neither payload carries a github-actions app/details_url, so poll_signals
+    # discovers no targets and issues no jobs/artifacts fetches.
+    side_effects_bb = collections.deque([CHECK_PENDING_BB, CHECK_DONE_BB])
+
+    def fake_request_bb(url, token, raw=False):
+        return side_effects_bb.popleft()
+
+    buf_bb = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_bb),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_bb),
+    ):
+        rc_bb = ci_monitor.main(["ci_monitor.py", "--sha", SHA_BB])
+
+    lines_bb = buf_bb.getvalue().splitlines()
+    check(
+        ("%s: Clear" % tag_bb) in lines_bb,
+        "the monitor eventually terminates Clear once the queued re-run completes success",
+        "expected a Clear terminal; output: %r" % lines_bb,
+    )
+    check(
+        len(side_effects_bb) == 0,
+        "both polls consumed: the monitor did NOT prematurely Clear on the pending first poll",
+        "monitor broke early on the pending poll; %d entries left" % len(side_effects_bb),
+    )
+    check(rc_bb == 0, "main() returned 0", "main() returned %r" % rc_bb)
 
     # ── Summary ────────────────────────────────────────────────────────────────────
     print("\nResults: %d passed, %d failed." % (PASS, FAIL))


### PR DESCRIPTION
Fixes #719.

## Problem

PR #716's `latest_check_runs` collapses same-named check runs to the most recent per name, keyed by `_check_run_recency_key` = `(started_at, id)`.
GitHub leaves `started_at` null until a run actually starts, so a freshly-queued re-run maps to `("", id)`, which sorts *oldest*.
When a required check has an old completed run plus a freshly-queued re-run of the same name, the queued run is collapsed away and only the stale completion survives.
`parse_check_result` then reads that completion (`all_passed`, or `Blocked` in the symmetric stale-`failure` case) instead of `in_progress`.

In `--pr` mode the `mergeable_state` gate is a backstop, but `--sha`/`--branch` modes have no such backstop, so this window could fire a premature terminal `Clear` (a wrong terminal that ends the monitor while a required re-run is still pending).

## Fix

Add a leading `pending` discriminator to `_check_run_recency_key`: a run whose `status` is not `completed` (queued/in_progress) now sorts above every completed run of the same name, regardless of `started_at`.
`True` sorts above `False`, so a pending re-run wins the collapse and the verdict correctly reads `in_progress`.

Among completed runs `pending` is uniformly `False`, so the existing `started_at`-primary / `id`-tiebreak ordering is preserved verbatim; issue #707's scenarios collapse exactly as before.
The residual error direction is fail-safe: at worst the monitor waits (`in_progress`) rather than terminating early on a wrong `Clear`.

Docstrings on `_check_run_recency_key` and `latest_check_runs` are updated to state the new pending-supersedes-completed rule.

## Tests

- `(ba)` unit cases: a same-named old-`success` + queued re-run and the symmetric old-`failure` + queued re-run both collapse to keep the queued run, and the collapsed payload reads `in_progress` (not `all_passed`/`Blocked`). The #707 fixtures (three-completed-run collapse, `STARTED_AT_WINS`, `ID_TIEBREAK`, `MIXED`) are re-asserted unchanged.
- `(bb)` end-to-end `--sha` `main()` case: a first poll with the queued re-run must not terminate `Clear`; the monitor keeps polling and only Clears once the re-run completes. This exercises the actual user-visible defect (premature `Clear` in a non-PR mode), not just the verdict token.

Verified locally: `python3 scripts/test_ci_monitor.py` reports 343 passed, 0 failed, and `scripts/lint.sh --check` passes on both changed files.

No functional change to the outcome vocabulary, so `scripts/ci_monitor/README.md` needs no update.
