### PR TITLE
Collapse same-named check runs by check-run id alone (#719)

### DIFF
--- a/scripts/ci_monitor/README.md
+++ b/scripts/ci_monitor/README.md
@@ -41,7 +41,8 @@ In `--run-id` mode, the run to track is simply the one named on the command line
 
 Before reading the verdict, summary, or run/job targets, the Monitor collapses the `/commits/{sha}/check-runs` payload so that each distinct check-run *name* keeps only its most recent run (issue #707).
 GitHub can attach several check runs with the same name to one commit when a workflow re-runs: for example, each PR-side label add/remove re-triggers `block-merge-on-blocking-labels.yml`, so the `No blocking labels` gate accumulates several entries against the same head commit, and a stale `failure` (from a blocking label that was since removed) can sit between two `success` runs.
-Recency is judged by the run's `started_at` (ISO 8601, lexically sortable), then its numeric check-run `id` as a monotonic tiebreak; the surviving run keeps the position of that name's first appearance so the summary's row order is otherwise unchanged.
+Recency is judged by the run's numeric check-run `id`: GitHub assigns it at creation and a re-run always gets a higher one, so it identifies the latest attempt without relying on `started_at`, which GitHub leaves null until a run actually starts (a freshly-queued re-run would otherwise sort oldest and let a stale completed run win; issue #719).
+The surviving run keeps the position of that name's first appearance so the summary's row order is otherwise unchanged.
 This mirrors GitHub's own `mergeable_state`, which judges a required check by its latest run per name.
 Without it, a superseded `failure` would outvote the authoritative later `success` and drive a spurious `Blocked` terminal, and the stale run's job would also be tracked for diagnostics.
 Runs with no usable `name` are passed through unchanged (each kept), since name-based identity does not apply to them and GitHub always names its own check runs.

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -366,8 +366,10 @@ def latest_check_runs(check_json):
     each distinct non-empty check-run `name`, only the most recent run (the
     highest check-run `id`, via `_check_run_recency_key`); the surviving run sits
     at the position of that name's first appearance, so the summary's row order
-    is otherwise preserved. Because check-run ids are unique, the `>=` winner
-    test below never ties, so no list-order tiebreak is relied on.
+    is otherwise preserved. Real check-run ids are unique, so in practice the
+    `>=` winner test below never ties; the one exception is two runs whose ids
+    are both unusable (each keyed -1), where `>=` keeps the later of the two in
+    list order, which is harmless since neither carries real recency.
     Runs with no usable `name` are passed through unchanged (each kept), since
     name-based identity does not apply to them and GitHub always names its own
     check runs; this also leaves the unnamed-Actions-run fixtures other tests

--- a/scripts/ci_monitor/ci_monitor.py
+++ b/scripts/ci_monitor/ci_monitor.py
@@ -339,33 +339,35 @@ def parse_pr_terminal(pr_json):
 
 
 def _check_run_recency_key(run):
-    """Return a sort key ordering check runs oldest-to-newest (issue #707).
+    """Return a sort key ordering check runs oldest-to-newest by check-run id.
 
-    GitHub can attach several check runs with the same `name` to one commit when
-    a workflow re-runs: e.g. each PR-side label add/remove re-triggers the
-    label-gate workflow, so that gate's check-run name accumulates several
-    entries against the same head commit, of which only the most recent
-    conclusion is authoritative (the earlier ones are stale).
-    Recency is judged by `started_at` (ISO 8601, so lexically sortable), then by
-    the numeric check-run `id` as a monotonic tiebreak (a re-run always gets a
-    higher id). A run missing both fields sorts oldest, so a run carrying real
-    recency data always outranks one that does not.
+    GitHub attaches several check runs with the same `name` to one commit when a
+    workflow re-runs (e.g. each PR-side label add/remove re-triggers the
+    label-gate workflow), so that gate's check-run name accumulates several
+    entries against the same head commit, of which only the most recent is
+    authoritative (issue #707). A re-run always creates a new check-run row with
+    a higher `id`, and--unlike `started_at`, which GitHub leaves null until a run
+    actually starts (issue #719)--the `id` is assigned at creation, so a
+    freshly-queued re-run already outranks the completed run it supersedes.
+    Sorting by `id` alone keeps the latest attempt for both completed re-runs
+    (#707) and not-yet-started ones (#719), with no null-handling and no
+    status special-casing. A run with an unusable id sorts oldest.
     """
-    started = run.get("started_at") or ""
     try:
-        run_id = int(run.get("id"))
+        return int(run.get("id"))
     except (TypeError, ValueError):
-        run_id = -1
-    return (started, run_id)
+        return -1
 
 
 def latest_check_runs(check_json):
-    """Collapse same-named check runs to the latest one each (issue #707).
+    """Collapse same-named check runs to the latest one each (issues #707, #719).
 
     Returns a shallow copy of `check_json` whose `check_runs` list keeps, for
-    each distinct non-empty check-run `name`, only the most recent run (by
-    `_check_run_recency_key`); the surviving run sits at the position of that
-    name's first appearance, so the summary's row order is otherwise preserved.
+    each distinct non-empty check-run `name`, only the most recent run (the
+    highest check-run `id`, via `_check_run_recency_key`); the surviving run sits
+    at the position of that name's first appearance, so the summary's row order
+    is otherwise preserved. Because check-run ids are unique, the `>=` winner
+    test below never ties, so no list-order tiebreak is relied on.
     Runs with no usable `name` are passed through unchanged (each kept), since
     name-based identity does not apply to them and GitHub always names its own
     check runs; this also leaves the unnamed-Actions-run fixtures other tests

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -69,13 +69,20 @@ Covers:
        whose distinguishing text lives in `suite` (name matching still works,
        and a pattern in neither still suppresses)
   (ay) #707 latest_check_runs: same-named check runs collapse to the latest
-       each (by started_at then id); the raw payload's stale failure reads
+       each (by check-run id); the raw payload's stale failure reads
        Blocked while the collapsed one reads all_passed; distinct names and
        unnamed runs are preserved; only the latest run is a diagnostic target
   (az) #707 main(): a stale label-gate re-run (failure) between two successes
        does not outvote the authoritative latest success -- the monitor
        terminates Clear (mergeable_state=clean), lists the gate once, and polls
        only the latest run's jobs/artifacts
+  (ba) #719 latest_check_runs/parse_check_result: a freshly-queued re-run with
+       a null started_at but a higher id wins over an old completed run, so the
+       collapsed payload reads in_progress (not a premature all_passed); the
+       symmetric stale-failure variant reads in_progress (not Blocked)
+  (bb) #719 main(): --sha mode does not terminate Clear while a same-named
+       required check has a queued re-run outstanding; it Clears only once that
+       re-run completes
 
 No network calls required; no GITHUB_TOKEN needed.
 Run this file directly to execute the suite: exits 0 on success, non-zero on failure.
@@ -4770,20 +4777,22 @@ def main() -> int:
         "expected [('333', None)]; got %r" % (targets_ay,),
     )
 
-    # started_at is the primary recency signal; the id is only a tiebreak. A run
-    # with a newer started_at wins even if its id is numerically lower.
-    STARTED_AT_WINS = {
+    # Recency is judged by check-run id alone. On real GitHub payloads the newer
+    # attempt has both the higher id and the later started_at (the id is assigned
+    # first, at creation; issue #719), so this agreement case is what actually
+    # occurs -- the newer run wins and the stale low-id run loses.
+    NEWER_ATTEMPT_WINS = {
         "total_count": 2,
         "check_runs": [
             {
-                "id": 999,
+                "id": 1,
                 "name": "gate",
                 "status": "completed",
                 "conclusion": "failure",
                 "started_at": "2026-01-01T00:00:00Z",
             },
             {
-                "id": 1,
+                "id": 999,
                 "name": "gate",
                 "status": "completed",
                 "conclusion": "success",
@@ -4791,11 +4800,13 @@ def main() -> int:
             },
         ],
     }
-    kept_started = ci_monitor.latest_check_runs(STARTED_AT_WINS)["check_runs"]
+    kept_newer = ci_monitor.latest_check_runs(NEWER_ATTEMPT_WINS)["check_runs"]
     check(
-        len(kept_started) == 1 and kept_started[0]["conclusion"] == "success",
-        "a newer started_at wins over a numerically higher id",
-        "started_at tiebreak wrong; got %r" % (kept_started,),
+        len(kept_newer) == 1
+        and kept_newer[0]["id"] == 999
+        and kept_newer[0]["conclusion"] == "success",
+        "the newer attempt (higher id and later started_at) wins",
+        "recency pick wrong; got %r" % (kept_newer,),
     )
 
     # When started_at is absent/equal, the numeric id breaks the tie.
@@ -4916,6 +4927,140 @@ def main() -> int:
         "request deque not drained; %d entries left" % len(side_effects_az),
     )
     check(rc_az == 0, "main() returned 0", "main() returned %r" % rc_az)
+
+    # ── (ba) #719 a queued re-run with a null started_at wins over an old run ───────
+    print(
+        "\n=== (ba) #719 latest_check_runs/parse_check_result: a queued re-run "
+        "(null started_at, higher id) is not outvoted by a stale completed run ==="
+    )
+
+    # The exact #719 shape: a required check has an old completed run plus a
+    # freshly-queued re-run of the same name. GitHub leaves the queued run's
+    # started_at null until it starts, so a started_at-primary key would sort the
+    # queued run oldest and collapse to the stale completed run -- reading its
+    # verdict during the re-run window. The id (assigned at creation) already
+    # ranks the queued re-run newest, so the collapse keeps it and the verdict
+    # stays in_progress until the re-run finishes.
+    QUEUED_RERUN_AFTER_SUCCESS = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 1,
+                "name": "build-and-test",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {"id": 2, "name": "build-and-test", "status": "queued"},  # no started_at yet
+        ],
+    }
+    collapsed_ba1 = ci_monitor.latest_check_runs(QUEUED_RERUN_AFTER_SUCCESS)
+    check(
+        len(collapsed_ba1["check_runs"]) == 1 and collapsed_ba1["check_runs"][0]["id"] == 2,
+        "the freshly-queued re-run (id 2, null started_at) survives the collapse",
+        "wrong surviving run; got %r" % (collapsed_ba1["check_runs"],),
+    )
+    check(
+        ci_monitor.parse_check_result(collapsed_ba1) == "in_progress",
+        "the collapsed payload reads in_progress, not a premature all_passed",
+        "expected in_progress; got %r" % ci_monitor.parse_check_result(collapsed_ba1),
+    )
+
+    # Symmetric variant: the stale completed run is a failure. The queued re-run
+    # must still win, so the verdict is in_progress rather than a spurious Blocked
+    # off the superseded failure.
+    QUEUED_RERUN_AFTER_FAILURE = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 10,
+                "name": "build-and-test",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {"id": 11, "name": "build-and-test", "status": "queued"},  # no started_at yet
+        ],
+    }
+    collapsed_ba2 = ci_monitor.latest_check_runs(QUEUED_RERUN_AFTER_FAILURE)
+    check(
+        len(collapsed_ba2["check_runs"]) == 1 and collapsed_ba2["check_runs"][0]["id"] == 11,
+        "the queued re-run (id 11) survives over the stale completed failure",
+        "wrong surviving run; got %r" % (collapsed_ba2["check_runs"],),
+    )
+    check(
+        ci_monitor.parse_check_result(collapsed_ba2) == "in_progress",
+        "the symmetric payload reads in_progress, not a spurious Blocked",
+        "expected in_progress; got %r" % ci_monitor.parse_check_result(collapsed_ba2),
+    )
+
+    # ── (bb) #719 main(): --sha mode does not Clear while a re-run is queued ────────
+    print(
+        "\n=== (bb) #719 main(): --sha mode keeps polling through a queued re-run "
+        "and Clears only once it completes ==="
+    )
+
+    # End-to-end reproduction of the user-visible defect: in --sha mode there is
+    # no mergeable_state backstop, so a premature all_passed would terminate Clear
+    # while a required check's re-run is still queued. Poll 1 carries the old
+    # completed success plus a queued re-run of the same name; poll 2 shows the
+    # re-run completed. The monitor must stay in_progress on poll 1 (consuming it)
+    # and Clear only on poll 2. Both check runs are unnamed to Actions (no
+    # github-actions details_url), so parse_actions_targets finds no jobs/artifacts
+    # to fetch -- exactly one check-runs request is issued per poll.
+    SHA_BB = "719f1xed0cafe"
+    tag_bb = "SHA#%s" % SHA_BB[:7]
+    POLL1_BB = QUEUED_RERUN_AFTER_SUCCESS
+    POLL2_BB = {
+        "total_count": 2,
+        "check_runs": [
+            {
+                "id": 1,
+                "name": "build-and-test",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "build-and-test",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-01-02T00:00:00Z",
+            },
+        ],
+    }
+    side_effects_bb = collections.deque([POLL1_BB, POLL2_BB])
+
+    def fake_request_bb(url, token, raw=False):
+        return side_effects_bb.popleft()
+
+    buf_bb = io.StringIO()
+    with (
+        unittest.mock.patch.object(ci_monitor, "_request", side_effect=fake_request_bb),
+        unittest.mock.patch.object(ci_monitor.time, "time", return_value=1000.0),
+        unittest.mock.patch.object(ci_monitor.time, "sleep", return_value=None),
+        unittest.mock.patch("sys.stdout", new=buf_bb),
+    ):
+        rc_bb = ci_monitor.main(["ci_monitor.py", "--sha", SHA_BB])
+
+    lines_bb = buf_bb.getvalue().splitlines()
+    check(
+        ("%s: Clear" % tag_bb) in lines_bb,
+        "the monitor eventually terminates Clear once the re-run completes",
+        "expected a Clear line; output: %r" % lines_bb,
+    )
+    check(
+        not any("Blocked" in ln for ln in lines_bb),
+        "no Blocked terminal is emitted",
+        "unexpected Blocked line; output: %r" % lines_bb,
+    )
+    check(
+        len(side_effects_bb) == 0,
+        "both polls were consumed: the monitor did not Clear on the queued poll 1",
+        "premature terminal on poll 1; %d payloads left unconsumed" % len(side_effects_bb),
+    )
+    check(rc_bb == 0, "main() returned 0", "main() returned %r" % rc_bb)
 
     # ── Summary ────────────────────────────────────────────────────────────────────
     print("\nResults: %d passed, %d failed." % (PASS, FAIL))

--- a/scripts/test_ci_monitor.py
+++ b/scripts/test_ci_monitor.py
@@ -4809,19 +4809,20 @@ def main() -> int:
         "recency pick wrong; got %r" % (kept_newer,),
     )
 
-    # When started_at is absent/equal, the numeric id breaks the tie.
-    ID_TIEBREAK = {
+    # The check-run id is the sole recency key: the higher id is the latest
+    # attempt and wins outright (issue #719), with no started_at consulted.
+    ID_RECENCY = {
         "total_count": 2,
         "check_runs": [
             {"id": 5, "name": "gate", "status": "completed", "conclusion": "failure"},
             {"id": 9, "name": "gate", "status": "completed", "conclusion": "success"},
         ],
     }
-    kept_id = ci_monitor.latest_check_runs(ID_TIEBREAK)["check_runs"]
+    kept_id = ci_monitor.latest_check_runs(ID_RECENCY)["check_runs"]
     check(
         len(kept_id) == 1 and kept_id[0]["id"] == 9,
-        "with no started_at, the higher id wins the tiebreak",
-        "id tiebreak wrong; got %r" % (kept_id,),
+        "the higher id (the latest attempt) wins outright",
+        "id recency pick wrong; got %r" % (kept_id,),
     )
 
     # Distinct names are all preserved, in first-appearance order; unnamed runs


### PR DESCRIPTION
Fixes #719.

## Problem

`latest_check_runs` collapses same-named check runs to the most recent per name, then `parse_check_result` reads that run's verdict.
The old recency key was `(started_at, id)`.
GitHub leaves `started_at` null until a run actually starts, so a required check with an old completed run plus a freshly-queued re-run of the same name collapsed to the *old* run (the queued re-run sorted oldest on its empty `started_at`), and the verdict was read off the stale run during that window.

In `--pr` mode the `mergeable_state` gate is a backstop (a pending required check reports non-`clean`), but `--sha`/`--branch` modes have no such backstop and could emit a premature `Clear` (or a spurious `Blocked` on the symmetric stale-`failure` case).

## Fix

Sort by check-run `id` alone.
A re-run always creates a new check-run row with a higher `id`, and unlike `started_at` the `id` is assigned at creation (before the run starts), so a freshly-queued re-run already outranks the completed run it supersedes.
This is a net deletion: the `started_at` read, the null sentinel, and the tuple key all go away; selection becomes pure recency and the verdict is read off the winner.

This reproduces the #707 collapse exactly (its real payloads have `id` and `started_at` in agreement) and fixes #719 in every non-PR mode.

## Tests

- `(ba)` unit: a queued re-run with a null `started_at` (higher id) survives the collapse and the payload reads `in_progress` (not a premature `all_passed`); plus the symmetric stale-`failure` variant reads `in_progress` (not `Blocked`).
- `(bb)` end-to-end (`--sha`): the monitor stays `in_progress` through the queued poll and `Clear`s only once the re-run completes. This test fails against the old key (which would `Clear` on the queued poll) and passes with the new one.
- #707 fixtures (`LABEL_GATE_3`, `ID_TIEBREAK`, `MIXED`) are unchanged and still pass.

Replaced test `STARTED_AT_WINS` because its premise (a lower-id run with a later `started_at` outranks a higher-id run) no longer holds and describes no real GitHub payload; the replacement `NEWER_ATTEMPT_WINS` asserts the newer attempt (higher id and later `started_at`) wins, per the issue's "Replace `STARTED_AT_WINS` ... or drop it" instruction.

## Note on scope

The issue said the README needs no update (outcome vocabulary unchanged), but the "Same-named check-run collapsing" section still stated recency was judged by `started_at` then `id`, which is now false.
I corrected that one sentence in a separate commit so it is easy to review or revert.

Verification (all green locally): `python3 scripts/test_ci_monitor.py` (340 passed, 0 failed); `ruff check` and `ruff format --check`; `mdformat --check --wrap keep --number` and `check_md040.py` on the README.
