### PR TITLE
Retry transient GitHub API errors in the mutually-exclusive-label check

### DIFF
--- a/scripts/enforce_mutually_exclusive_labels.py
+++ b/scripts/enforce_mutually_exclusive_labels.py
@@ -28,7 +28,9 @@ Exit code:
        failure).
     1  ISSUE_NUMBER is not a valid integer, the issue/PR's current labels
        could not be fetched, or removing a conflicting label failed for a
-       reason other than 404.
+       reason other than 404. A transient GitHub blip (a 5xx, a 429, or a
+       network error) is retried with exponential backoff first, so a nonzero
+       exit reflects a persistent failure, not a passing blip.
 
 Required environment variables:
     GITHUB_TOKEN        Personal access token or Actions secret with
@@ -41,6 +43,7 @@ Required environment variables:
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -69,14 +72,53 @@ MUTUALLY_EXCLUSIVE_PREFIXES: list[str] = [
 # GitHub API helper
 # ---------------------------------------------------------------------------
 
+# Transient-error retry policy (issue #749). A GitHub API blip (a 5xx server
+# error, a 429 rate-limit response, or a network-level URLError) may clear on a
+# repeat, so it is retried with exponential backoff before the call is allowed
+# to fail. This matches the "retry once, transient GitHub errors are expected"
+# guidance already followed by scripts/update_gh_labels.sh and
+# agents/dev_orchestration.md for this exact class of instability. A real error
+# (a 4xx other than 429, e.g. a 404 already-gone or a 422 validation failure) is
+# never retried: repeating it would not change the outcome.
+MAX_ATTEMPTS = 4
+INITIAL_BACKOFF_SECONDS = 1.0
+BACKOFF_MULTIPLIER = 2.0
 
-def gh_api(path: str, token: str, method: str = "GET", body: object = None) -> object:
+
+def _is_transient_error(exc: Exception) -> bool:
+    """Return True if *exc* is a transient GitHub API failure worth retrying.
+
+    Transient means the same request may succeed on a repeat: a 5xx server
+    error, a 429 rate-limit response, or a network-level ``URLError``
+    (connection reset, DNS blip). Any other ``HTTPError`` (a 4xx other than
+    429, such as a 404 already-gone or a 422 validation failure) is a real
+    error that a retry would not clear.
+
+    ``HTTPError`` is a subclass of ``URLError``, so it is checked first.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code == 429 or 500 <= exc.code <= 599
+    return isinstance(exc, urllib.error.URLError)
+
+
+def gh_api(
+    path: str,
+    token: str,
+    method: str = "GET",
+    body: object = None,
+    max_attempts: int = MAX_ATTEMPTS,
+) -> object:
     """Make a GitHub API request and return the parsed JSON response.
 
     Returns ``None`` for responses with an empty body (e.g. 204 No Content).
 
-    Raises ``urllib.error.HTTPError`` or ``urllib.error.URLError`` on
-    failure so callers can handle errors explicitly.
+    A transient failure (see ``_is_transient_error``) is retried up to
+    *max_attempts* times with exponential backoff so a passing GitHub blip does
+    not surface as a real error. Once the attempts are exhausted, or on a
+    non-transient error, raises ``urllib.error.HTTPError`` or
+    ``urllib.error.URLError`` so callers can handle errors explicitly (the
+    already-gone 404 case in ``remove_labels`` is unchanged, since a 404 is not
+    transient and is never retried here).
     """
     url = f"https://api.github.com/{path}"
     req = urllib.request.Request(url, method=method)
@@ -88,10 +130,28 @@ def gh_api(path: str, token: str, method: str = "GET", body: object = None) -> o
         req.add_header("Content-Type", "application/json")
     else:
         data = None
-    # URL is built from a GitHub API constant; the file:// risk does not apply.
-    with urllib.request.urlopen(req, data) as r:  # nosemgrep
-        response_body = r.read()
-        return json.loads(response_body) if response_body else None
+
+    backoff = INITIAL_BACKOFF_SECONDS
+    for attempt in range(1, max_attempts + 1):
+        try:
+            # URL is built from a GitHub API constant; the file:// risk does not apply.
+            with urllib.request.urlopen(req, data) as r:  # nosemgrep
+                response_body = r.read()
+                return json.loads(response_body) if response_body else None
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            if attempt >= max_attempts or not _is_transient_error(exc):
+                raise
+            print(
+                f"Transient error on {method} {path} "
+                f"(attempt {attempt}/{max_attempts}): {exc}. "
+                f"Retrying in {backoff:g}s.",
+                file=sys.stderr,
+            )
+            time.sleep(backoff)
+            backoff *= BACKOFF_MULTIPLIER
+    # Unreachable: the final attempt above either returns or raises. Present so
+    # the function has a definite terminal on every path.
+    raise AssertionError("gh_api retry loop exited without returning or raising")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/test_enforce_mutually_exclusive_labels.py
@@ -12,6 +12,11 @@ sys.path.insert(0, os.path.dirname(__file__))
 import enforce_mutually_exclusive_labels as emxl  # noqa: E402
 
 
+def _http_error(code: int) -> urllib.error.HTTPError:
+    """Build an HTTPError carrying the given status code for retry tests."""
+    return urllib.error.HTTPError(url=None, code=code, msg="err", hdrs=None, fp=None)
+
+
 # ---------------------------------------------------------------------------
 # gh_api tests
 # ---------------------------------------------------------------------------
@@ -43,6 +48,136 @@ class TestGhApi(unittest.TestCase):
                 "repos/owner/repo/issues/1/labels/p2", token="tok", method="DELETE"
             )
         self.assertIsNone(result)
+
+    # ------------------------------------------------------------------
+    # Transient-error retry tests (issue #749)
+    # ------------------------------------------------------------------
+
+    def test_retries_transient_503_then_succeeds(self):
+        """A 503 blip is retried and the following success is returned."""
+        payload = {"labels": [{"name": "p1"}]}
+        response = self._make_response(json.dumps(payload).encode())
+        with patch.object(emxl.time, "sleep") as mock_sleep:
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[_http_error(503), response],
+            ) as mock_urlopen:
+                result = emxl.gh_api("repos/owner/repo/issues/1", token="tok")
+        self.assertEqual(result, payload)
+        self.assertEqual(mock_urlopen.call_count, 2)
+        mock_sleep.assert_called_once()
+
+    def test_retries_429_then_succeeds(self):
+        """A 429 rate-limit response is transient and is retried."""
+        response = self._make_response(b"")
+        with patch.object(emxl.time, "sleep"):
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[_http_error(429), response],
+            ) as mock_urlopen:
+                result = emxl.gh_api(
+                    "repos/owner/repo/issues/1/labels/p2", token="tok", method="DELETE"
+                )
+        self.assertIsNone(result)
+        self.assertEqual(mock_urlopen.call_count, 2)
+
+    def test_retries_url_error_then_succeeds(self):
+        """A network-level URLError (e.g. connection reset) is retried."""
+        payload = {"ok": True}
+        response = self._make_response(json.dumps(payload).encode())
+        with patch.object(emxl.time, "sleep"):
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[urllib.error.URLError("connection reset"), response],
+            ) as mock_urlopen:
+                result = emxl.gh_api("repos/owner/repo/issues/1", token="tok")
+        self.assertEqual(result, payload)
+        self.assertEqual(mock_urlopen.call_count, 2)
+
+    def test_retries_exhaust_and_raise_last_transient(self):
+        """After max_attempts transient failures, the last error propagates."""
+        with patch.object(emxl.time, "sleep") as mock_sleep:
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[_http_error(503), _http_error(502), _http_error(500)],
+            ) as mock_urlopen:
+                with self.assertRaises(urllib.error.HTTPError) as ctx:
+                    emxl.gh_api("repos/owner/repo/issues/1", token="tok", max_attempts=3)
+        self.assertEqual(ctx.exception.code, 500)
+        self.assertEqual(mock_urlopen.call_count, 3)
+        # One sleep between each pair of attempts: three attempts => two sleeps.
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    def test_does_not_retry_404(self):
+        """A 404 is benign/real, not transient, so it is raised without retry."""
+        with patch.object(emxl.time, "sleep") as mock_sleep:
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[_http_error(404), self._make_response(b"{}")],
+            ) as mock_urlopen:
+                with self.assertRaises(urllib.error.HTTPError) as ctx:
+                    emxl.gh_api("repos/owner/repo/issues/1/labels/p2", token="tok", method="DELETE")
+        self.assertEqual(ctx.exception.code, 404)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    def test_does_not_retry_422(self):
+        """A 422 validation error is real, not transient, so it is not retried."""
+        with patch.object(emxl.time, "sleep") as mock_sleep:
+            with patch("urllib.request.urlopen", side_effect=_http_error(422)) as mock_urlopen:
+                with self.assertRaises(urllib.error.HTTPError):
+                    emxl.gh_api("repos/owner/repo/issues/1", token="tok")
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    def test_backoff_grows_exponentially(self):
+        """Each retry waits longer than the last, following the backoff policy."""
+        with patch.object(emxl.time, "sleep") as mock_sleep:
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=[
+                    _http_error(503),
+                    _http_error(503),
+                    _http_error(503),
+                    _http_error(503),
+                ],
+            ):
+                with self.assertRaises(urllib.error.HTTPError):
+                    emxl.gh_api("repos/owner/repo/issues/1", token="tok", max_attempts=4)
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        b0 = emxl.INITIAL_BACKOFF_SECONDS
+        m = emxl.BACKOFF_MULTIPLIER
+        self.assertEqual(delays, [b0, b0 * m, b0 * m * m])
+
+
+# ---------------------------------------------------------------------------
+# _is_transient_error tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientError(unittest.TestCase):
+    def test_5xx_is_transient(self):
+        for code in (500, 502, 503, 504, 599):
+            self.assertTrue(emxl._is_transient_error(_http_error(code)), code)
+
+    def test_429_is_transient(self):
+        self.assertTrue(emxl._is_transient_error(_http_error(429)))
+
+    def test_url_error_is_transient(self):
+        self.assertTrue(emxl._is_transient_error(urllib.error.URLError("boom")))
+
+    def test_404_is_not_transient(self):
+        self.assertFalse(emxl._is_transient_error(_http_error(404)))
+
+    def test_422_is_not_transient(self):
+        self.assertFalse(emxl._is_transient_error(_http_error(422)))
+
+    def test_other_4xx_not_transient(self):
+        for code in (400, 401, 403):
+            self.assertFalse(emxl._is_transient_error(_http_error(code)), code)
+
+    def test_non_url_exception_not_transient(self):
+        self.assertFalse(emxl._is_transient_error(ValueError("nope")))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 Author

Fixes #749.

## Problem

`scripts/enforce_mutually_exclusive_labels.py` made exactly one un-retried `gh_api()` call (`urllib.request.urlopen`, no retry loop) to fetch the issue/PR's current labels.
Any non-2xx response, including a transient 503, raised and made `main()` return 1 with no further attempt.
On PR #734 this failed the "Enforce mutually exclusive label sets" check twice with `HTTP Error 503: Service Unavailable`, with no real mutually-exclusive-label conflict, during a window of GitHub-wide API instability.

Since #614 (which correctly made real reconciliation failures surface as a red check) a purely transient blip reads exactly like a real failure, with no retry to distinguish "GitHub blipped" from "the reconciliation itself failed."

## Fix

Give `gh_api()` a small retry-with-backoff for transient failures only:

- A transient error (a 5xx, a 429 rate-limit response, or a network-level `URLError`) is retried up to `MAX_ATTEMPTS` (4) times with exponential backoff (1s, 2s, 4s) before the error is allowed to propagate.
- A real error is never retried: any other `HTTPError` (a 4xx other than 429, such as a 404 already-gone or a 422 validation failure) is raised immediately, so the existing 404-is-benign handling in `remove_labels()` is untouched.

Because the retry lives inside `gh_api()`, both the issue-fetch `GET` and the label-removal `DELETE`s benefit (the `DELETE` is idempotent, so retrying a label removal is safe: a re-run that finds the label already gone gets a benign 404).

This matches the "retry once, transient GitHub errors are expected" guidance already followed by `scripts/update_gh_labels.sh` and `agents/dev_orchestration.md` for this exact class of instability.
Exit codes are unchanged; a nonzero exit now reflects a persistent failure rather than a passing blip.

## Tests

Added unit tests in `scripts/test_enforce_mutually_exclusive_labels.py`:

- `_is_transient_error` classification (5xx / 429 / `URLError` transient; 404 / 422 / other 4xx / non-URL exceptions not transient).
- `gh_api` retries a 503, a 429, and a `URLError` then returns the following success; exhausts retries and raises the last transient error; does not retry a 404 or a 422 (raised on the first attempt, no sleep); and grows the backoff exponentially.

All 90 tests in the file pass, and `ruff check` / `ruff format --check` are clean.
