### PR TITLE
Do not merge: verify PR #763 (keyguard-reasserted start-of-test toast)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -601,6 +601,21 @@ jobs:
           path: results/e2e-gallery.ndjson
           retention-days: 14
 
+      - name: (verify-pr-763) Force secure keyguard reassertion before PermissionsGrantedE2ETest
+        # Throwaway step for issue #764 (verification of PR #763 / issue #761): puts the
+        # display to sleep, which re-engages the secure PIN keyguard scripts/setup-e2e-emulator.sh
+        # configures, then wakes the display back up without dismissing it. This reproduces the
+        # "keyguard reasserted between CI steps" scenario the issue describes, so the next step's
+        # own start-of-test toast has a locked secure keyguard to contend with. Not part of the
+        # PR under test; removed before this test branch's throwaway PR is closed.
+        if: needs.check-diff.outputs.needs_full_build == 'true'
+        run: |
+          ADB="$ANDROID_HOME/platform-tools/adb"
+          "$ADB" shell input keyevent 223 # KEYCODE_SLEEP: engages the secure PIN keyguard
+          sleep 2
+          "$ADB" shell input keyevent 224 # KEYCODE_WAKEUP: display on, secure keyguard still locked
+          sleep 2
+
       - name: Run PermissionsGrantedE2ETest
         # No `continue-on-error` (issue #309): record the real outcome and defer
         # the pass/fail verdict to the "Gate on test failures" step.
@@ -660,9 +675,11 @@ jobs:
           wait "$RECPID_PERMISSIONS_GRANTED" 2>/dev/null || true
 
       - name: Pull PermissionsGrantedE2ETest video on failure
-        # Only pull and upload the recording when this suite failed (issue #604).
-        # On a green run the file is left on the device and discarded when the emulator exits.
-        if: always() && needs.check-diff.outputs.needs_full_build == 'true' && steps.run_permissions_granted_e2e.outputs.outcome == 'failure'
+        # (verify-pr-763): condition temporarily loosened to always() (was
+        # `... && steps.run_permissions_granted_e2e.outputs.outcome == 'failure'`, issue #604's
+        # original intent) so issue #764's verification run captures the video regardless of the
+        # suite's outcome. Restored before this throwaway test branch's PR is closed.
+        if: always() && needs.check-diff.outputs.needs_full_build == 'true'
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p /tmp/e2e-videos
@@ -670,7 +687,8 @@ jobs:
             echo "WARNING: could not pull e2e-permissions-granted.mp4"
 
       - name: Upload PermissionsGrantedE2ETest video
-        if: always() && needs.check-diff.outputs.needs_full_build == 'true' && steps.run_permissions_granted_e2e.outputs.outcome == 'failure'
+        # (verify-pr-763): condition temporarily loosened to always(), see the pull step above.
+        if: always() && needs.check-diff.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-video-PermissionsGrantedE2ETest

--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsDeniedE2ETest.kt
@@ -12,6 +12,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -60,9 +62,6 @@ import org.junit.runner.RunWith
 @E2ETest
 @RunWith(AndroidJUnit4::class)
 class PermissionsDeniedE2ETest {
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = instrumentation.targetContext
     private val fixture =
@@ -70,6 +69,28 @@ class PermissionsDeniedE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761). The suite's own setUp() only wires
+    // fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure keyguard
+    // scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast has
+    // already fired; if the keyguard has reasserted between CI steps the marker would be occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() {

--- a/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PermissionsGrantedE2ETest.kt
@@ -9,6 +9,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -26,9 +28,6 @@ import org.junit.runner.RunWith
 @E2ETest
 @RunWith(AndroidJUnit4::class)
 class PermissionsGrantedE2ETest {
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = instrumentation.targetContext
     private val fixture =
@@ -36,6 +35,28 @@ class PermissionsGrantedE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761). The suite's own setUp() only wires
+    // fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure keyguard
+    // scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast has
+    // already fired; if the keyguard has reasserted between CI steps the marker would be occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Do not merge.

Throwaway PR created by the Verification Agent to carry out the before-merging step tracked in issue #764 (blocking PR #763 / issue #761).

**Item under test:** PR #763's `PermissionsGrantedE2ETest`/`PermissionsDeniedE2ETest` `RuleChain` fix, which dismisses the secure keyguard before the start-of-test name toast. Issue #764 requires a recording of one of these two suites running with the secure keyguard reasserted, confirming the toast now paints over the app UI rather than behind the lock screen.

This branch is `fix/issue-761` (PR #763's head) plus one throwaway commit on top that:
1. Adds a step immediately before `Run PermissionsGrantedE2ETest` that sleeps then wakes the display, re-engaging the secure PIN keyguard scripts/setup-e2e-emulator.sh configures -- reproducing the "keyguard reasserted between CI steps" scenario issue #761/#764 describe.
2. Loosens the `Pull`/`Upload PermissionsGrantedE2ETest video` steps' `if:` condition from "only on suite failure" to `always()`, so the recording is captured (and uploaded as the `e2e-video-PermissionsGrantedE2ETest` artifact) regardless of the suite's outcome.

Neither change is part of PR #763; both are reverted by discarding this test branch. This PR will be closed (not merged) once the verification evidence is collected.
