### PR TITLE
Fit the overlay thumbnail by its short edge instead of its long edge

### DIFF
--- a/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/gb4pc/overlay/OverlayManager.kt
@@ -260,7 +260,9 @@ class OverlayManager(
                     }
                 }
             }
-        imageView.scaleType = ImageView.ScaleType.FIT_CENTER
+        // Issue #767: CENTER_CROP scales so the short edge fills the view and the long
+        // edge is cropped, instead of FIT_CENTER's letterbox bars on the short axis.
+        imageView.scaleType = ImageView.ScaleType.CENTER_CROP
         updateIconDrawable(imageView)
         imageView.setOnClickListener { handleTap() }
         return imageView

--- a/app/src/main/java/com/gb4pc/overlay/SquircleDrawable.kt
+++ b/app/src/main/java/com/gb4pc/overlay/SquircleDrawable.kt
@@ -9,7 +9,39 @@ import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import kotlin.math.abs
+import kotlin.math.min
 import kotlin.math.pow
+
+/** Top-left offset and side length of a centered square sub-region within a `w x h` rect. */
+internal data class SquareRegion(
+    val left: Int,
+    val top: Int,
+    val side: Int,
+)
+
+/**
+ * Computes the centered square sub-region of a `w x h` rect.
+ *
+ * Issue #767 follow-up: [ImageView.ScaleType.CENTER_CROP][android.widget.ImageView.ScaleType]
+ * leaves a [Drawable]'s own `bounds` at its raw, unscaled intrinsic size (`configureBounds()`
+ * applies the actual crop/scale through a [Canvas] matrix at draw time, not by resizing
+ * `bounds`), so for a non-square photo thumbnail `bounds` is not square. This codebase's
+ * overlay window is always square, so CENTER_CROP always crops such a drawable down to the
+ * centered square sub-region this function computes--exactly the window that ends up visible
+ * in the (square) overlay button. [SquircleDrawable] clips against this square, not the full
+ * (possibly non-square) `bounds`, so the squircle's shape is unaffected by the wrapped
+ * drawable's own aspect ratio.
+ *
+ * A no-op for an already-square rect (`left == top == 0`, `side == w == h`), so the gallery
+ * icon's clip (always square) is unchanged.
+ */
+internal fun centeredSquareRegion(
+    w: Int,
+    h: Int,
+): SquareRegion {
+    val side = min(w, h)
+    return SquareRegion(left = (w - side) / 2, top = (h - side) / 2, side = side)
+}
 
 /**
  * A [Drawable] wrapper that clips its content to a superellipse ("squircle") shape,
@@ -43,12 +75,17 @@ class SquircleDrawable(
         val b = bounds
         if (b.isEmpty) return
 
-        rebuildPathIfNeeded(b.width(), b.height())
+        // Issue #767 follow-up: clip against the centered square sub-region of `bounds`
+        // (see centeredSquareRegion's kdoc), not the full (possibly non-square) bounds.
+        val square = centeredSquareRegion(b.width(), b.height())
+        rebuildPathIfNeeded(square.side, square.side)
 
         val save = canvas.save()
         try {
             canvas.translate(b.left.toFloat(), b.top.toFloat())
+            canvas.translate(square.left.toFloat(), square.top.toFloat())
             canvas.clipPath(clipPath)
+            canvas.translate(-square.left.toFloat(), -square.top.toFloat())
 
             // Draw into the local (0,0) origin after translate.
             val localBounds = Rect(0, 0, b.width(), b.height())

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -405,6 +405,10 @@ class OverlayManagerRobolectricTest {
      * [ImageView.ScaleType.CENTER_CROP], not FIT_CENTER. FIT_CENTER scales so the image's
      * long edge fits inside the view, leaving letterbox bars along the short axis;
      * CENTER_CROP scales so the short edge fills the view, cropping the long edge instead.
+     *
+     * What that scale type actually produces on screen, for each of the issue's edge ratios,
+     * is asserted from rendered pixels in [OverlayThumbnailFitPixelTest]; this test just pins
+     * the enum, so a change to it fails with an obvious message instead of a colour mismatch.
      */
     @Test
     fun `overlay ImageView uses CENTER_CROP scale type`() {
@@ -429,97 +433,5 @@ class OverlayManagerRobolectricTest {
             ImageView.ScaleType.CENTER_CROP,
             overlayView.scaleType,
         )
-    }
-
-    /**
-     * Regression guard for Issue #767: verifies the real [ImageView.ScaleType.CENTER_CROP]
-     * geometry Android computes for the overlay (via the framework's private `mDrawMatrix`,
-     * the same field [ImageView.onDraw] uses) crops the long edge and fits the short edge for
-     * each of the issue's four edge ratios (16:9, 4:3, 9:16, 3:4), leaving no letterbox gap on
-     * either axis of the square overlay view.
-     *
-     * A full pixel-rendered assertion (rendering a fixture bitmap through the view and reading
-     * back pixels) was tried and rejected: this Robolectric setup's native graphics shim does
-     * not apply a translated [android.graphics.Canvas.concat] to a subsequent bitmap draw
-     * (reproduced with a bare `Canvas` and `Bitmap`, independent of [ImageView] or
-     * [SquircleDrawable]), which would make such a test fail regardless of whether the overlay
-     * code is correct. Reading the matrix Android actually computed avoids that rendering gap
-     * while still exercising the framework's real CENTER_CROP calculation.
-     */
-    @Test
-    fun `CENTER_CROP matrix fits the short edge and crops the long edge for every edge ratio`() {
-        val context: Application = ApplicationProvider.getApplicationContext()
-        val prefsManager: PrefsManager =
-            mock {
-                on { galleryPackage } doReturn null
-                on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
-                on { focusableOverlay } doReturn false
-            }
-
-        // (wRatio, hRatio) pairs for the issue's four edge ratios: 16:9, 4:3 (wide) and
-        // 9:16, 3:4 (tall). shortEdge is the fixture's minor-edge pixel count (an arbitrary,
-        // but non-trivial, size).
-        val ratios = listOf(16 to 9, 4 to 3, 9 to 16, 3 to 4)
-        val shortEdge = 90
-        val viewSize = 90
-
-        val matrixField = ImageView::class.java.getDeclaredField("mDrawMatrix").apply { isAccessible = true }
-
-        for ((wRatio, hRatio) in ratios) {
-            val drawableW = if (wRatio >= hRatio) shortEdge * wRatio / hRatio else shortEdge
-            val drawableH = if (wRatio >= hRatio) shortEdge else shortEdge * hRatio / wRatio
-
-            val overlayManager = OverlayManager(context, prefsManager)
-            overlayManager.show()
-
-            val windowManager = context.getSystemService(WindowManager::class.java)
-            val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
-            val overlayView = shadowWm.views.last() as ImageView
-
-            val fixtureBitmap = Bitmap.createBitmap(drawableW, drawableH, Bitmap.Config.ARGB_8888)
-            // Match the fixture's density to the resources used to wrap it, so
-            // BitmapDrawable's intrinsic size (which ImageView scales against) equals the
-            // fixture's actual pixel dimensions, not a density-rescaled size.
-            fixtureBitmap.density = context.resources.displayMetrics.densityDpi
-            overlayView.setImageDrawable(SquircleDrawable(BitmapDrawable(context.resources, fixtureBitmap)))
-            // Force a real size: the fake WindowManager does not run a layout pass.
-            overlayView.layout(0, 0, viewSize, viewSize)
-
-            val matrix = matrixField.get(overlayView) as android.graphics.Matrix?
-            assertNotNull(
-                "Issue #767: ratio $wRatio:$hRatio, expected a non-null CENTER_CROP " +
-                    "mDrawMatrix (a null matrix means ImageView drew the drawable unscaled).",
-                matrix,
-            )
-            val values = FloatArray(9)
-            matrix!!.getValues(values)
-            val scaleX = values[android.graphics.Matrix.MSCALE_X]
-            val scaleY = values[android.graphics.Matrix.MSCALE_Y]
-
-            val scaledW = drawableW * scaleX
-            val scaledH = drawableH * scaleY
-            // No letterbox gap on either axis: the scaled drawable must cover the full view.
-            assertTrue(
-                "Issue #767: ratio $wRatio:$hRatio, scaled width $scaledW must cover the " +
-                    "$viewSize px view (no vertical letterbox bar).",
-                scaledW >= viewSize - 1,
-            )
-            assertTrue(
-                "Issue #767: ratio $wRatio:$hRatio, scaled height $scaledH must cover the " +
-                    "$viewSize px view (no horizontal letterbox bar).",
-                scaledH >= viewSize - 1,
-            )
-            // The short edge must fit exactly (not overshoot far beyond the view), confirming
-            // the crop is keyed to the short edge, not merely an oversized scale on both axes.
-            val shortScaledEdge = kotlin.math.min(scaledW, scaledH)
-            assertTrue(
-                "Issue #767: ratio $wRatio:$hRatio, the short scaled edge $shortScaledEdge " +
-                    "must match the $viewSize px view almost exactly (CENTER_CROP fits the " +
-                    "short edge to the view).",
-                kotlin.math.abs(shortScaledEdge - viewSize) <= 1f,
-            )
-
-            overlayManager.hide()
-        }
     }
 }

--- a/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayManagerRobolectricTest.kt
@@ -397,4 +397,129 @@ class OverlayManagerRobolectricTest {
             )
         }
     }
+
+    // ── Issue #767: thumbnail zooms to fit the short edge, not the long edge ─
+
+    /**
+     * Regression guard for Issue #767: the overlay's photo-thumbnail [ImageView] must use
+     * [ImageView.ScaleType.CENTER_CROP], not FIT_CENTER. FIT_CENTER scales so the image's
+     * long edge fits inside the view, leaving letterbox bars along the short axis;
+     * CENTER_CROP scales so the short edge fills the view, cropping the long edge instead.
+     */
+    @Test
+    fun `overlay ImageView uses CENTER_CROP scale type`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager =
+            mock {
+                on { galleryPackage } doReturn null
+                on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+                on { focusableOverlay } doReturn false
+            }
+
+        val overlayManager = OverlayManager(context, prefsManager)
+        overlayManager.show()
+
+        val windowManager = context.getSystemService(WindowManager::class.java)
+        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+        val overlayView = shadowWm.views[0] as ImageView
+
+        assertEquals(
+            "Issue #767: the overlay ImageView must use CENTER_CROP so thumbnails zoom to " +
+                "fit the short edge instead of letterboxing the long edge.",
+            ImageView.ScaleType.CENTER_CROP,
+            overlayView.scaleType,
+        )
+    }
+
+    /**
+     * Regression guard for Issue #767: verifies the real [ImageView.ScaleType.CENTER_CROP]
+     * geometry Android computes for the overlay (via the framework's private `mDrawMatrix`,
+     * the same field [ImageView.onDraw] uses) crops the long edge and fits the short edge for
+     * each of the issue's four edge ratios (16:9, 4:3, 9:16, 3:4), leaving no letterbox gap on
+     * either axis of the square overlay view.
+     *
+     * A full pixel-rendered assertion (rendering a fixture bitmap through the view and reading
+     * back pixels) was tried and rejected: this Robolectric setup's native graphics shim does
+     * not apply a translated [android.graphics.Canvas.concat] to a subsequent bitmap draw
+     * (reproduced with a bare `Canvas` and `Bitmap`, independent of [ImageView] or
+     * [SquircleDrawable]), which would make such a test fail regardless of whether the overlay
+     * code is correct. Reading the matrix Android actually computed avoids that rendering gap
+     * while still exercising the framework's real CENTER_CROP calculation.
+     */
+    @Test
+    fun `CENTER_CROP matrix fits the short edge and crops the long edge for every edge ratio`() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager =
+            mock {
+                on { galleryPackage } doReturn null
+                on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+                on { focusableOverlay } doReturn false
+            }
+
+        // (wRatio, hRatio) pairs for the issue's four edge ratios: 16:9, 4:3 (wide) and
+        // 9:16, 3:4 (tall). shortEdge is the fixture's minor-edge pixel count (an arbitrary,
+        // but non-trivial, size).
+        val ratios = listOf(16 to 9, 4 to 3, 9 to 16, 3 to 4)
+        val shortEdge = 90
+        val viewSize = 90
+
+        val matrixField = ImageView::class.java.getDeclaredField("mDrawMatrix").apply { isAccessible = true }
+
+        for ((wRatio, hRatio) in ratios) {
+            val drawableW = if (wRatio >= hRatio) shortEdge * wRatio / hRatio else shortEdge
+            val drawableH = if (wRatio >= hRatio) shortEdge else shortEdge * hRatio / wRatio
+
+            val overlayManager = OverlayManager(context, prefsManager)
+            overlayManager.show()
+
+            val windowManager = context.getSystemService(WindowManager::class.java)
+            val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+            val overlayView = shadowWm.views.last() as ImageView
+
+            val fixtureBitmap = Bitmap.createBitmap(drawableW, drawableH, Bitmap.Config.ARGB_8888)
+            // Match the fixture's density to the resources used to wrap it, so
+            // BitmapDrawable's intrinsic size (which ImageView scales against) equals the
+            // fixture's actual pixel dimensions, not a density-rescaled size.
+            fixtureBitmap.density = context.resources.displayMetrics.densityDpi
+            overlayView.setImageDrawable(SquircleDrawable(BitmapDrawable(context.resources, fixtureBitmap)))
+            // Force a real size: the fake WindowManager does not run a layout pass.
+            overlayView.layout(0, 0, viewSize, viewSize)
+
+            val matrix = matrixField.get(overlayView) as android.graphics.Matrix?
+            assertNotNull(
+                "Issue #767: ratio $wRatio:$hRatio, expected a non-null CENTER_CROP " +
+                    "mDrawMatrix (a null matrix means ImageView drew the drawable unscaled).",
+                matrix,
+            )
+            val values = FloatArray(9)
+            matrix!!.getValues(values)
+            val scaleX = values[android.graphics.Matrix.MSCALE_X]
+            val scaleY = values[android.graphics.Matrix.MSCALE_Y]
+
+            val scaledW = drawableW * scaleX
+            val scaledH = drawableH * scaleY
+            // No letterbox gap on either axis: the scaled drawable must cover the full view.
+            assertTrue(
+                "Issue #767: ratio $wRatio:$hRatio, scaled width $scaledW must cover the " +
+                    "$viewSize px view (no vertical letterbox bar).",
+                scaledW >= viewSize - 1,
+            )
+            assertTrue(
+                "Issue #767: ratio $wRatio:$hRatio, scaled height $scaledH must cover the " +
+                    "$viewSize px view (no horizontal letterbox bar).",
+                scaledH >= viewSize - 1,
+            )
+            // The short edge must fit exactly (not overshoot far beyond the view), confirming
+            // the crop is keyed to the short edge, not merely an oversized scale on both axes.
+            val shortScaledEdge = kotlin.math.min(scaledW, scaledH)
+            assertTrue(
+                "Issue #767: ratio $wRatio:$hRatio, the short scaled edge $shortScaledEdge " +
+                    "must match the $viewSize px view almost exactly (CENTER_CROP fits the " +
+                    "short edge to the view).",
+                kotlin.math.abs(shortScaledEdge - viewSize) <= 1f,
+            )
+
+            overlayManager.hide()
+        }
+    }
 }

--- a/app/src/test/java/com/gb4pc/overlay/OverlayThumbnailFitPixelTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/OverlayThumbnailFitPixelTest.kt
@@ -1,0 +1,300 @@
+package com.gb4pc.overlay
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import android.view.View
+import android.view.WindowManager
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import com.gb4pc.data.OverlayPosition
+import com.gb4pc.data.PrefsManager
+import com.gb4pc.e2e.visual.PixelMask
+import com.gb4pc.e2e.visual.ShapeTemplates
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowLooper
+import org.robolectric.shadows.ShadowWindowManagerImpl
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Pixel-level acceptance test for Issue #767, built to the test design in that issue.
+ *
+ * For each of the issue's four edge ratios (16:9, 4:3, 9:16, 3:4) a fixture photo is built by
+ * the issue's rules: a solid BLUE `s x s` square (where `s` is the photo's short edge) centred
+ * on a RED background, at a pixel size on the order of a Pixel Camera output photo. The fixture
+ * is served through the content resolver and displayed by the real
+ * [OverlayManager.showLatestPhotoThumbnail] path, then the overlay button is rendered over a
+ * BLACK backdrop and scanned.
+ *
+ * Acceptance, quoting the issue: "the entire thumbnail should appear BLUE, with no black, and
+ * no RED appearing". Concretely:
+ *  - no pixel of the button matches RED, so the fixture's reverse-letterbox bars were cropped
+ *    away rather than shown,
+ *  - every pixel inside the button's squircle is BLUE, so no BLACK letterbox gap survives,
+ *  - the BLUE region spans the button edge to edge on both axes,
+ *  - and the BLUE region is still squircle-shaped, so filling the button did not cost the
+ *    corner rounding.
+ *
+ * Verified to fail on both halves of this PR's fix: with `FIT_CENTER` restored, ~9.5k px (4:3)
+ * to ~17k px (16:9) inside the button render BLACK; with the squircle clipped against the
+ * photo's raw bounds again, the BLUE region's superellipse IoU drops from ~0.99 to ~0.94 as the
+ * corners go square.
+ *
+ * No emulator, no camera app, and no device: the whole path runs on the JVM under Robolectric's
+ * native graphics (see [PixelRender]).
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w411dp-h891dp-xxhdpi")
+class OverlayThumbnailFitPixelTest {
+    private companion object {
+        /**
+         * Fraction of the button size excluded from the "all BLUE" scan at the squircle's
+         * boundary. The fixture's BLUE/RED edge lands exactly on the crop window's edge, so the
+         * bitmap filtering that downscales a multi-megapixel photo into a ~185 px button blends
+         * the two colours across a hairline right at that boundary. The band is far thinner
+         * than any letterbox bar this test exists to catch: the narrowest of those, for 4:3,
+         * covers 12.5% of the button.
+         */
+        const val EDGE_INSET_FRACTION = 0.04f
+
+        /** Slack, in pixels, allowed when asserting the BLUE region reaches the button edges. */
+        const val EDGE_SLACK_PX = 2
+
+        /**
+         * Gates for the squircle-shape check. Measured values are ~0.99 against the superellipse
+         * template and ~0.92 against the square one, so these leave headroom for rasterisation
+         * noise while still failing a button whose corners have gone square.
+         */
+        const val MIN_SQUIRCLE_IOU = 0.97f
+        const val MIN_SQUIRCLE_MARGIN = 0.03f
+
+        /** Photo sizes for the issue's four edge ratios, at Pixel Camera output resolutions. */
+        const val WIDE_16_9_W = 4032
+        const val WIDE_16_9_H = 2268
+        const val WIDE_4_3_W = 4032
+        const val WIDE_4_3_H = 3024
+    }
+
+    @Test
+    fun `16 by 9 photo fills the overlay thumbnail with no letterbox and no red`() {
+        assertThumbnailIsAllBlue(WIDE_16_9_W, WIDE_16_9_H)
+    }
+
+    @Test
+    fun `4 by 3 photo fills the overlay thumbnail with no letterbox and no red`() {
+        assertThumbnailIsAllBlue(WIDE_4_3_W, WIDE_4_3_H)
+    }
+
+    @Test
+    fun `9 by 16 photo fills the overlay thumbnail with no letterbox and no red`() {
+        assertThumbnailIsAllBlue(WIDE_16_9_H, WIDE_16_9_W)
+    }
+
+    @Test
+    fun `3 by 4 photo fills the overlay thumbnail with no letterbox and no red`() {
+        assertThumbnailIsAllBlue(WIDE_4_3_H, WIDE_4_3_W)
+    }
+
+    // ── the acceptance check ─────────────────────────────────────────────────
+
+    /**
+     * Shows the overlay, feeds it a [photoW] x [photoH] fixture photo through the production
+     * thumbnail path, renders the button, and asserts the issue's acceptance criteria.
+     */
+    private fun assertThumbnailIsAllBlue(
+        photoW: Int,
+        photoH: Int,
+    ) {
+        val photo = "$photoW x $photoH"
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val prefsManager: PrefsManager =
+            mock {
+                on { galleryPackage } doReturn null
+                on { getOverlayPosition(any()) } doReturn OverlayPosition.default()
+                on { focusableOverlay } doReturn false
+            }
+
+        val overlayManager = OverlayManager(context, prefsManager)
+        overlayManager.show()
+
+        val windowManager = context.getSystemService(WindowManager::class.java)
+        val shadowWm = shadowOf(windowManager) as ShadowWindowManagerImpl
+        val overlayView = shadowWm.views.single() as ImageView
+        val params = overlayView.layoutParams as WindowManager.LayoutParams
+        val size = params.width
+        assertEquals("The overlay window must be square for this test to mean anything.", size, params.height)
+        assertTrue("Overlay window is too small to scan: $size px", size >= 32)
+
+        // Serve the fixture from the content resolver and drive the real thumbnail path
+        // (background decode, main-looper hand-off, SquircleDrawable(BitmapDrawable(...))
+        // wrapping) rather than handing the view a drawable directly.
+        val uri = Uri.parse("content://com.gb4pc.test.photos/$photoW-$photoH")
+        val png = fixturePhotoPng(photoW, photoH)
+        shadowOf(context.contentResolver).registerInputStreamSupplier(uri) { ByteArrayInputStream(png) }
+        overlayManager.showLatestPhotoThumbnail(uri.toString())
+        val thumbnail = awaitThumbnailBitmap(overlayView, photo)
+
+        // Sanity: the loaded thumbnail still carries the fixture's edge ratio, so what the
+        // ImageView is asked to fit is genuinely non-square.
+        assertEquals(
+            "Loaded thumbnail for $photo must keep the fixture's edge ratio " +
+                "(got ${thumbnail.width} x ${thumbnail.height}).",
+            photoW.toFloat() / photoH,
+            thumbnail.width.toFloat() / thumbnail.height,
+            0.02f,
+        )
+
+        overlayView.measure(
+            View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY),
+        )
+        overlayView.layout(0, 0, size, size)
+        val pixels = PixelRender.renderOverBlack(size, size) { canvas -> overlayView.draw(canvas) }
+
+        // 1. "no RED appearing": the fixture's reverse-letterbox bars must be cropped away.
+        val red = PixelMask.scan(pixels, size, size, 255, 0, 0, PixelRender.TOLERANCE)
+        assertEquals(
+            "Issue #767: photo $photo, no RED may appear in the overlay thumbnail, but " +
+                "${red.pixelCount} of ${size * size} px matched RED (bbox " +
+                "${red.bboxLeft},${red.bboxTop}-${red.bboxRight},${red.bboxBottom}). The " +
+                "thumbnail is fitting the long edge, so the fixture's RED bars are on screen.",
+            0,
+            red.pixelCount,
+        )
+
+        // 2. "the entire thumbnail should appear BLUE, with no black": every pixel inside the
+        // button's squircle must be BLUE. Whatever the photo fails to cover shows the BLACK
+        // backdrop it was rendered over.
+        val inset = maxOf(2, (size * EDGE_INSET_FRACTION).roundToInt())
+        val notBlue = countNonBlueInsideSquircle(pixels, size, inset)
+        assertEquals(
+            "Issue #767: photo $photo, the whole thumbnail must be BLUE, but $notBlue px " +
+                "inside the button's squircle (inset $inset px) were not BLUE. Letterbox bars " +
+                "render as the BLACK backdrop.",
+            0,
+            notBlue,
+        )
+
+        // 3. The BLUE region reaches all four edges: the photo fills the button rather than
+        // sitting centred inside it.
+        val blue = PixelMask.scan(pixels, size, size, 0, 0, 255, PixelRender.TOLERANCE)
+        assertTrue(
+            "Issue #767: photo $photo, BLUE must reach the left and top edges of the " +
+                "${size}px button (bbox left=${blue.bboxLeft}, top=${blue.bboxTop}).",
+            blue.bboxLeft <= EDGE_SLACK_PX && blue.bboxTop <= EDGE_SLACK_PX,
+        )
+        assertTrue(
+            "Issue #767: photo $photo, BLUE must reach the right and bottom edges of the " +
+                "${size}px button (bbox right=${blue.bboxRight}, bottom=${blue.bboxBottom}).",
+            blue.bboxRight >= size - EDGE_SLACK_PX && blue.bboxBottom >= size - EDGE_SLACK_PX,
+        )
+
+        // 4. The button is still a squircle: cropping the photo must not cost the corner
+        // rounding. The BLUE region has to match the superellipse template and beat the square
+        // template by a clear margin.
+        val squircleIoU = PixelRender.alignedIoU(blue, ShapeTemplates.squircle(size, size))
+        val squareIoU = PixelRender.alignedIoU(blue, ShapeTemplates.square(size, size))
+        assertTrue(
+            "Issue #767: photo $photo, the BLUE thumbnail must fill the button's squircle " +
+                "(IoU $squircleIoU against the superellipse template, min $MIN_SQUIRCLE_IOU).",
+            squircleIoU >= MIN_SQUIRCLE_IOU,
+        )
+        assertTrue(
+            "Issue #767: photo $photo, the thumbnail must be squircle-shaped, not square " +
+                "(squircle IoU $squircleIoU vs square IoU $squareIoU, min margin " +
+                "$MIN_SQUIRCLE_MARGIN). A square result means the squircle clip was built " +
+                "against the photo's own non-square bounds instead of the crop window.",
+            squircleIoU - squareIoU >= MIN_SQUIRCLE_MARGIN,
+        )
+
+        overlayManager.hide()
+    }
+
+    // ── fixture and helpers ──────────────────────────────────────────────────
+
+    /**
+     * Builds the issue's fixture photo as PNG bytes: a solid BLUE square of the photo's short
+     * edge, centred, with every remaining pixel RED. PNG rather than JPEG so the two colours
+     * stay exact and the scan measures the overlay's scaling, not codec noise.
+     */
+    private fun fixturePhotoPng(
+        w: Int,
+        h: Int,
+    ): ByteArray {
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        try {
+            val canvas = Canvas(bitmap)
+            canvas.drawColor(Color.RED)
+            val side = min(w, h).toFloat()
+            val left = (w - side) / 2f
+            val top = (h - side) / 2f
+            canvas.drawRect(left, top, left + side, top + side, Paint().apply { color = Color.BLUE })
+            val out = ByteArrayOutputStream()
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            return out.toByteArray()
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    /**
+     * Counts pixels inside the button's squircle, shrunk by [inset] px on every side, that do
+     * not match BLUE.
+     */
+    private fun countNonBlueInsideSquircle(
+        pixels: IntArray,
+        size: Int,
+        inset: Int,
+    ): Int {
+        val inner = ShapeTemplates.squircle(size - 2 * inset, size - 2 * inset)
+        var notBlue = 0
+        for (y in 0 until inner.height) {
+            for (x in 0 until inner.width) {
+                if (!inner.bits[y * inner.width + x]) continue
+                val pixel = pixels[(y + inset) * size + (x + inset)]
+                if (!PixelMask.matches(pixel, 0, 0, 255, PixelRender.TOLERANCE)) notBlue++
+            }
+        }
+        return notBlue
+    }
+
+    /**
+     * Waits for [OverlayManager.showLatestPhotoThumbnail]'s background decode to hand its
+     * bitmap to the main looper and land on [view], then returns that bitmap.
+     */
+    private fun awaitThumbnailBitmap(
+        view: ImageView,
+        photo: String,
+    ): Bitmap {
+        val deadline = System.currentTimeMillis() + 30_000
+        while (System.currentTimeMillis() < deadline) {
+            ShadowLooper.idleMainLooper()
+            val inner = (view.drawable as? SquircleDrawable)?.inner
+            // The gallery-icon placeholder this overlay starts with is a vector/layer drawable,
+            // never a BitmapDrawable, so this only matches once the photo has arrived.
+            if (inner is BitmapDrawable) return inner.bitmap
+            Thread.sleep(20)
+        }
+        fail("Thumbnail for photo $photo never reached the overlay ImageView.")
+        error("unreachable")
+    }
+}

--- a/app/src/test/java/com/gb4pc/overlay/PixelRender.kt
+++ b/app/src/test/java/com/gb4pc/overlay/PixelRender.kt
@@ -1,0 +1,74 @@
+package com.gb4pc.overlay
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import com.gb4pc.e2e.visual.MaskData
+
+/**
+ * Shared rendering helpers for the overlay's pixel-level Robolectric tests.
+ *
+ * These tests draw real pixels rather than inspecting framework or drawable internals, which
+ * requires [org.robolectric.annotation.GraphicsMode.Mode.NATIVE]: Robolectric's default LEGACY
+ * graphics mode stubs drawing out entirely, so every readback comes back untouched and pixel
+ * assertions look impossible. Every caller of these helpers must carry that annotation.
+ *
+ * The scan side is [com.gb4pc.e2e.visual.PixelMask], the same pure-JVM colour-mask scanner the
+ * on-device E2E visual suite uses, so a unit test and an E2E test describe a rendered button the
+ * same way.
+ */
+internal object PixelRender {
+    /** Per-channel match tolerance, matching `ColorMatch`'s on-device default. */
+    const val TOLERANCE = 20
+
+    /**
+     * Runs [draw] against a [width] x [height] canvas pre-filled with opaque BLACK and returns
+     * the result as row-major ARGB pixels.
+     *
+     * The BLACK fill stands in for whatever lies behind the overlay window: anything the drawing
+     * fails to cover reads back as black instead of as an ambiguous transparent pixel.
+     */
+    fun renderOverBlack(
+        width: Int,
+        height: Int,
+        draw: (Canvas) -> Unit,
+    ): IntArray {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        try {
+            val canvas = Canvas(bitmap)
+            canvas.drawColor(Color.BLACK)
+            draw(canvas)
+            val pixels = IntArray(width * height)
+            bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+            return pixels
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    /**
+     * Intersection-over-union of [mask] and [template], which must be the same size and are
+     * compared in place (no position or scale sweep, unlike
+     * [com.gb4pc.e2e.visual.ShapeMatcher.classify]): a rendered overlay is already aligned with
+     * the template generated at its own dimensions, and holding the alignment fixed keeps the
+     * comparison sensitive to a shape that has shifted as well as one that has changed.
+     */
+    fun alignedIoU(
+        mask: MaskData,
+        template: MaskData,
+    ): Float {
+        require(mask.width == template.width && mask.height == template.height) {
+            "alignedIoU needs equal sizes: ${mask.width}x${mask.height} vs " +
+                "${template.width}x${template.height}"
+        }
+        var intersection = 0
+        var union = 0
+        for (i in mask.bits.indices) {
+            val inMask = mask.bits[i]
+            val inTemplate = template.bits[i]
+            if (inMask && inTemplate) intersection++
+            if (inMask || inTemplate) union++
+        }
+        return if (union == 0) 1f else intersection.toFloat() / union
+    }
+}

--- a/app/src/test/java/com/gb4pc/overlay/SquircleDrawableRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/SquircleDrawableRobolectricTest.kt
@@ -1,0 +1,86 @@
+package com.gb4pc.overlay
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Robolectric regression tests for [SquircleDrawable]'s clip-path sizing.
+ *
+ * Issue #767 follow-up: CENTER_CROP (introduced by #767 for photo thumbnails) leaves a wrapped
+ * drawable's own `bounds` at its raw, unscaled intrinsic size, which is not square for a
+ * non-square photo. [SquircleDrawable] must clip against the centered square sub-region of
+ * those bounds ([centeredSquareRegion]), not the full bounds, or the squircle's curvature ends
+ * up concentrated almost entirely outside CENTER_CROP's visible crop window, rendering the
+ * button's corners essentially sharp instead of rounded.
+ *
+ * These tests read [SquircleDrawable]'s private `pathWidth` / `pathHeight` cache fields
+ * (populated by plain field assignment, not native graphics) after a real `draw()` call,
+ * rather than asserting on rendered pixels: OverlayManagerRobolectricTest documents that this
+ * Robolectric setup does not apply a translated `Canvas.concat`/`translate` to a subsequent
+ * bitmap draw, which would make a pixel-level assertion unreliable here.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SquircleDrawableRobolectricTest {
+    private fun pathDimensionsAfterDraw(
+        w: Int,
+        h: Int,
+    ): Pair<Int, Int> {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val squircle = SquircleDrawable(BitmapDrawable(context.resources, bitmap))
+        squircle.setBounds(0, 0, w, h)
+
+        val canvasSide = maxOf(w, h)
+        squircle.draw(Canvas(Bitmap.createBitmap(canvasSide, canvasSide, Bitmap.Config.ARGB_8888)))
+
+        val widthField = SquircleDrawable::class.java.getDeclaredField("pathWidth").apply { isAccessible = true }
+        val heightField = SquircleDrawable::class.java.getDeclaredField("pathHeight").apply { isAccessible = true }
+        return (widthField.get(squircle) as Int) to (heightField.get(squircle) as Int)
+    }
+
+    @Test
+    fun `clip path is built from the square crop window for a wide non-square drawable`() {
+        val (pathW, pathH) = pathDimensionsAfterDraw(160, 90)
+        assertEquals(
+            "Issue #767: clip path width must equal the short edge (CENTER_CROP's crop " +
+                "window), not the raw drawable width.",
+            90,
+            pathW,
+        )
+        assertEquals(
+            "Issue #767: clip path height must equal the short edge.",
+            90,
+            pathH,
+        )
+    }
+
+    @Test
+    fun `clip path is built from the square crop window for a tall non-square drawable`() {
+        val (pathW, pathH) = pathDimensionsAfterDraw(90, 160)
+        assertEquals(
+            "Issue #767: clip path width must equal the short edge.",
+            90,
+            pathW,
+        )
+        assertEquals(
+            "Issue #767: clip path height must equal the short edge (CENTER_CROP's crop " +
+                "window), not the raw drawable height.",
+            90,
+            pathH,
+        )
+    }
+
+    @Test
+    fun `clip path matches the full bounds for an already-square drawable`() {
+        val (pathW, pathH) = pathDimensionsAfterDraw(64, 64)
+        assertEquals("Square bounds must be unaffected by the Issue #767 follow-up.", 64, pathW)
+        assertEquals("Square bounds must be unaffected by the Issue #767 follow-up.", 64, pathH)
+    }
+}

--- a/app/src/test/java/com/gb4pc/overlay/SquircleDrawableRobolectricTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/SquircleDrawableRobolectricTest.kt
@@ -3,15 +3,22 @@ package com.gb4pc.overlay
 import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import androidx.test.core.app.ApplicationProvider
+import com.gb4pc.e2e.visual.MaskData
+import com.gb4pc.e2e.visual.PixelMask
+import com.gb4pc.e2e.visual.ShapeTemplates
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+import kotlin.math.min
 
 /**
- * Robolectric regression tests for [SquircleDrawable]'s clip-path sizing.
+ * Pixel-level regression tests for [SquircleDrawable]'s clip shape.
  *
  * Issue #767 follow-up: CENTER_CROP (introduced by #767 for photo thumbnails) leaves a wrapped
  * drawable's own `bounds` at its raw, unscaled intrinsic size, which is not square for a
@@ -20,67 +27,126 @@ import org.robolectric.RobolectricTestRunner
  * up concentrated almost entirely outside CENTER_CROP's visible crop window, rendering the
  * button's corners essentially sharp instead of rounded.
  *
- * These tests read [SquircleDrawable]'s private `pathWidth` / `pathHeight` cache fields
- * (populated by plain field assignment, not native graphics) after a real `draw()` call,
- * rather than asserting on rendered pixels: OverlayManagerRobolectricTest documents that this
- * Robolectric setup does not apply a translated `Canvas.concat`/`translate` to a subsequent
- * bitmap draw, which would make a pixel-level assertion unreliable here.
+ * Each test draws the real drawable over a BLACK backdrop and inspects the pixels it actually
+ * covered, so what is asserted is the shape a user would see rather than an internal field.
  */
 @RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
 class SquircleDrawableRobolectricTest {
-    private fun pathDimensionsAfterDraw(
+    @Test
+    fun `wide drawable is clipped to a squircle filling its centered square crop window`() {
+        assertClipsToCenteredSquareSquircle(160, 90)
+    }
+
+    @Test
+    fun `tall drawable is clipped to a squircle filling its centered square crop window`() {
+        assertClipsToCenteredSquareSquircle(90, 160)
+    }
+
+    @Test
+    fun `square drawable is clipped to a squircle filling its whole bounds`() {
+        assertClipsToCenteredSquareSquircle(64, 64)
+    }
+
+    /**
+     * Asserts the drawn shape of a [w] x [h] [SquircleDrawable] is a squircle filling the
+     * centered square sub-region of those bounds, which is exactly the window CENTER_CROP shows
+     * inside this codebase's always-square overlay.
+     */
+    private fun assertClipsToCenteredSquareSquircle(
         w: Int,
         h: Int,
-    ): Pair<Int, Int> {
+    ) {
+        val side = min(w, h)
+        val expected = centeredSquareRegion(w, h)
+        val drawn = drawnShape(w, h)
+
+        assertEquals(
+            "Issue #767: the clip must start at the crop window's left edge for a $w x $h drawable.",
+            expected.left,
+            drawn.bboxLeft,
+        )
+        assertEquals(
+            "Issue #767: the clip must start at the crop window's top edge for a $w x $h drawable.",
+            expected.top,
+            drawn.bboxTop,
+        )
+        assertEquals(
+            "Issue #767: the clip must end at the crop window's right edge for a $w x $h drawable.",
+            expected.left + side,
+            drawn.bboxRight,
+        )
+        assertEquals(
+            "Issue #767: the clip must end at the crop window's bottom edge for a $w x $h drawable.",
+            expected.top + side,
+            drawn.bboxBottom,
+        )
+
+        // Shape, not merely extent: a square clip over the same crop window would satisfy every
+        // bbox check above.
+        val template = squircleAt(w, h, expected.left, expected.top, side)
+        val iou = PixelRender.alignedIoU(drawn, template)
+        assertTrue(
+            "Issue #767: a $w x $h drawable must be clipped to a superellipse filling its " +
+                "${side}px crop window (IoU $iou, min $MIN_IOU).",
+            iou >= MIN_IOU,
+        )
+    }
+
+    /**
+     * Draws a [w] x [h] [SquircleDrawable] wrapping a solid BLUE bitmap over BLACK and returns
+     * the mask of the BLUE pixels it covered: the clip shape, made visible.
+     */
+    private fun drawnShape(
+        w: Int,
+        h: Int,
+    ): MaskData {
         val context: Application = ApplicationProvider.getApplicationContext()
-        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-        val squircle = SquircleDrawable(BitmapDrawable(context.resources, bitmap))
+        val solidBlue = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        Canvas(solidBlue).drawColor(Color.BLUE)
+        val squircle = SquircleDrawable(BitmapDrawable(context.resources, solidBlue))
         squircle.setBounds(0, 0, w, h)
 
-        val canvasSide = maxOf(w, h)
-        squircle.draw(Canvas(Bitmap.createBitmap(canvasSide, canvasSide, Bitmap.Config.ARGB_8888)))
-
-        val widthField = SquircleDrawable::class.java.getDeclaredField("pathWidth").apply { isAccessible = true }
-        val heightField = SquircleDrawable::class.java.getDeclaredField("pathHeight").apply { isAccessible = true }
-        return (widthField.get(squircle) as Int) to (heightField.get(squircle) as Int)
+        val pixels = PixelRender.renderOverBlack(w, h) { canvas -> squircle.draw(canvas) }
+        return PixelMask.scan(pixels, w, h, 0, 0, 255, PixelRender.TOLERANCE)
     }
 
-    @Test
-    fun `clip path is built from the square crop window for a wide non-square drawable`() {
-        val (pathW, pathH) = pathDimensionsAfterDraw(160, 90)
-        assertEquals(
-            "Issue #767: clip path width must equal the short edge (CENTER_CROP's crop " +
-                "window), not the raw drawable width.",
-            90,
-            pathW,
-        )
-        assertEquals(
-            "Issue #767: clip path height must equal the short edge.",
-            90,
-            pathH,
-        )
-    }
-
-    @Test
-    fun `clip path is built from the square crop window for a tall non-square drawable`() {
-        val (pathW, pathH) = pathDimensionsAfterDraw(90, 160)
-        assertEquals(
-            "Issue #767: clip path width must equal the short edge.",
-            90,
-            pathW,
-        )
-        assertEquals(
-            "Issue #767: clip path height must equal the short edge (CENTER_CROP's crop " +
-                "window), not the raw drawable height.",
-            90,
-            pathH,
+    /** A [w] x [h] mask holding a [side]-sized squircle at ([left], [top]). */
+    private fun squircleAt(
+        w: Int,
+        h: Int,
+        left: Int,
+        top: Int,
+        side: Int,
+    ): MaskData {
+        val shape = ShapeTemplates.squircle(side, side)
+        val bits = BooleanArray(w * h)
+        for (y in 0 until side) {
+            for (x in 0 until side) {
+                if (shape.bits[y * side + x]) bits[(y + top) * w + (x + left)] = true
+            }
+        }
+        return MaskData(
+            bits = bits,
+            width = w,
+            height = h,
+            bboxLeft = left,
+            bboxTop = top,
+            bboxRight = left + side,
+            bboxBottom = top + side,
+            centroidX = left + shape.centroidX,
+            centroidY = top + shape.centroidY,
+            pixelCount = shape.pixelCount,
         )
     }
 
-    @Test
-    fun `clip path matches the full bounds for an already-square drawable`() {
-        val (pathW, pathH) = pathDimensionsAfterDraw(64, 64)
-        assertEquals("Square bounds must be unaffected by the Issue #767 follow-up.", 64, pathW)
-        assertEquals("Square bounds must be unaffected by the Issue #767 follow-up.", 64, pathH)
+    private companion object {
+        /**
+         * Minimum IoU between the drawn clip and the superellipse template. The drawable
+         * approximates the superellipse with a 256-gon and the clip is not anti-aliased, so a
+         * correct clip lands a little under a perfect match at these sizes; a square clip over
+         * the same crop window scores about 0.9 against the same template.
+         */
+        const val MIN_IOU = 0.95f
     }
 }

--- a/app/src/test/java/com/gb4pc/overlay/SquircleDrawableTest.kt
+++ b/app/src/test/java/com/gb4pc/overlay/SquircleDrawableTest.kt
@@ -5,6 +5,7 @@ import com.gb4pc.e2e.visual.MaskData
 import com.gb4pc.e2e.visual.Shape
 import com.gb4pc.e2e.visual.ShapeMatcher
 import com.gb4pc.e2e.visual.ShapeTemplates
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.abs
@@ -181,5 +182,52 @@ class SquircleDrawableTest {
                 "ShapeTemplates.squircle (${templateMask.pixelCount}), got ${relDiff * 100}%",
             relDiff <= 0.05,
         )
+    }
+
+    // ── Issue #767 follow-up: centeredSquareRegion ───────────────────────────
+
+    @Test
+    fun `centeredSquareRegion for a wide rect crops the horizontal axis`() {
+        val region = centeredSquareRegion(160, 90)
+        assertEquals(90, region.side)
+        assertEquals(35, region.left)
+        assertEquals(0, region.top)
+    }
+
+    @Test
+    fun `centeredSquareRegion for a tall rect crops the vertical axis`() {
+        val region = centeredSquareRegion(90, 160)
+        assertEquals(90, region.side)
+        assertEquals(0, region.left)
+        assertEquals(35, region.top)
+    }
+
+    @Test
+    fun `centeredSquareRegion for an already-square rect is a no-op`() {
+        val region = centeredSquareRegion(64, 64)
+        assertEquals(64, region.side)
+        assertEquals(0, region.left)
+        assertEquals(0, region.top)
+    }
+
+    @Test
+    fun `centeredSquareRegion always fits within the original rect for the issue's edge ratios`() {
+        // (w, h) pairs at the issue's four edge ratios (16:9, 4:3 wide; 9:16, 3:4 tall), at a
+        // pixel scale on the order of a typical Pixel Camera output photo.
+        val sizes =
+            listOf(
+                4032 to 2268, // 16:9 wide
+                4032 to 3024, // 4:3 wide
+                2268 to 4032, // 9:16 tall
+                3024 to 4032, // 3:4 tall
+            )
+        for ((w, h) in sizes) {
+            val region = centeredSquareRegion(w, h)
+            assertEquals("side must equal the short edge for $w x $h", minOf(w, h), region.side)
+            assertTrue("left must be non-negative for $w x $h", region.left >= 0)
+            assertTrue("top must be non-negative for $w x $h", region.top >= 0)
+            assertTrue("square must fit within width for $w x $h", region.left + region.side <= w)
+            assertTrue("square must fit within height for $w x $h", region.top + region.side <= h)
+        }
     }
 }


### PR DESCRIPTION
Fixes #767.

## Problem

The overlay's photo-thumbnail `ImageView` used `ImageView.ScaleType.FIT_CENTER`, which scales an image so its **long** edge fits inside the button.
For non-square photos (16:9, 4:3, 9:16, 3:4) that leaves letterbox bars along the short axis instead of filling the button.

## Fix

Two commits of production code:

1. `OverlayManager` switches the overlay's thumbnail `ImageView` to `ImageView.ScaleType.CENTER_CROP`, which scales so the **short** edge fills the view and crops the long edge.
2. `SquircleDrawable` clips against the centered square sub-region of its bounds (`centeredSquareRegion`) rather than the full bounds.
   CENTER_CROP leaves a wrapped drawable's own `bounds` at its raw, unscaled intrinsic size (the crop and scale are applied through a `Canvas` matrix at draw time), so for a non-square photo the squircle was being built against a non-square canvas and nearly all of its curvature landed outside the window CENTER_CROP actually displays, rendering the button's corners essentially sharp.
   Since this codebase's overlay window is always square, that centered square sub-region is exactly the window CENTER_CROP crops to.
   A no-op for the already-square gallery icon.

## Tests

The acceptance test is the one written into issue #767, run for real, with no manual step:

`OverlayThumbnailFitPixelTest` builds a fixture photo per the issue's rules for each of its four edge ratios (16:9, 4:3, 9:16, 3:4), at Pixel Camera output resolution: a solid BLUE square of the photo's short edge, centred, with every other pixel RED.
Each fixture is served through the content resolver and displayed by the real `showLatestPhotoThumbnail()` path (background decode, main-looper hand-off, `SquircleDrawable(BitmapDrawable(...))` wrapping), then the overlay button is rendered over a BLACK backdrop and scanned:

- no pixel matches RED, so the reverse-letterbox bars were cropped away rather than shown;
- every pixel inside the button's squircle is BLUE, so no BLACK letterbox gap survives;
- the BLUE region spans the button edge to edge on both axes;
- the BLUE region is still superellipse-shaped rather than square, so filling the button did not cost the corner rounding.

Both halves of the fix are covered: restoring `FIT_CENTER` leaves 9.5k px (4:3) to 17k px (16:9) of the button rendering BLACK, and clipping the squircle against the photo's raw bounds again drops the BLUE region's superellipse IoU from ~0.99 to ~0.94 as the corners go square.
Both were run to confirm the test fails in each case.

This needs no emulator, no device, and no camera app.
The only obstacle was Robolectric's graphics mode: the default LEGACY mode stubs drawing out entirely, so every pixel readback comes back untouched, which is what earlier revisions of this PR mistook for an inherent limitation.
`@GraphicsMode(NATIVE)` turns on the real Skia-backed pipeline; the four ratios then run in about a second each.
The scan side reuses `PixelMask` and `ShapeTemplates`, the pure-JVM helpers the on-device E2E visual suite already uses, so a unit test and an E2E test describe a rendered button the same way.

With real rendering available, two tests added earlier in this PR no longer needed reflection:

- `SquircleDrawableRobolectricTest` now draws the real `SquircleDrawable` and asserts the shape of the pixels it covered (bounding box equals the centered square crop window; covered region matches a superellipse template filling it at IoU >= 0.95, where a square clip scores about 0.9), instead of reading the private `pathWidth` / `pathHeight` fields. Same wide, tall, and square cases; still fails if the clip is built from raw bounds.
- `CENTER_CROP matrix fits the short edge and crops the long edge for every edge ratio` is **deleted**. It read the framework's private `ImageView.mDrawMatrix` by reflection to re-derive Android's own CENTER_CROP arithmetic; `OverlayThumbnailFitPixelTest` asserts the visible result of that arithmetic for the same four edge ratios without depending on a private framework field. The scale-type test beside it is unchanged and still pins the enum.

No existing test's requirements were loosened.

`:app:testDebugUnitTest` (305 tests) and `ktlint` are clean locally.

## Test plan

Fully automated; nothing manual remains.
`OverlayThumbnailFitPixelTest` is the issue's acceptance criteria, executed in `:app:testDebugUnitTest`.
