### PR TITLE
Dismiss the secure keyguard before the start-of-test slate in PixelCameraOverlayE2ETest and GalleryButtonVisualE2ETest

### DIFF
--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -19,6 +19,8 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
 import kotlin.math.sqrt
@@ -50,9 +52,6 @@ class GalleryButtonVisualE2ETest {
     @get:Rule
     val screenshotRule = ScreenshotTestRule()
 
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context = instrumentation.targetContext
     private val fixture =
@@ -60,6 +59,29 @@ class GalleryButtonVisualE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761 / #765). The suite's own setUp() only
+    // wires fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure
+    // keyguard scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast
+    // has already fired; if the keyguard has reasserted between CI steps the marker would be
+    // occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() = fixture.setUp()

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -8,6 +8,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -53,15 +55,35 @@ class PixelCameraOverlayE2ETest {
     @get:Rule
     val screenshotRule = ScreenshotTestRule()
 
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val fixture =
         E2EFixture(
             context = instrumentation.targetContext,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761 / #765). The suite's own setUp() only
+    // wires fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure
+    // keyguard scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast
+    // has already fired; if the keyguard has reasserted between CI steps the marker would be
+    // occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() = fixture.setUp()


### PR DESCRIPTION
🤖 Author

Fixes #765

## Problem

Issue #765 is a follow-on from PR #763 / issue #761: a start-of-test toast (`TestNameToastRule`) cannot paint over the *secure* PIN keyguard `scripts/setup-e2e-emulator.sh` configures, so if that keyguard has reasserted between CI steps before a recorded suite runs, its slate renders behind the lock screen and is invisible in the video artifact.

The issue named three suites as carrying this same latent risk: `PixelCameraOverlayE2ETest`, `GalleryButtonVisualE2ETest`, and `PartialAccessPhotoPickerE2ETest`.

## Change

`PixelCameraOverlayE2ETest` and `GalleryButtonVisualE2ETest` now use a `RuleChain` whose outer rule runs `E2EFixture.dismissSecureKeyguard()` (via an `ExternalResource`) ahead of the innermost `testNameToastRule`, identical to the pattern PR #763 introduced for `PermissionsGrantedE2ETest`/`PermissionsDeniedE2ETest`. Both suites launch the camera later, inside each test body via `fixture.launchPixelCamera()`, not in an activity-launching rule, so the toast stays innermost with no new dismissal-then-launch race introduced (the same reasoning PR #763's review confirmed for the Permissions suites). `screenshotRule` (a separate `TestWatcher`) is left as an independent plain `@get:Rule`: its `starting()` only records a screenshot-filename prefix and a baseline file snapshot, with no ordering dependency on keyguard dismissal or the toast.

## `PartialAccessPhotoPickerE2ETest` is intentionally left unchanged

Re-checking the current state of this suite against the issue's premise, neither half of "records video with a plain `@get:Rule testNameToastRule`" actually holds for it:

- It does not wire `testNameToastRule` at all (verified with a repo-wide grep; only `PixelCameraOverlayE2ETest` and `GalleryButtonVisualE2ETest` had the plain-`@get:Rule` form the issue described). There is no toast rule here for a reasserted keyguard to occlude.
- Its CI step (`Run PartialAccessPhotoPickerE2ETest` in `.github/workflows/build.yml`) does not run `screenrecord` and produces no `e2e-video-*` artifact, unlike every other suite named in #761/#765's investigation. It is not one of the "recorded E2E suites" the issue title refers to.
- It already dismisses the secure keyguard ahead of its own `composeRule`-driven `SetupActivity` launch (`RuleChain.outerRule(keyguardDismiss).around(composeRule)`), so the gap the other two suites had does not exist here either.

Since the underlying premise does not apply to this suite, no change to it is included in this PR. (The reviewer comment that seeded #765 was accurate about the general pattern but appears to have described this suite's state incorrectly, possibly from a stale reading, since the git history for this file shows no prior revision that wired `testNameToastRule`.)

## Test plan

The keyguard-reassertion scenario is a property of the recorded video, which no automated assertion checks, so it needs manual confirmation from a keyguard-reasserted CI run, mirroring how #764 verified this for PR #763:

- [ ] Inspect this PR's `e2e-video-PixelCameraOverlayE2ETest` and `e2e-video-GalleryButtonVisualE2ETest` artifacts (ideally from a run where the keyguard has reasserted before these steps) and confirm the start-of-test toast renders over the app UI, not behind the lock screen.

`ktlint` passes on both edited files (verified with the pinned standalone ktlint CLI via `scripts/install-ktlint.sh`, since the Android SDK and an emulator are not available in the development environment). These instrumented (`androidTest`) suites are compiled and run only by CI's connected-test job.
