### PR TITLE
Narrow label_by_title's agents rule from review\w+ to reviewers?

### DIFF
--- a/scripts/ci/labels/label_by_title.py
+++ b/scripts/ci/labels/label_by_title.py
@@ -68,7 +68,7 @@ LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
         rf"|{_B}bylines?{_B}"
         rf"|{_B}verif\w+{_B}"
         rf"|{_B}author{_B}"
-        rf"|{_B}review\w+{_B}"
+        rf"|{_B}reviewers?{_B}"
         rf"|{_B}orchestrat\w*"
         rf"|{_B}ci[\W_]*monitor\w*"
         rf"|{_B}sub[\W_]?agent\w*",

--- a/scripts/ci/labels/test_label_by_title.py
+++ b/scripts/ci/labels/test_label_by_title.py
@@ -175,7 +175,13 @@ class TestMatchingLabelsAgents(unittest.TestCase):
 
     def test_review_requires_suffix(self):
         self.assertIn("agents", lpt.matching_labels("Clarify Reviewer account sharing"))
+        self.assertIn("agents", lpt.matching_labels("Add a reviewers checklist"))
         self.assertNotIn("agents", lpt.matching_labels("Leave a review"))
+
+    def test_reviewing_and_reviewed_do_not_match(self):
+        self.assertNotIn("agents", lpt.matching_labels("Reviewing PRs takes too long"))
+        self.assertNotIn("agents", lpt.matching_labels("The reviewed manuscript needs edits"))
+        self.assertNotIn("agents", lpt.matching_labels("Collect reviews from beta testers"))
 
     def test_orchestrat_suffixes_match(self):
         self.assertIn("agents", lpt.matching_labels("Orchestrator directions: CI review loop"))


### PR DESCRIPTION
## Summary

- `scripts/ci/labels/label_by_title.py`'s `agents` label rule matched any `review\w+` (reviewing, reviewed, reviews, reviewer, reviewers), which pulled titles about generic reviewing into the `agents` label even when they had nothing to do with the AI Reviewer role.
- Narrowed the rule to `reviewers?`, so only "reviewer"/"reviewers" trigger the label. "Reviewing PRs takes too long" or "Collect reviews from beta testers" no longer match; "Clarify Reviewer account sharing" still does.

## Test plan

- [x] `cd scripts/ci/labels && python3 -m unittest test_label_by_title`: all 61 tests pass, including two new ones (`test_review_requires_suffix` extended, `test_reviewing_and_reviewed_do_not_match` added) that lock in the narrowed behavior.

🦀

