### PR TITLE
Add a manual workflow to regenerate the Gradle toolchain

### DIFF
--- a/.github/workflows/regenerate-gradle-toolchain.yml
+++ b/.github/workflows/regenerate-gradle-toolchain.yml
@@ -1,0 +1,131 @@
+name: Regenerate Gradle toolchain (wrapper + verification metadata)
+
+# Manual, deliberate trigger only. Lives on main so workflow_dispatch registers;
+# dispatch it with ref=<branch> to run a branch's version. Produces an artifact
+# for human review and commit; it never pushes.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    # Never inherit GitHub's 360-minute default (issue #611); a cold run is
+    # 20-45 minutes, and the dangerous failure mode is slow, not loud.
+    timeout-minutes: 90
+    env:
+      GRADLE_VERSION: "9.5.1"
+      DIST_SHA256: "bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f"
+      WRAPPER_JAR_SHA256: "497c8c2a7e5031f6aa847f88104aa80a93532ec32ee17bdb8d1d2f67a194a9c7"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+        with:
+          packages: ''
+
+      - name: Pin the SDK components explicitly
+        # The generator is this repo's toolchain provenance; versions are
+        # declared here, not chosen implicitly by AGP at run time.
+        # platform-tools is required: app/build.gradle.kts resolves adb via
+        # sdkComponents.sdkDirectory + platform-tools/adb.
+        run: sdkmanager --install "build-tools;36.0.0" "platforms;android-35" "platform-tools"
+
+      - name: Download and verify standalone Gradle
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+            -o /tmp/gradle.zip
+          echo "${DIST_SHA256}  /tmp/gradle.zip" | sha256sum -c -
+          unzip -q /tmp/gradle.zip -d /opt
+          echo "/opt/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+
+      - name: Create a throwaway release keystore
+        # Exercises the release signing DSL (app/build.gradle.kts gates it on
+        # KEYSTORE_PATH), which is otherwise dead code on every pre-merge run;
+        # AGP 9 would first meet it after merge. Never leaves the runner.
+        run: |
+          set -euo pipefail
+          keytool -genkeypair -keystore "$RUNNER_TEMP/throwaway.jks" \
+            -storepass throwaway123 -keypass throwaway123 -alias throwaway \
+            -keyalg RSA -keysize 2048 -validity 1 -dname "CN=generator-throwaway"
+          {
+            echo "KEYSTORE_PATH=$RUNNER_TEMP/throwaway.jks"
+            echo "KEYSTORE_PASSWORD=throwaway123"
+            echo "KEY_ALIAS=throwaway"
+            echo "KEY_PASSWORD=throwaway123"
+          } >> "$GITHUB_ENV"
+
+      - name: Delete verification metadata for from-scratch regeneration
+        # Prunes stale pins and disables enforcement for this run's generation.
+        # This rm deliberately lives HERE, not in the regeneration script: the
+        # script is also run locally, where a failure after a delete would
+        # leave the working tree silently unverified. Guard check (e)
+        # allowlists exactly this workflow file for this pattern.
+        run: rm gradle/verification-metadata.xml
+
+      - name: Regenerate verification-metadata.xml from scratch
+        # Runs on the standalone Gradle (the committed wrapper cannot run the
+        # AGP 9 build). Metadata-first ordering lets the wrapper step below
+        # run under enforcement of the fresh pins.
+        run: GRADLE_BIN=gradle bash scripts/regenerate-gradle-verification.sh
+
+      - name: Regenerate the wrapper matched set (enforced against the fresh pins)
+        run: |
+          set -euo pipefail
+          gradle wrapper --gradle-version "${GRADLE_VERSION}" \
+            --gradle-distribution-sha256-sum "${DIST_SHA256}"
+          # The produced wrapper JAR must match Gradle's published checksum.
+          echo "${WRAPPER_JAR_SHA256}  gradle/wrapper/gradle-wrapper.jar" | sha256sum -c -
+
+      - name: Run the build-integrity guard tests
+        run: bash scripts/test_verification_metadata.sh
+
+      - name: Emit the pinned-component listing for human review
+        run: |
+          python3 - <<'PY' | sort > /tmp/metadata-components.txt
+          import xml.etree.ElementTree as ET
+          root = ET.parse("gradle/verification-metadata.xml").getroot()
+          for el in root.iter():
+              if el.tag.rsplit("}", 1)[-1] == "component":
+                  print(f'{el.get("group")}:{el.get("name")}:{el.get("version")}')
+          PY
+          wc -l /tmp/metadata-components.txt
+
+      - name: Bundle the matched set (tar preserves the gradlew exec bit)
+        run: |
+          tar -czf /tmp/gradle-toolchain-regenerated.tar.gz \
+            gradlew gradlew.bat \
+            gradle/wrapper/gradle-wrapper.jar \
+            gradle/wrapper/gradle-wrapper.properties \
+            gradle/verification-metadata.xml \
+            -C /tmp metadata-components.txt
+
+      - name: Upload regenerated artifacts for human review and commit
+        uses: actions/upload-artifact@v7
+        with:
+          name: gradle-toolchain-regenerated
+          path: /tmp/gradle-toolchain-regenerated.tar.gz
+
+      - name: Upload failure diagnostics
+        # A failed run's metadata can be silently under-populated (Gradle
+        # writes the file even on build failure); quarantined under a name
+        # that screams not to commit it. Diagnostic use only.
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gradle-toolchain-partial-DO-NOT-COMMIT
+          path: |
+            gradle/verification-metadata.xml
+            gradle/wrapper/gradle-wrapper.properties
+            **/build/reports/
+          if-no-files-found: ignore


### PR DESCRIPTION
Step 2 of #774: the generator workflow, landed on `main` first so `workflow_dispatch` registers (GitHub only registers dispatch triggers from the default branch; a dispatch then runs the selected ref's version).

The workflow is inert here: manual trigger only, `permissions: contents: read`, not fork-triggerable, and it never pushes; it produces an artifact for human review and commit.
Dispatching it against `main` would merely fail configuration (AGP 8.7.3 cannot run under Gradle 9.5.1), which is expected and harmless; its real target is the future migration branch (Step 3 of #774).

Content is byte-exact from the plan in #774, including the pinned checksums (`gradle-9.5.1-bin.zip` and the published wrapper-JAR SHA-256), the SHA-pinned third-party action, `timeout-minutes: 90`, the metadata-first step ordering, and the tar bundling that preserves the `gradlew` exec bit.

Validation: YAML parses; `scripts/test_verification_metadata.sh` passes 8/8 with the file present (check (e) is not tripped: the workflow contains no `--dependency-verification` flag); the diff adds exactly this one file.

Note for reviewers: the comment in the delete step refers to a check (e) deletion-pattern allowlist that does not exist yet; that guard extension arrives with the Step 3 branch prep, which must allowlist exactly this filename.

🦀

