### PR TITLE
Strengthen seedOnePhoto()'s MediaStore-visibility wait to a rowsBefore/rowsAfter check

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/E2EFixture.kt
@@ -429,6 +429,12 @@ class E2EFixture(
      */
     fun seedOnePhoto(): Uri {
         val resolver = context.contentResolver
+        // Capture the count before the insert so the visibility wait below can require *this*
+        // insert to land, matching captureOnePhoto()'s rowsBefore/rowsAfter pattern. A bare
+        // `count > 0` check would be vacuously satisfied by any residual image a prior E2E suite
+        // left in the shared MediaStore (this method's caller does not clear the camera roll
+        // first), so it would not actually prove this row became visible (issue #606).
+        val rowsBefore = countMediaStoreImages()
         val values =
             ContentValues().apply {
                 put(MediaStore.Images.Media.DISPLAY_NAME, "gb4pc-e2e-seed-${System.currentTimeMillis()}.jpg")
@@ -461,8 +467,10 @@ class E2EFixture(
         }
 
         // Confirm the row is now visible via an unfiltered query, so the caller does not open the
-        // picker before the insert is observable.
-        waitForCondition(5_000L) { countMediaStoreImages() > 0 }
+        // picker before the insert is observable. Waiting for the count to rise above rowsBefore
+        // (rather than merely be positive) means this wait proves *this* insert landed even when
+        // the shared MediaStore already held residual images.
+        waitForCondition(5_000L) { countMediaStoreImages() > rowsBefore }
         return uri
     }
 


### PR DESCRIPTION
Fixes #606

## Problem

`E2EFixture.seedOnePhoto()` confirmed its MediaStore insert was visible with:

```kotlin
waitForCondition(5_000L) { countMediaStoreImages() > 0 }
```

That check is vacuously satisfied whenever the shared-images MediaStore already holds a residual image from an earlier E2E suite. `seedOnePhoto()`'s caller (`PartialAccessPhotoPickerE2ETest`) does not clear the camera roll first, so `count > 0` can already be true before this insert, and the wait does not actually prove *this* insert became visible.

## Fix

Capture the row count before the insert and wait for the count to rise above that baseline, mirroring the `rowsBefore`/`rowsAfter` pattern `captureOnePhoto()` already uses a few lines below in the same file. The sanity wait now means something rather than being vacuously true.

The change is confined to the `seedOnePhoto()` test fixture helper; there is no product-code change. The helper is exercised by `PartialAccessPhotoPickerE2ETest` in the E2E suite CI already runs.
