### PR TITLE
Unify tap tests' post-tap failure reporting via a shared helper

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -301,7 +301,8 @@ class GalleryButtonVisualE2ETest {
         // reasons rather than throwing on the first and hiding the second.
         val coverage = ColorMatch.coverageFraction(greenMask)
         val foreground = fixture.foregroundPackage()
-        val failures =
+        reportPostTapFailures(
+            "test3a_populatedGalleryShowsGreenAfterTap",
             buildList {
                 if (coverage <= 0.40f) {
                     add(
@@ -316,10 +317,8 @@ class GalleryButtonVisualE2ETest {
                             "green mock camera in front)",
                     )
                 }
-            }
-        if (failures.isNotEmpty()) {
-            fail("test3a_populatedGalleryShowsGreenAfterTap: " + failures.joinToString("; "))
-        }
+            },
+        )
     }
 
     // test4a: Secure camera + empty gallery: no GREEN after tap---------------
@@ -543,6 +542,23 @@ class GalleryButtonVisualE2ETest {
 
     /** Full-screen GREEN coverage fraction of [screen]. */
     private fun greenCoverage(screen: Bitmap): Float = ColorMatch.coverageFraction(ColorMatch.mask(screen, Rgb.GREEN))
+
+    /**
+     * Fails [testName], reporting every post-tap [reasons] entry that held, joined into a single
+     * message. A no-op when [reasons] is empty (all post-tap conditions passed).
+     *
+     * Shared by the tap tests (test2a/test3a/test4a): their post-tap coverage and foreground checks
+     * are independent failure modes, so when more than one fails the report should name every reason
+     * rather than throwing on the first fail() and hiding the rest (issue #737).
+     */
+    private fun reportPostTapFailures(
+        testName: String,
+        reasons: List<String>,
+    ) {
+        if (reasons.isNotEmpty()) {
+            fail("$testName: " + reasons.joinToString("; "))
+        }
+    }
 
     /**
      * test5a's letterboxed-band geometry, measured on a screenshot's GREEN mask: the session's

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -234,21 +234,25 @@ class GalleryButtonVisualE2ETest {
         Screenshot.saveForArtifact(maskToBitmap(greenMask), "2a-green-mask.png")
 
         val coverage = ColorMatch.coverageFraction(greenMask)
-        if (coverage >= 0.10f) {
-            fail(
-                "test2a_emptyGalleryNoGreenAfterTap: GREEN coverage after tap is " +
-                    "${coverage * 100f}%--expected < 10%. " +
-                    "The gallery opened showing unexpected green content with an empty roll.",
-            )
-        }
         val foreground = fixture.foregroundPackage()
-        if (foreground != MOCK_GALLERY_PACKAGE) {
-            fail(
-                "test2a_emptyGalleryNoGreenAfterTap: foreground package after tap is " +
-                    "$foreground--expected $MOCK_GALLERY_PACKAGE. The screen shows no green, " +
-                    "but the gallery did not open (screen off, keyguard, or no-op tap).",
-            )
-        }
+        reportPostTapFailures(
+            "test2a_emptyGalleryNoGreenAfterTap",
+            buildList {
+                if (coverage >= 0.10f) {
+                    add(
+                        "GREEN coverage after tap is ${coverage * 100f}%--expected < 10% " +
+                            "(the gallery opened showing unexpected green content with an empty roll)",
+                    )
+                }
+                if (foreground != MOCK_GALLERY_PACKAGE) {
+                    add(
+                        "foreground package after tap is $foreground--expected $MOCK_GALLERY_PACKAGE " +
+                            "(the screen shows no green, but the gallery did not open: screen off, " +
+                            "keyguard, or no-op tap)",
+                    )
+                }
+            },
+        )
     }
 
     // test3a: Populated gallery: tapping overlay shows GREEN------------------
@@ -395,22 +399,25 @@ class GalleryButtonVisualE2ETest {
         Screenshot.saveForArtifact(maskToBitmap(greenMask), "4a-green-mask.png")
 
         val coverage = ColorMatch.coverageFraction(greenMask)
-        if (coverage >= 0.10f) {
-            fail(
-                "test4a_secureCameraLockedEmptyGalleryNoGreen: GREEN coverage after tap is " +
-                    "${coverage * 100f}%--expected < 10%. " +
-                    "The gallery opened showing unexpected green content with an empty roll.",
-            )
-        }
         val foreground = fixture.foregroundPackage()
-        if (foreground != context.packageName) {
-            fail(
-                "test4a_secureCameraLockedEmptyGalleryNoGreen: foreground package after tap is " +
-                    "$foreground--expected ${context.packageName} (SecureViewerActivity). The " +
-                    "screen shows no green, but the viewer did not open (screen off, keyguard, " +
-                    "or no-op tap).",
-            )
-        }
+        reportPostTapFailures(
+            "test4a_secureCameraLockedEmptyGalleryNoGreen",
+            buildList {
+                if (coverage >= 0.10f) {
+                    add(
+                        "GREEN coverage after tap is ${coverage * 100f}%--expected < 10% " +
+                            "(the gallery opened showing unexpected green content with an empty roll)",
+                    )
+                }
+                if (foreground != context.packageName) {
+                    add(
+                        "foreground package after tap is $foreground--expected ${context.packageName} " +
+                            "(SecureViewerActivity; the screen shows no green, but the viewer did not " +
+                            "open: screen off, keyguard, or no-op tap)",
+                    )
+                }
+            },
+        )
     }
 
     // test5a: Secure camera + populated session: SecureViewer shows GREEN---


### PR DESCRIPTION
Fixes #737

## Problem

`GalleryButtonVisualE2ETest` carried two different post-tap failure-reporting shapes across three very similar tap tests. PR #734 changed `test3a` to collect its post-tap failure conditions into a list and emit a single `fail()` with every reason joined, so both surface when both fail. `test2a` and `test4a` still used the older two sequential `if (...) fail(...)` blocks, where the coverage check throws before the foreground check runs, hiding the second failing condition.

## Change

Two commits, split by concern:

1. **Extract shared helper (pure refactoring).** Factor `test3a`'s collect-and-join logic into a private `reportPostTapFailures(testName, reasons)` helper that fails the test with every reason joined into one message, or is a no-op when the list is empty. `test3a` now calls the helper; its output is byte-for-byte unchanged.
2. **Adopt combined reporting in `test2a` and `test4a` (behavior change).** Both tests now collect every failing post-tap condition into a `buildList` and hand it to the shared helper, so all three tap tests report every failing post-tap condition consistently.

## Notes

The pass/fail thresholds are unchanged in every test (`coverage >= 0.10f` for `test2a`/`test4a`, and the same foreground-package equality checks), so no test requirement is loosened. Only the failure message changes: when both post-tap conditions fail, the report now names both reasons instead of throwing on the first `fail()` and hiding the second.

Verified locally with ktlint (`scripts/lint.sh --check --only kotlin --all`), which passes. The instrumentation tests themselves run on CI (they require an emulator).
