### PR TITLE
Require the mock gallery in the foreground in test3a's post-tap check

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -295,22 +295,30 @@ class GalleryButtonVisualE2ETest {
         val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
         Screenshot.saveForArtifact(maskToBitmap(greenMask), "3a-green-mask.png")
 
+        // Evaluate both post-tap conditions and report every one that fails in a single message.
+        // The coverage and foreground checks are independent failure modes, so when both hold
+        // (for example, the tap opened some other, non-green screen) the report should name both
+        // reasons rather than throwing on the first and hiding the second.
         val coverage = ColorMatch.coverageFraction(greenMask)
-        if (coverage <= 0.40f) {
-            fail(
-                "test3a_populatedGalleryShowsGreenAfterTap: GREEN coverage after tap is " +
-                    "${coverage * 100f}%--expected > 40%. " +
-                    "The gallery did not open, or the captured photo is not green.",
-            )
-        }
         val foreground = fixture.foregroundPackage()
-        if (foreground != MOCK_GALLERY_PACKAGE) {
-            fail(
-                "test3a_populatedGalleryShowsGreenAfterTap: foreground package after tap is " +
-                    "$foreground--expected $MOCK_GALLERY_PACKAGE. The screen shows green, but the " +
-                    "gallery did not open (the pre-tap mock-camera feed is still in front after a " +
-                    "no-op tap).",
-            )
+        val failures =
+            buildList {
+                if (coverage <= 0.40f) {
+                    add(
+                        "GREEN coverage after tap is ${coverage * 100f}%--expected > 40% " +
+                            "(the gallery did not open, or the captured photo is not green)",
+                    )
+                }
+                if (foreground != MOCK_GALLERY_PACKAGE) {
+                    add(
+                        "foreground package after tap is $foreground--expected $MOCK_GALLERY_PACKAGE " +
+                            "(the gallery did not come to the foreground; a no-op tap leaves the " +
+                            "green mock camera in front)",
+                    )
+                }
+            }
+        if (failures.isNotEmpty()) {
+            fail("test3a_populatedGalleryShowsGreenAfterTap: " + failures.joinToString("; "))
         }
     }
 

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -255,7 +255,17 @@ class GalleryButtonVisualE2ETest {
 
     /**
      * Verifies that tapping the overlay when the camera roll contains one GREEN photo opens
-     * the gallery and shows the GREEN content. Coverage after tap must exceed 40%.
+     * the mock gallery in the foreground and shows the GREEN content. Coverage after tap must
+     * exceed 40%, and the foreground package must be the mock gallery.
+     *
+     * The foreground-package check is load-bearing (issue #733): MockCameraActivity already fills
+     * the screen with close to 100% GREEN before the tap, so coverage alone stays above 40% even
+     * when the tap is a no-op and the gallery never launches (the #241/#705 regression class this
+     * test exists to catch). A stability requirement would not help either: the no-op failure mode
+     * is a screen that never changes, so any number of consecutive samples is satisfied just as
+     * trivially as one. Requiring the mock gallery in the foreground, mirroring test2a/test4a's
+     * safeguard, makes a no-op tap time out and fail loudly instead of passing on the stale
+     * pre-tap frame.
      */
     @Test
     fun test3a_populatedGalleryShowsGreenAfterTap() {
@@ -271,9 +281,15 @@ class GalleryButtonVisualE2ETest {
         val s1 = Screenshot.captureScreen()
         Screenshot.saveForArtifact(s1, "3a-s1.png")
 
-        // Await the gallery showing the captured GREEN photo; its cold start (process spawn +
-        // MediaStore query + JPEG decode) takes ~1.4 s in CI.
-        val s2 = fixture.tapOverlayAndAwait { greenCoverage(it) > 0.40f }
+        // Await the mock gallery, in the foreground, showing the captured GREEN photo; its cold
+        // start (process spawn + MediaStore query + JPEG decode) takes ~1.4 s in CI. The
+        // foreground-package predicate is essential: the pre-tap MockCameraActivity is already
+        // ~100% GREEN, so a coverage-only predicate is satisfied by that stale frame and a no-op
+        // tap would pass without the gallery launching (issue #733).
+        val s2 =
+            fixture.tapOverlayAndAwait { screen ->
+                greenCoverage(screen) > 0.40f && fixture.foregroundPackage() == MOCK_GALLERY_PACKAGE
+            }
         Screenshot.saveForArtifact(s2, "3a-s2.png")
 
         val greenMask = ColorMatch.mask(s2, Rgb.GREEN)
@@ -285,6 +301,15 @@ class GalleryButtonVisualE2ETest {
                 "test3a_populatedGalleryShowsGreenAfterTap: GREEN coverage after tap is " +
                     "${coverage * 100f}%--expected > 40%. " +
                     "The gallery did not open, or the captured photo is not green.",
+            )
+        }
+        val foreground = fixture.foregroundPackage()
+        if (foreground != MOCK_GALLERY_PACKAGE) {
+            fail(
+                "test3a_populatedGalleryShowsGreenAfterTap: foreground package after tap is " +
+                    "$foreground--expected $MOCK_GALLERY_PACKAGE. The screen shows green, but the " +
+                    "gallery did not open (the pre-tap mock-camera feed is still in front after a " +
+                    "no-op tap).",
             )
         }
     }


### PR DESCRIPTION
🤖 Author

Fixes #733.

## Problem

`test3a_populatedGalleryShowsGreenAfterTap` asserted only `greenCoverage(s2) > 0.40f` after tapping the overlay, with no check that the tap actually launched the mock gallery.
Before the tap, `MockCameraActivity` already covers the screen with close to 100% GREEN.
On a no-op tap (the #241/#705 regression class this test exists to catch) the screen never changes, coverage stays above 40% for the whole poll, and the test passed without the gallery ever launching.

A stability requirement would not fix this: the failure mode is a screen that never changes, so any number of consecutive samples is satisfied just as trivially as one.

## Fix

Mirror the positive foreground-package safeguard that test2a/test4a already use (added in #730): require `fixture.foregroundPackage() == MOCK_GALLERY_PACKAGE` alongside the coverage check, in two places:

- In the `tapOverlayAndAwait` poll predicate, so the poll waits for the mock gallery specifically rather than being satisfied by the stale pre-tap mock-camera frame.
- As a final assertion with its own failure message, so a no-op tap times out and then fails loudly (naming the actual foreground package) instead of passing on stale pre-tap content.

The kdoc is updated to record why the foreground check is load-bearing.

This is the last remaining tap test in this file without either the foreground safeguard (test2a/test4a) or test5a's structural letterboxed-band discriminator.

The change touches only the instrumented E2E test; CI exercises it on the emulator.

