### PR TITLE
Dismiss the secure keyguard before the start-of-test slate in the Permissions E2E suites

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
@@ -12,6 +12,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -60,9 +62,6 @@ import org.junit.runner.RunWith
 @E2ETest
 @RunWith(AndroidJUnit4::class)
 class PermissionsDeniedE2ETest {
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = instrumentation.targetContext
     private val fixture =
@@ -70,6 +69,28 @@ class PermissionsDeniedE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761). The suite's own setUp() only wires
+    // fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure keyguard
+    // scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast has
+    // already fired; if the keyguard has reasserted between CI steps the marker would be occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() {

--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
@@ -9,6 +9,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -26,9 +28,6 @@ import org.junit.runner.RunWith
 @E2ETest
 @RunWith(AndroidJUnit4::class)
 class PermissionsGrantedE2ETest {
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = instrumentation.targetContext
     private val fixture =
@@ -36,6 +35,28 @@ class PermissionsGrantedE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761). The suite's own setUp() only wires
+    // fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure keyguard
+    // scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast has
+    // already fired; if the keyguard has reasserted between CI steps the marker would be occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() {


### PR DESCRIPTION
🤖 Author

Fixes #761

## Problem

Three recorded E2E suites produced failure videos where the start-of-test name toast never appears. The cause is Android windowing: a toast cannot paint over the *secure* PIN keyguard that `scripts/setup-e2e-emulator.sh` configures, so when the keyguard has reasserted between CI steps the marker renders behind the lock screen and is invisible in the recording.

Two of the three suites, `PermissionsGrantedE2ETest` and `PermissionsDeniedE2ETest`, wired `TestNameToastRule` as a plain `@get:Rule` and relied on `fixture.setUp()`'s swipe-only `wakeAndDismissKeyguard()`, which does nothing against the secure PIN keyguard. `TestNameToastRule.starting()` also fires before `@Before`, so even that swipe had not run when the slate appeared.

The third suite named in the issue, `SetupActivityGrantedE2ETest`, already dismisses the secure keyguard ahead of the toast via its `RuleChain`, so it needed no change.

## Change

`PermissionsGrantedE2ETest` and `PermissionsDeniedE2ETest` now use a `RuleChain` whose outer rule runs `E2EFixture.dismissSecureKeyguard()` (via an `ExternalResource` reusing the existing `fixture` field) ahead of the innermost `TestNameToastRule`, so the slate renders over the app UI rather than behind the lock screen. This mirrors the established pattern in `SetupActivityDeniedE2ETest`/`SetupActivityGrantedE2ETest`.

The toast stays the innermost link, preserving the keyguard-dismissal-then-launch ordering that `TestNameToastRule.kt` documents (the PR #564 / #509 re-engagement race). These two suites launch the camera later, inside each test body via `fixture.launchPixelCamera()`, not in an activity-launching rule, so no new dismissal-then-launch race is introduced.

## How the acceptance criteria are met

- The keyguard-dismissal-then-launch ordering that `TestNameToastRule.kt` documents is preserved: the toast remains the innermost rule, so its ~3s duration sits after dismissal, with no regression of the PR #564 / #509 race.
- `dismissSecureKeyguard()` now runs before the start-of-test slate for all three named suites, so the marker renders over the app UI rather than behind the lock screen.

## Test plan

The first acceptance criterion is a property of the recorded video, which no automated assertion checks, so it needs manual confirmation from a keyguard-reasserted CI run:

- [ ] Inspect this PR's `e2e-video-*` artifacts for `PermissionsGrantedE2ETest` and `PermissionsDeniedE2ETest` and confirm the start-of-test name toast is now visible over the app UI (not painted behind the lock screen).

`ktlint` passes on both edited files. The Android SDK and an emulator are not available in the development environment, so these instrumented (`androidTest`) suites are compiled and run only by CI's connected-test job.