### PR TITLE
Authenticate the committed Gradle wrapper JAR against Gradle's published checksum

### DIFF
--- a/gradle/README.md
+++ b/gradle/README.md
@@ -43,7 +43,7 @@ Never commit that flag into CI, and do not commit a file regenerated on a non-Li
 The Gradle wrapper verifies the downloaded distribution against this checksum before running it, so a substituted or corrupted distribution fails loudly.
 
 The wrapper JAR (`wrapper/gradle-wrapper.jar`) is committed and reviewed directly; it is read before `verification-metadata.xml` is consulted, so it cannot be covered by that file.
-Instead, `scripts/test_verification_metadata.sh` check (g) pins the JAR's SHA-256 to the checksum Gradle officially publishes for it (issue #744), so a substituted or corrupted wrapper JAR fails the `shell-tests` CI job rather than being trusted silently.
+Instead, `scripts/test_verification_metadata.sh` check (g) verifies the JAR's SHA-256 against a pinned copy of the checksum Gradle officially publishes for it (issue #744), so a substituted or corrupted wrapper JAR fails the `shell-tests` CI job rather than being trusted silently.
 
 When bumping the Gradle version, update both `distributionUrl` and `distributionSha256Sum` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256`), then regenerate `verification-metadata.xml`.
 If the wrapper JAR itself changes, also update its pinned SHA-256 in `scripts/test_verification_metadata.sh` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`).

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -42,6 +42,8 @@ Never commit that flag into CI, and do not commit a file regenerated on a non-Li
 `distributionSha256Sum` pins the Gradle 8.9 distribution (`gradle-8.9-bin.zip`) to its published SHA-256.
 The Gradle wrapper verifies the downloaded distribution against this checksum before running it, so a substituted or corrupted distribution fails loudly.
 
-The wrapper JAR (`wrapper/gradle-wrapper.jar`) is committed and reviewed directly; it is read before `verification-metadata.xml` is consulted, so it cannot be, and is not, covered by that file.
+The wrapper JAR (`wrapper/gradle-wrapper.jar`) is committed and reviewed directly; it is read before `verification-metadata.xml` is consulted, so it cannot be covered by that file.
+Instead, `scripts/test_verification_metadata.sh` check (g) pins the JAR's SHA-256 to the checksum Gradle officially publishes for it (issue #744), so a substituted or corrupted wrapper JAR fails the `shell-tests` CI job rather than being trusted silently.
 
 When bumping the Gradle version, update both `distributionUrl` and `distributionSha256Sum` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256`), then regenerate `verification-metadata.xml`.
+If the wrapper JAR itself changes, also update its pinned SHA-256 in `scripts/test_verification_metadata.sh` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`).

--- a/scripts/test_verification_metadata.sh
+++ b/scripts/test_verification_metadata.sh
@@ -19,6 +19,11 @@
 #       lenient|off flag in a CI workflow, and no org.gradle.dependency.verification
 #       lenient|off property in a committed gradle.properties
 #   (f) gradle-wrapper.properties pins the distribution via distributionSha256Sum
+#   (g) gradle-wrapper.jar matches the SHA-256 Gradle officially publishes for its
+#       wrapper JAR (issue #744): the wrapper JAR is executed before
+#       verification-metadata.xml is consulted, so it cannot be covered there; this
+#       authenticates it against Gradle instead of trusting whatever bytes are
+#       committed, catching a substituted or corrupted wrapper JAR
 #
 # Always exits 0 on success, non-zero on failure.
 
@@ -28,7 +33,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 METADATA="$REPO_ROOT/gradle/verification-metadata.xml"
 WRAPPER_PROPS="$REPO_ROOT/gradle/wrapper/gradle-wrapper.properties"
+WRAPPER_JAR="$REPO_ROOT/gradle/wrapper/gradle-wrapper.jar"
 WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+
+# Pinned SHA-256 of gradle/wrapper/gradle-wrapper.jar, authenticated against the
+# checksum Gradle officially publishes for its wrapper JAR (the same authoritative
+# source GitHub's gradle/wrapper-validation-action verifies against). Pinning the
+# published value, rather than the current file's own hash, makes this guard
+# authenticate the JAR against Gradle instead of trusting whatever bytes happen to
+# be committed. The committed JAR is the genuine Gradle 8.14 wrapper JAR:
+#   https://services.gradle.org/distributions/gradle-8.14-wrapper.jar.sha256
+# (This is newer than the 8.9 distribution pinned in gradle-wrapper.properties; a
+# newer wrapper JAR launches an older distribution without issue.) On a wrapper
+# upgrade, update this pin to the published checksum for the new version from the
+# gradle-<version>-wrapper.jar.sha256 URL above.
+WRAPPER_JAR_SHA256="7d3a4ac4de1c32b59bc6a4eb8ecb8e612ccd0cf1ae1e99f66902da64df296172"
 
 PASS=0
 FAIL=0
@@ -123,6 +142,22 @@ if grep -Eq '^distributionSha256Sum=[0-9a-f]{64}$' "$WRAPPER_PROPS"; then
     pass "gradle-wrapper.properties pins the distribution via distributionSha256Sum"
 else
     fail "gradle-wrapper.properties is missing a valid distributionSha256Sum pin"
+fi
+
+# (g) the committed wrapper JAR matches its pinned SHA-256. gradlew reads and runs
+# this JAR before gradle/verification-metadata.xml is ever consulted (issue #714,
+# Decision 3), so dependency verification cannot cover it. This first-party check
+# mirrors the pinned-checksum compare in scripts/install-ktlint.sh so a substituted
+# or corrupted wrapper JAR is caught rather than silently trusted (issue #744).
+if [ ! -f "$WRAPPER_JAR" ]; then
+    fail "gradle/wrapper/gradle-wrapper.jar is missing"
+else
+    ACTUAL_WRAPPER_SHA=$(sha256sum "$WRAPPER_JAR" | cut -d' ' -f1)
+    if [ "$ACTUAL_WRAPPER_SHA" = "$WRAPPER_JAR_SHA256" ]; then
+        pass "gradle-wrapper.jar matches its pinned SHA-256"
+    else
+        fail "gradle-wrapper.jar SHA-256 mismatch: expected $WRAPPER_JAR_SHA256, got $ACTUAL_WRAPPER_SHA"
+    fi
 fi
 
 echo


### PR DESCRIPTION
Fixes #744.

## Problem

`gradlew` reads and executes `gradle/wrapper/gradle-wrapper.jar` before `gradle/verification-metadata.xml` is ever consulted (issue #714, Decision 3), so Gradle dependency verification cannot cover the wrapper JAR itself.
Until now a substituted or corrupted wrapper JAR would be trusted silently.

## Change

Add check (g) to `scripts/test_verification_metadata.sh`, the existing build-integrity guard test.
It computes the committed wrapper JAR's SHA-256 and compares it to a pinned value, mirroring the pinned-checksum compare in `scripts/install-ktlint.sh`.

The pin is authenticated against Gradle: it is the checksum Gradle officially publishes for its wrapper JAR (the same authoritative source GitHub's `gradle/wrapper-validation-action` verifies against), not the current file's own hash.
Pinning the published value means the guard authenticates the JAR against Gradle rather than trusting whatever bytes happen to be committed.
The committed JAR was confirmed to be the genuine Gradle wrapper JAR by matching `https://services.gradle.org/distributions/gradle-8.14-wrapper.jar.sha256`.

The check runs in the existing `shell-tests` CI job via the `scripts/test_*.sh` discovery, alongside the distribution-pin guard (check (f)) it sits next to, so a substituted or corrupted wrapper JAR now fails CI.

## Note: wrapper JAR / distribution version skew (pre-existing)

Authenticating the JAR surfaced that the committed wrapper JAR is Gradle **8.14**, while `gradle-wrapper.properties` pins the **8.9** distribution.
This is functionally fine (a newer wrapper JAR launches an older distribution without issue) and predates this PR, so it is left as-is here.
Aligning the two versions is a reasonable follow-up but is out of scope for the wrapper-JAR integrity check.

## On the sibling issues #745 and #746

Both were already implemented in commit `ea8f5f2`, already merged to `main`, so this PR contains no code for them:

- #745: check (e) already scans every committed `gradle.properties` (via `git ls-files`) for `org.gradle.dependency.verification` set to `lenient` or `off`, covering all non-strict values, not just the CI CLI flag.
- #746: the redundant grep alternation is already gone; the pattern is the single `--dependency-verification[= ](lenient|off)`.

## Testing

Covered by the automated shell-test suite (`scripts/test_verification_metadata.sh`, run in the `shell-tests` CI job).
Verified locally that the suite passes with the JAR intact (8/8) and that check (g) fails with a non-zero exit when the JAR's bytes do not match the pin.
