### PR TITLE
Scan screenshots via one Bitmap.getPixels bulk read in ColorMatch.mask

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/visual/ColorMatch.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/visual/ColorMatch.kt
@@ -1,7 +1,6 @@
 package com.gb4pc.e2e.visual
 
 import android.graphics.Bitmap
-import android.graphics.Color
 import android.graphics.PointF
 import android.graphics.Rect
 
@@ -14,22 +13,37 @@ import android.graphics.Rect
  * takeScreenshot() PNG noise.
  */
 object ColorMatch {
+    // Scratch buffer reused across mask() calls, grown to the largest bitmap seen so far, so a
+    // 1080x2400 screenshot poll does not allocate a fresh ~2.6M-int array on every iteration
+    // (issue #731). ColorMatch is used single-threaded from the E2E test thread.
+    private var pixelBuffer = IntArray(0)
+
+    private fun pixelBuffer(size: Int): IntArray {
+        if (pixelBuffer.size < size) {
+            pixelBuffer = IntArray(size)
+        }
+        return pixelBuffer
+    }
+
     /**
-     * Returns true if every RGB channel of [pixel] (a packed ARGB int from Bitmap.getPixel)
+     * Returns true if every RGB channel of [pixel] (a packed ARGB int, e.g. from Bitmap.getPixels)
      * is within [tolerance] of the corresponding channel in [target].
      */
     fun matches(
         pixel: Int,
         target: Rgb,
         tolerance: Int = 20,
-    ): Boolean =
-        kotlin.math.abs(Color.red(pixel) - target.r) <= tolerance &&
-            kotlin.math.abs(Color.green(pixel) - target.g) <= tolerance &&
-            kotlin.math.abs(Color.blue(pixel) - target.b) <= tolerance
+    ): Boolean = PixelMask.matches(pixel, target.r, target.g, target.b, tolerance)
 
     /**
      * Builds a [BinaryMask] by scanning [bmp] for pixels matching [target] within [tolerance].
      * Computes bbox, centroid, and pixelCount in a single pass.
+     *
+     * Reads the whole bitmap once into a reused [IntArray] via [Bitmap.getPixels] (one JNI call)
+     * and scans that flat, row-major buffer, rather than paying a `getPixel` JNI call per pixel
+     * (~2.6M for a 1080x2400 screenshot; issue #731). The scan itself lives in the pure-JVM,
+     * unit-tested [PixelMask.scan]; here we only bridge the [MaskData] it returns to the
+     * android.graphics-flavored [BinaryMask].
      */
     fun mask(
         bmp: Bitmap,
@@ -38,45 +52,22 @@ object ColorMatch {
     ): BinaryMask {
         val w = bmp.width
         val h = bmp.height
-        val bits = BooleanArray(w * h)
+        val pixels = pixelBuffer(w * h)
+        // stride = w, offset = 0, from (0,0), reading the full w*h grid row-major.
+        bmp.getPixels(pixels, 0, w, 0, 0, w, h)
 
-        var minX = Int.MAX_VALUE
-        var maxX = Int.MIN_VALUE
-        var minY = Int.MAX_VALUE
-        var maxY = Int.MIN_VALUE
-        var sumX = 0L
-        var sumY = 0L
-        var count = 0
-
-        for (y in 0 until h) {
-            for (x in 0 until w) {
-                val px = bmp.getPixel(x, y)
-                if (matches(px, target, tolerance)) {
-                    bits[y * w + x] = true
-                    if (x < minX) minX = x
-                    if (x > maxX) maxX = x
-                    if (y < minY) minY = y
-                    if (y > maxY) maxY = y
-                    sumX += x
-                    sumY += y
-                    count++
-                }
-            }
-        }
-
-        val bbox =
-            if (count == 0) {
-                Rect(0, 0, 0, 0)
-            } else {
-                Rect(minX, minY, maxX + 1, maxY + 1)
-            }
-        val centroid =
-            if (count == 0) {
-                PointF(0f, 0f)
-            } else {
-                PointF(sumX.toFloat() / count, sumY.toFloat() / count)
-            }
-        return BinaryMask(bits, w, h, bbox, centroid, count)
+        val data = PixelMask.scan(pixels, w, h, target.r, target.g, target.b, tolerance)
+        // Wrap data's fields directly (no defensive copy of bits): data is freshly allocated by
+        // scan() and discarded here, so BinaryMask can own its bits array. Empty results already
+        // carry a (0,0,0,0) bbox and (0,0) centroid from scan(), matching the previous behavior.
+        return BinaryMask(
+            data.bits,
+            w,
+            h,
+            Rect(data.bboxLeft, data.bboxTop, data.bboxRight, data.bboxBottom),
+            PointF(data.centroidX, data.centroidY),
+            data.pixelCount,
+        )
     }
 
     /** Fraction of all pixels in [mask] that are true. */

--- a/app/src/sharedTest/java/com/gb4pc/e2e/visual/PixelMask.kt
+++ b/app/src/sharedTest/java/com/gb4pc/e2e/visual/PixelMask.kt
@@ -1,0 +1,100 @@
+package com.gb4pc.e2e.visual
+
+import kotlin.math.abs
+
+/**
+ * Pure-JVM core of [com.gb4pc.e2e.visual.ColorMatch.mask]'s pixel scan.
+ *
+ * Deliberately free of android.* API dependencies (like [MaskData]) so it can be unit-tested
+ * directly on the JVM (app/src/test) without an emulator, while [ColorMatch] (app/src/androidTest)
+ * feeds it a row-major ARGB buffer read in one shot via [android.graphics.Bitmap.getPixels].
+ * Reading the whole bitmap once and scanning the flat array replaces ~w*h per-pixel
+ * `Bitmap.getPixel` JNI calls with a single bulk read (issue #731).
+ */
+object PixelMask {
+    /**
+     * True if every RGB channel of [pixel] (a packed ARGB int) is within [tolerance] of the
+     * corresponding target channel. Alpha is ignored. Channel extraction mirrors
+     * android.graphics.Color.red/green/blue so results match the on-device path exactly.
+     */
+    fun matches(
+        pixel: Int,
+        targetR: Int,
+        targetG: Int,
+        targetB: Int,
+        tolerance: Int,
+    ): Boolean {
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        return abs(r - targetR) <= tolerance &&
+            abs(g - targetG) <= tolerance &&
+            abs(b - targetB) <= tolerance
+    }
+
+    /**
+     * Scans the first [width]*[height] entries of [pixels] (row-major, packed ARGB) for pixels
+     * matching the target color within [tolerance], computing bits, tight bbox, centroid, and
+     * pixelCount in a single pass. The returned [MaskData] has the same shape [ColorMatch.mask]
+     * produces: an empty result carries an all-false bits array of length width*height, a
+     * (0,0,0,0) bbox, and a (0,0) centroid.
+     *
+     * [pixels] may be longer than width*height (e.g. a reused scratch buffer sized to the largest
+     * bitmap seen so far); only the leading width*height entries are read.
+     */
+    fun scan(
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        targetR: Int,
+        targetG: Int,
+        targetB: Int,
+        tolerance: Int,
+    ): MaskData {
+        val n = width * height
+        require(pixels.size >= n) {
+            "pixels buffer too small: size=${pixels.size} < width*height=$n"
+        }
+        val bits = BooleanArray(n)
+
+        var minX = Int.MAX_VALUE
+        var maxX = Int.MIN_VALUE
+        var minY = Int.MAX_VALUE
+        var maxY = Int.MIN_VALUE
+        var sumX = 0L
+        var sumY = 0L
+        var count = 0
+
+        for (y in 0 until height) {
+            val row = y * width
+            for (x in 0 until width) {
+                if (matches(pixels[row + x], targetR, targetG, targetB, tolerance)) {
+                    bits[row + x] = true
+                    if (x < minX) minX = x
+                    if (x > maxX) maxX = x
+                    if (y < minY) minY = y
+                    if (y > maxY) maxY = y
+                    sumX += x
+                    sumY += y
+                    count++
+                }
+            }
+        }
+
+        if (count == 0) {
+            return MaskData(bits, width, height, 0, 0, 0, 0, 0f, 0f, 0)
+        }
+        return MaskData(
+            bits = bits,
+            width = width,
+            height = height,
+            bboxLeft = minX,
+            bboxTop = minY,
+            bboxRight = maxX + 1,
+            bboxBottom = maxY + 1,
+            centroidX = sumX.toFloat() / count,
+            centroidY = sumY.toFloat() / count,
+            pixelCount = count,
+        )
+    }
+}

--- a/app/src/test/java/com/gb4pc/e2e/visual/PixelMaskTest.kt
+++ b/app/src/test/java/com/gb4pc/e2e/visual/PixelMaskTest.kt
@@ -1,0 +1,261 @@
+package com.gb4pc.e2e.visual
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.random.Random
+
+/**
+ * JVM unit tests for [PixelMask], the pure-JVM core of [ColorMatch.mask]'s pixel scan (issue #731).
+ *
+ * These run without an emulator: they feed [PixelMask.scan] a hand-built row-major ARGB buffer,
+ * exactly as [ColorMatch.mask] feeds it the buffer it reads via Bitmap.getPixels, and assert the
+ * resulting [MaskData] (bits, bbox, centroid, pixelCount). A cross-check against an independent
+ * reference implementation guards the single-pass bbox/centroid accumulation and, crucially, the
+ * row-major indexing the bulk-read path depends on.
+ */
+class PixelMaskTest {
+    private val tR = 100
+    private val tG = 150
+    private val tB = 200
+    private val tol = 20
+
+    /** Packs channels into an ARGB int the way android.graphics.Color does. */
+    private fun argb(
+        r: Int,
+        g: Int,
+        b: Int,
+        a: Int = 0xFF,
+    ): Int = (a shl 24) or (r shl 16) or (g shl 8) or b
+
+    /** A color that matches the target exactly. */
+    private fun onTarget(): Int = argb(tR, tG, tB)
+
+    /** A color far outside tolerance on every channel. */
+    private fun offTarget(): Int = argb(0, 0, 0)
+
+    // ── matches ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `matches is true for an exact hit`() {
+        assertTrue(PixelMask.matches(argb(tR, tG, tB), tR, tG, tB, tol))
+    }
+
+    @Test
+    fun `matches ignores the alpha channel`() {
+        assertTrue(PixelMask.matches(argb(tR, tG, tB, a = 0x00), tR, tG, tB, tol))
+    }
+
+    @Test
+    fun `matches is inclusive at exactly tolerance on each channel`() {
+        assertTrue(PixelMask.matches(argb(tR + tol, tG, tB), tR, tG, tB, tol))
+        assertTrue(PixelMask.matches(argb(tR, tG - tol, tB), tR, tG, tB, tol))
+        assertTrue(PixelMask.matches(argb(tR, tG, tB + tol), tR, tG, tB, tol))
+    }
+
+    @Test
+    fun `matches is false one step beyond tolerance on any channel`() {
+        assertFalse(PixelMask.matches(argb(tR + tol + 1, tG, tB), tR, tG, tB, tol))
+        assertFalse(PixelMask.matches(argb(tR, tG - tol - 1, tB), tR, tG, tB, tol))
+        assertFalse(PixelMask.matches(argb(tR, tG, tB + tol + 1), tR, tG, tB, tol))
+    }
+
+    // ── scan: shape and empties ──────────────────────────────────────────────────
+
+    @Test
+    fun `scan with no matches yields an all-false full-size mask`() {
+        val w = 4
+        val h = 3
+        val pixels = IntArray(w * h) { offTarget() }
+
+        val data = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+
+        assertEquals(0, data.pixelCount)
+        assertEquals(w * h, data.bits.size)
+        assertFalse(data.bits.any { it })
+        assertEquals(0, data.bboxLeft)
+        assertEquals(0, data.bboxTop)
+        assertEquals(0, data.bboxRight)
+        assertEquals(0, data.bboxBottom)
+        assertEquals(0f, data.centroidX, 0f)
+        assertEquals(0f, data.centroidY, 0f)
+    }
+
+    @Test
+    fun `scan of a single matching pixel reports a 1x1 bbox and that pixel's centroid`() {
+        val w = 5
+        val h = 4
+        val hitX = 3
+        val hitY = 1
+        val pixels = IntArray(w * h) { offTarget() }
+        pixels[hitY * w + hitX] = onTarget()
+
+        val data = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+
+        assertEquals(1, data.pixelCount)
+        assertTrue(data.bits[hitY * w + hitX])
+        assertEquals(1, data.bits.count { it })
+        assertEquals(hitX, data.bboxLeft)
+        assertEquals(hitY, data.bboxTop)
+        assertEquals(hitX + 1, data.bboxRight)
+        assertEquals(hitY + 1, data.bboxBottom)
+        assertEquals(hitX.toFloat(), data.centroidX, 0f)
+        assertEquals(hitY.toFloat(), data.centroidY, 0f)
+    }
+
+    @Test
+    fun `scan uses row-major stride, not a transposed layout`() {
+        // A non-square grid with hits at (col=3,row=0) and (col=0,row=1). If scan mixed up the
+        // stride (e.g. indexed x*h+y instead of y*w+x) the wrong flat cells would light up and
+        // the bbox would come out transposed. This is the exact failure mode of a bulk-read bug.
+        val w = 4
+        val h = 2
+        val pixels = IntArray(w * h) { offTarget() }
+        pixels[0 * w + 3] = onTarget() // (x=3, y=0)
+        pixels[1 * w + 0] = onTarget() // (x=0, y=1)
+
+        val data = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+
+        assertEquals(2, data.pixelCount)
+        assertTrue(data.bits[0 * w + 3])
+        assertTrue(data.bits[1 * w + 0])
+        assertEquals(0, data.bboxLeft)
+        assertEquals(0, data.bboxTop)
+        assertEquals(4, data.bboxRight)
+        assertEquals(2, data.bboxBottom)
+        // Centroid is the mean of (3,0) and (0,1).
+        assertEquals(1.5f, data.centroidX, 0f)
+        assertEquals(0.5f, data.centroidY, 0f)
+    }
+
+    @Test
+    fun `scan spans a bbox and centroid over several matches`() {
+        val w = 6
+        val h = 6
+        val pixels = IntArray(w * h) { offTarget() }
+        val hits = listOf(1 to 2, 4 to 2, 2 to 5)
+        for ((x, y) in hits) pixels[y * w + x] = onTarget()
+
+        val data = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+
+        assertEquals(hits.size, data.pixelCount)
+        assertEquals(1, data.bboxLeft)
+        assertEquals(2, data.bboxTop)
+        assertEquals(5, data.bboxRight) // maxX(4) + 1
+        assertEquals(6, data.bboxBottom) // maxY(5) + 1
+        assertEquals(hits.sumOf { it.first }.toFloat() / hits.size, data.centroidX, 0f)
+        assertEquals(hits.sumOf { it.second }.toFloat() / hits.size, data.centroidY, 0f)
+    }
+
+    @Test
+    fun `scan reads only the leading width times height entries of an oversized buffer`() {
+        // Mirrors the reused scratch buffer, which can be larger than the current bitmap.
+        val w = 3
+        val h = 2
+        val pixels = IntArray(w * h + 5) { offTarget() }
+        pixels[1 * w + 2] = onTarget() // in range
+        pixels[w * h] = onTarget() // just past the region: must be ignored
+        pixels[w * h + 4] = onTarget() // trailing slot: must be ignored
+
+        val data = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+
+        assertEquals(1, data.pixelCount)
+        assertTrue(data.bits[1 * w + 2])
+        assertEquals(w * h, data.bits.size)
+    }
+
+    @Test
+    fun `scan rejects a buffer smaller than width times height`() {
+        val w = 4
+        val h = 4
+        val tooSmall = IntArray(w * h - 1)
+        assertThrows(IllegalArgumentException::class.java) {
+            PixelMask.scan(tooSmall, w, h, tR, tG, tB, tol)
+        }
+    }
+
+    @Test
+    fun `scan of a zero-size grid is empty`() {
+        val data = PixelMask.scan(IntArray(0), 0, 0, tR, tG, tB, tol)
+        assertEquals(0, data.pixelCount)
+        assertEquals(0, data.bits.size)
+    }
+
+    // ── scan: equivalence to an independent reference ────────────────────────────
+
+    @Test
+    fun `scan matches an independent reference over pseudo-random buffers`() {
+        val rng = Random(731)
+        repeat(20) {
+            val w = 1 + rng.nextInt(40)
+            val h = 1 + rng.nextInt(40)
+            val pixels =
+                IntArray(w * h) {
+                    if (rng.nextInt(100) < 40) {
+                        // Near the target, straddling the tolerance boundary in both directions.
+                        argb(
+                            (tR + rng.nextInt(-tol - 3, tol + 3)).coerceIn(0, 255),
+                            (tG + rng.nextInt(-tol - 3, tol + 3)).coerceIn(0, 255),
+                            (tB + rng.nextInt(-tol - 3, tol + 3)).coerceIn(0, 255),
+                        )
+                    } else {
+                        argb(rng.nextInt(256), rng.nextInt(256), rng.nextInt(256))
+                    }
+                }
+
+            val expected = referenceScan(pixels, w, h, tR, tG, tB, tol)
+            val actual = PixelMask.scan(pixels, w, h, tR, tG, tB, tol)
+            assertEquals("mismatch for ${w}x$h buffer", expected, actual)
+        }
+    }
+
+    /**
+     * Independent, deliberately different implementation of the scan: it collects matched
+     * coordinates into lists and derives the bbox/centroid from those, rather than accumulating
+     * min/max/sum inline. Any bug in [PixelMask.scan]'s single-pass accumulation shows up as a
+     * disagreement with this reference.
+     */
+    private fun referenceScan(
+        pixels: IntArray,
+        w: Int,
+        h: Int,
+        tr: Int,
+        tg: Int,
+        tb: Int,
+        tolerance: Int,
+    ): MaskData {
+        val bits = BooleanArray(w * h)
+        val xs = ArrayList<Int>()
+        val ys = ArrayList<Int>()
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                val p = pixels[y * w + x]
+                val r = (p and 0x00FF0000) ushr 16
+                val g = (p and 0x0000FF00) ushr 8
+                val b = p and 0x000000FF
+                if (abs(r - tr) <= tolerance && abs(g - tg) <= tolerance && abs(b - tb) <= tolerance) {
+                    bits[y * w + x] = true
+                    xs.add(x)
+                    ys.add(y)
+                }
+            }
+        }
+        if (xs.isEmpty()) return MaskData(bits, w, h, 0, 0, 0, 0, 0f, 0f, 0)
+        val count = xs.size
+        return MaskData(
+            bits = bits,
+            width = w,
+            height = h,
+            bboxLeft = xs.min(),
+            bboxTop = ys.min(),
+            bboxRight = xs.max() + 1,
+            bboxBottom = ys.max() + 1,
+            centroidX = xs.sum().toFloat() / count,
+            centroidY = ys.sum().toFloat() / count,
+            pixelCount = count,
+        )
+    }
+}


### PR DESCRIPTION
🤖 Author

Fixes #731.

## Problem

`ColorMatch.mask` scanned a 1080x2400 screenshot with one `Bitmap.getPixel` JNI call per pixel (~2.6M calls per invocation).
Every screenshot poll in the E2E suite pays this cost per iteration, which coarsens effective poll cadence on the loaded CI emulator.

## Change

`ColorMatch.mask` now reads the whole bitmap once into a reused `IntArray` via `Bitmap.getPixels` (one JNI call) and scans that flat, row-major buffer, instead of ~2.6M per-pixel JNI reads.
The scratch buffer is grown to the largest bitmap seen so far and reused across calls, so a poll loop no longer allocates a ~2.6M-int array every iteration.
The `BinaryMask` result shape is unchanged, so all callers benefit uniformly (which is why the fix lives inside `ColorMatch` rather than at one call site).

The per-pixel scan itself is extracted into a pure-JVM `PixelMask.scan` (placed in `sharedTest`, free of `android.*` deps like `MaskData`), which consumes the flat ARGB buffer and returns a `MaskData`.
`ColorMatch.mask` reads the bitmap and bridges that `MaskData` to the `android.graphics`-flavored `BinaryMask` directly (no defensive copy of the bits array, since the `MaskData` is freshly allocated and discarded there).
`ColorMatch.matches` now delegates to `PixelMask.matches` so the channel-tolerance logic lives in one place.

Output is identical to the previous per-pixel implementation, including the empty-mask shape (`(0,0,0,0)` bbox, `(0,0)` centroid).

## Tests

Extracting the scan into pure-JVM code lets it be unit-tested without an emulator.
New `PixelMaskTest` (JVM) covers:

- `matches` tolerance boundaries (inclusive at exactly tolerance, false one step beyond, alpha ignored).
- Empty, single-pixel, and multi-pixel scans: bits, tight bbox, centroid, and pixelCount.
- Row-major stride correctness (a non-square grid with off-diagonal hits, the exact failure mode of a bulk-read indexing bug).
- Reuse semantics: an oversized buffer only reads its leading `width*height` entries; a too-small buffer is rejected; a zero-size grid is empty.
- A cross-check of the single-pass bbox/centroid/count accumulation against an independent reference implementation over 20 pseudo-random buffers.

The existing instrumented E2E visual suite continues to exercise the on-device `Bitmap.getPixels` path.
