### PR TITLE
Do not merge: verify PR #768 keyguard-reassertion toast visibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,6 +441,21 @@ jobs:
           cp -r app/build/outputs/androidTest-results/connected/debug/. \
             app/build/outputs/androidTest-results/instrumented/
 
+      - name: (verify-pr-768) Force secure keyguard reassertion before PixelCameraOverlayE2ETest
+        # Throwaway step for issue #769 (verification of PR #768 / issue #765): puts the
+        # display to sleep, which re-engages the secure PIN keyguard scripts/setup-e2e-emulator.sh
+        # configures, then wakes the display back up without dismissing it. This reproduces the
+        # "keyguard reasserted between CI steps" scenario the issue describes, so the next step's
+        # own start-of-test toast has a locked secure keyguard to contend with. Not part of the
+        # PR under test; removed before this test branch's throwaway PR is closed.
+        if: needs.check-diff.outputs.needs_full_build == 'true'
+        run: |
+          ADB="$ANDROID_HOME/platform-tools/adb"
+          "$ADB" shell input keyevent 223 # KEYCODE_SLEEP: engages the secure PIN keyguard
+          sleep 2
+          "$ADB" shell input keyevent 224 # KEYCODE_WAKEUP: display on, secure keyguard still locked
+          sleep 2
+
       - name: Run PixelCameraOverlayE2ETest
         # No `continue-on-error` (issue #309): record the real outcome and defer
         # the pass/fail verdict to the "Gate on test failures" step.
@@ -502,9 +517,11 @@ jobs:
             bash scripts/filter_logcat.sh | tee results/e2e-overlay-logcat.txt
 
       - name: Pull PixelCameraOverlayE2ETest video on failure
-        # Only pull and upload the recording when the overlay E2E suite failed (issue #520).
-        # On a green run the file is left on the device and discarded when the emulator exits.
-        if: always() && needs.check-diff.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
+        # (verify-pr-768): condition temporarily loosened to always() (was
+        # `... && steps.run_overlay_e2e.outputs.outcome == 'failure'`, issue #520's
+        # original intent) so issue #769's verification run captures the video regardless of the
+        # suite's outcome. Restored before this throwaway test branch's PR is closed.
+        if: always() && needs.check-diff.outputs.needs_full_build == 'true'
         run: |
           ADB="$ANDROID_HOME/platform-tools/adb"
           mkdir -p /tmp/e2e-videos
@@ -512,7 +529,8 @@ jobs:
             echo "WARNING: could not pull e2e-overlay.mp4"
 
       - name: Upload PixelCameraOverlayE2ETest video
-        if: always() && needs.check-diff.outputs.needs_full_build == 'true' && steps.run_overlay_e2e.outputs.outcome == 'failure'
+        # (verify-pr-768): condition temporarily loosened to always(), see the pull step above.
+        if: always() && needs.check-diff.outputs.needs_full_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-video-PixelCameraOverlayE2ETest

--- a/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/GalleryButtonVisualE2ETest.kt
@@ -19,6 +19,8 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
 import kotlin.math.sqrt
@@ -50,9 +52,6 @@ class GalleryButtonVisualE2ETest {
     @get:Rule
     val screenshotRule = ScreenshotTestRule()
 
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context = instrumentation.targetContext
     private val fixture =
@@ -60,6 +59,29 @@ class GalleryButtonVisualE2ETest {
             context = context,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761 / #765). The suite's own setUp() only
+    // wires fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure
+    // keyguard scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast
+    // has already fired; if the keyguard has reasserted between CI steps the marker would be
+    // occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() = fixture.setUp()

--- a/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
+++ b/app/src/androidTest/java/com/gb4pc/e2e/PixelCameraOverlayE2ETest.kt
@@ -8,6 +8,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -53,15 +55,35 @@ class PixelCameraOverlayE2ETest {
     @get:Rule
     val screenshotRule = ScreenshotTestRule()
 
-    @get:Rule
-    val testNameToastRule = TestNameToastRule()
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val fixture =
         E2EFixture(
             context = instrumentation.targetContext,
             uiAutomation = instrumentation.uiAutomation,
         )
+
+    // Dismiss the PIN-secured keyguard before the start-of-test toast so the slate renders over the
+    // app UI rather than behind the lock screen (issue #761 / #765). The suite's own setUp() only
+    // wires fixture.wakeAndDismissKeyguard() (a swipe), which does nothing against the secure
+    // keyguard scripts/setup-e2e-emulator.sh configures, and it runs from @Before, after the toast
+    // has already fired; if the keyguard has reasserted between CI steps the marker would be
+    // occluded.
+    private val keyguardDismiss =
+        object : ExternalResource() {
+            override fun before() {
+                fixture.dismissSecureKeyguard()
+            }
+        }
+
+    private val testNameToastRule = TestNameToastRule()
+
+    @get:Rule
+    val ruleChain: RuleChain =
+        // keyguardDismiss is outermost so the secure keyguard is cleared before testNameToastRule
+        // (innermost) shows the slate; the toast's ~3s duration therefore sits after dismissal,
+        // preserving the keyguard-dismissal-then-launch ordering TestNameToastRule.kt documents (the
+        // camera launch itself happens later, in each test body, via fixture.launchPixelCamera()).
+        RuleChain.outerRule(keyguardDismiss).around(testNameToastRule)
 
     @Before
     fun setUp() = fixture.setUp()


### PR DESCRIPTION
Do not merge. Throwaway verification PR for issue #769 (before-merging item for PR #768 / issue #765).

Items under test:
- Confirm the start-of-test toast in `PixelCameraOverlayE2ETest` renders over the app UI (not behind the lock screen) when the secure keyguard has reasserted before the suite runs, following the pattern PR #768 introduced (`RuleChain.outerRule(dismissSecureKeyguard).around(testNameToastRule)`).

This branch is PR #768's exact head commit plus one throwaway commit that:
1. Forces the secure keyguard to reassert (`KEYCODE_SLEEP` then `KEYCODE_WAKEUP`) immediately before the `Run PixelCameraOverlayE2ETest` step.
2. Loosens the `Pull`/`Upload PixelCameraOverlayE2ETest video` steps' condition to `always()` so the recording is captured regardless of the suite's outcome.

Mirrors the method used for issue #764 / PR #763 (see test PR #766).

This PR will be closed once evidence is collected. Its branch is left in place as the evidence trail.
