### PR TITLE
Add a by-file-changes labeling signal for PRs where every changed file is CI or test

### DIFF
--- a/.github/workflows/label-by-files.yml
+++ b/.github/workflows/label-by-files.yml
@@ -1,0 +1,33 @@
+name: Label PR by changed files
+
+# Applies labels to a pull request based on the set of files it changed,
+# when every changed file maps to the same label. See
+# scripts/ci/labels/label_by_files.py for the exact rule. Labels are only
+# ever added, never removed.
+#
+# A separate workflow from label-by-title.yml because the two signals want
+# different triggers: title labeling only needs to run when the title
+# itself changes, while this needs to run on every push (synchronize) and
+# has nothing to do on title edits or issue events.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-by-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Apply labels matching the changed files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 scripts/ci/labels/label_by_files.py

--- a/scripts/ci/labels/label_by_files.py
+++ b/scripts/ci/labels/label_by_files.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Apply labels to a pull request based on the set of files it changed.
+
+Unlike label_by_title.py (which matches a title against a regex per label),
+this module classifies each *changed path* and applies a label only when
+every changed path justifies it. See matching_labels() below for the exact
+rule--not duplicated here, to avoid this docstring drifting out of sync with
+the code.
+
+Two properties keep the rule safe:
+
+- An unclassified path contributes the empty label set, which empties the
+  intersection across all paths. So any file the map below does not
+  recognize disables the file signal entirely for that PR: adding a path
+  mapping can only ever make the signal fire more, and a gap in the map can
+  only ever make it fire less.
+- The empty file list returns [] (no labels) rather than vacuously matching
+  every label, since intersecting zero sets has no defined result.
+
+Labels are only ever added, never removed.
+
+Usage:
+    python3 scripts/ci/labels/label_by_files.py
+
+Exit code:
+    0  no labels matched, the changed-file list may be truncated, or labels
+       were applied successfully.
+    1  required configuration is missing/invalid, or a GitHub API call
+       failed.
+
+Required environment variables:
+    GITHUB_TOKEN        Personal access token or Actions secret with
+                        issues: write and pull-requests: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+    PR_NUMBER           Number of the pull request
+"""
+
+import os
+import re
+import sys
+import urllib.error
+
+import label_by_title
+
+# ---------------------------------------------------------------------------
+# Path classification
+# ---------------------------------------------------------------------------
+
+TEST_DIR_SEGMENTS = frozenset({"test", "androidTest", "sharedTest"})
+TEST_SCRIPT_BASENAME = re.compile(r"test_.+\.(py|sh)\Z")
+CI_PATH_PREFIXES = (".github/workflows/",)
+
+
+def labels_for_path(path: str) -> frozenset[str]:
+    """Return the labels *path* alone justifies (empty when it justifies none)."""
+    segments = path.split("/")
+    labels = set()
+    # segments[:-1] restricts this check to directories, so a file literally
+    # named "test" is not itself a test.
+    if TEST_DIR_SEGMENTS.intersection(segments[:-1]):
+        labels.add("automated tests")
+    if TEST_SCRIPT_BASENAME.match(segments[-1]):
+        labels.add("automated tests")
+    if path.startswith(CI_PATH_PREFIXES):
+        labels.add("ci")
+    return frozenset(labels)
+
+
+def matching_labels(paths: list[str]) -> list[str]:
+    """Return the labels every path in *paths* justifies; [] when *paths* is empty."""
+    if not paths:
+        return []
+    return sorted(frozenset.intersection(*(labels_for_path(p) for p in paths)))
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helper
+# ---------------------------------------------------------------------------
+
+# 10 pages of 100 files each. A PR with more than 1000 changed files is not a
+# case worth optimizing for; fetch_changed_files() returns None rather than
+# risk a verdict from a partial file list.
+MAX_PAGES = 10
+PER_PAGE = 100
+
+
+def fetch_changed_files(repo: str, pr_number: int, token: str) -> list[str] | None:
+    """Return every path changed in the pull request, or None if possibly truncated.
+
+    Paginates GET pulls/{pr_number}/files?per_page=100. Stops as soon as a
+    page comes back shorter than PER_PAGE (the normal end of the list) or
+    empty. If MAX_PAGES pages are consumed without ever seeing a short page,
+    the file list may continue beyond what was fetched, so this returns
+    None instead of a partial list.
+    """
+    paths: list[str] = []
+    page = 1
+    while page <= MAX_PAGES:
+        batch = label_by_title.gh_api(
+            f"repos/{repo}/pulls/{pr_number}/files?per_page={PER_PAGE}&page={page}",
+            token=token,
+        )
+        if not batch:
+            return paths
+        paths.extend(item["filename"] for item in batch)
+        if len(batch) < PER_PAGE:
+            return paths
+        page += 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number_str = os.environ.get("PR_NUMBER", "")
+
+    if not token:
+        print("Error: GITHUB_TOKEN not set.", file=sys.stderr)
+        return 1
+    if not repo:
+        print("Error: GITHUB_REPOSITORY not set.", file=sys.stderr)
+        return 1
+    if not pr_number_str:
+        print("Error: PR_NUMBER not set.", file=sys.stderr)
+        return 1
+
+    try:
+        pr_number = int(pr_number_str)
+    except ValueError:
+        print(f"Error: PR_NUMBER is not a valid integer: {pr_number_str!r}", file=sys.stderr)
+        return 1
+
+    try:
+        paths = fetch_changed_files(repo, pr_number, token)
+    except urllib.error.HTTPError as exc:
+        print(f"Error fetching changed files for #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Network error fetching changed files for #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+
+    if paths is None:
+        print(
+            f"Changed-file list for #{pr_number} may be truncated "
+            f"(hit {MAX_PAGES} pages)--nothing to do."
+        )
+        return 0
+
+    labels = matching_labels(paths)
+    if not labels:
+        print(f"No label rules matched the changed files on #{pr_number}--nothing to do.")
+        return 0
+
+    try:
+        label_by_title.gh_api(
+            f"repos/{repo}/issues/{pr_number}/labels",
+            token=token,
+            method="POST",
+            body={"labels": labels},
+        )
+        print(f"Applied labels {labels} to #{pr_number}.")
+    except urllib.error.HTTPError as exc:
+        print(f"Error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"Network error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Unit tests for label_by_files.py."""
+
+import os
+import sys
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import label_by_files as lbf  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# labels_for_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestLabelsForPath(unittest.TestCase):
+    def test_gradle_test_source_sets_give_automated_tests(self):
+        for path in (
+            "app/src/test/java/com/gb4pc/Foo.kt",
+            "app/src/androidTest/java/com/gb4pc/Foo.kt",
+            "app/src/sharedTest/java/com/gb4pc/Foo.kt",
+            "e2e-mock-gallery/src/test/java/com/gb4pc/Foo.kt",
+        ):
+            self.assertEqual(lbf.labels_for_path(path), frozenset({"automated tests"}), msg=path)
+
+    def test_test_script_basename_gives_automated_tests(self):
+        self.assertEqual(
+            lbf.labels_for_path("scripts/ci/labels/test_label_by_files.py"),
+            frozenset({"automated tests"}),
+        )
+
+    def test_workflow_yaml_gives_ci(self):
+        self.assertEqual(lbf.labels_for_path(".github/workflows/build.yml"), frozenset({"ci"}))
+
+    def test_unclassified_paths_give_empty_set(self):
+        for path in (
+            "app/src/main/java/com/gb4pc/Foo.kt",
+            "README.md",
+            "agents/pr_participation.md",
+            ".github/release.yml",
+            ".github/allowed-test-failures.txt",
+        ):
+            self.assertEqual(lbf.labels_for_path(path), frozenset(), msg=path)
+
+    def test_file_literally_named_test_is_not_itself_a_test(self):
+        # segments[:-1] restricts the directory-segment check to
+        # directories, so a *file* named "test" doesn't trigger the rule.
+        self.assertEqual(lbf.labels_for_path("app/src/main/test"), frozenset())
+
+
+# ---------------------------------------------------------------------------
+# matching_labels tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchingLabels(unittest.TestCase):
+    def test_empty_list_gives_no_labels(self):
+        self.assertEqual(lbf.matching_labels([]), [])
+
+    def test_all_test_paths_give_automated_tests(self):
+        self.assertEqual(
+            lbf.matching_labels(
+                [
+                    "app/src/test/java/com/gb4pc/FooTest.kt",
+                    "app/src/androidTest/java/com/gb4pc/BarTest.kt",
+                ]
+            ),
+            ["automated tests"],
+        )
+
+    def test_all_workflow_paths_give_ci(self):
+        self.assertEqual(
+            lbf.matching_labels([".github/workflows/build.yml", ".github/workflows/lint.yml"]),
+            ["ci"],
+        )
+
+    def test_mixing_test_and_workflow_files_gives_no_labels(self):
+        # Unanimity: a test path justifies only "automated tests" and a
+        # workflow path justifies only "ci", so their intersection is empty.
+        self.assertEqual(
+            lbf.matching_labels(
+                [
+                    "app/src/test/java/com/gb4pc/FooTest.kt",
+                    ".github/workflows/build.yml",
+                ]
+            ),
+            [],
+        )
+
+    def test_test_files_plus_one_product_file_gives_no_labels(self):
+        self.assertEqual(
+            lbf.matching_labels(
+                [
+                    "app/src/test/java/com/gb4pc/FooTest.kt",
+                    "app/src/androidTest/java/com/gb4pc/BarTest.kt",
+                    "app/src/main/java/com/gb4pc/Foo.kt",
+                ]
+            ),
+            [],
+        )
+
+    def test_pr_735_regression_fixture(self):
+        # #735: touches only app/src/androidTest, sharedTest, and test
+        # sources. This is one of the two misses issue #775 cited.
+        paths = [
+            "app/src/androidTest/java/com/gb4pc/e2e/visual/ColorMatch.kt",
+            "app/src/sharedTest/java/com/gb4pc/e2e/visual/PixelMask.kt",
+            "app/src/test/java/com/gb4pc/e2e/visual/PixelMaskTest.kt",
+        ]
+        self.assertEqual(lbf.matching_labels(paths), ["automated tests"])
+
+    def test_pr_665_regression_fixture(self):
+        # #665: a pure .github/workflows/*.yml version bump. The other miss
+        # issue #775 cited.
+        paths = [".github/workflows/strip-session-bylines.yml"]
+        self.assertEqual(lbf.matching_labels(paths), ["ci"])
+
+
+# ---------------------------------------------------------------------------
+# fetch_changed_files tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchChangedFiles(unittest.TestCase):
+    def _page(self, n: int, start: int = 0) -> list[dict]:
+        return [{"filename": f"file{i}.py"} for i in range(start, start + n)]
+
+    def test_stops_on_short_page(self):
+        page1 = self._page(100)
+        page2 = self._page(1, start=100)
+        with patch.object(lbf.label_by_title, "gh_api", side_effect=[page1, page2]) as mock_api:
+            result = lbf.fetch_changed_files("owner/repo", 42, "tok")
+        self.assertEqual(len(result), 101)
+        self.assertEqual(mock_api.call_count, 2)
+
+    def test_stops_on_empty_first_page(self):
+        with patch.object(lbf.label_by_title, "gh_api", return_value=[]) as mock_api:
+            result = lbf.fetch_changed_files("owner/repo", 42, "tok")
+        self.assertEqual(result, [])
+        mock_api.assert_called_once()
+
+    def test_single_short_page_returns_its_paths(self):
+        with patch.object(lbf.label_by_title, "gh_api", return_value=[{"filename": "a.py"}]):
+            result = lbf.fetch_changed_files("owner/repo", 42, "tok")
+        self.assertEqual(result, ["a.py"])
+
+    def test_hitting_max_pages_without_a_short_page_returns_none(self):
+        full_page = self._page(100)
+        with patch.object(lbf.label_by_title, "gh_api", return_value=full_page) as mock_api:
+            result = lbf.fetch_changed_files("owner/repo", 42, "tok")
+        self.assertIsNone(result)
+        self.assertEqual(mock_api.call_count, lbf.MAX_PAGES)
+
+    def test_uses_pull_files_endpoint(self):
+        with patch.object(lbf.label_by_title, "gh_api", return_value=[]) as mock_api:
+            lbf.fetch_changed_files("owner/repo", 42, "tok")
+        self.assertIn("pulls/42/files", mock_api.call_args[0][0])
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._env_patch = patch.dict(
+            os.environ,
+            {
+                "GITHUB_TOKEN": "test-token",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "PR_NUMBER": "42",
+            },
+        )
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_exit_1_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_when_pr_number_missing(self):
+        with patch.dict(os.environ, {"PR_NUMBER": ""}):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_when_pr_number_non_integer(self):
+        with patch.dict(os.environ, {"PR_NUMBER": "abc"}):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_no_api_call_when_no_files_match(self):
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+
+    def test_no_api_call_when_file_list_possibly_truncated(self):
+        with patch.object(lbf, "fetch_changed_files", return_value=None):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+
+    def test_posts_matching_label(self):
+        with patch.object(lbf, "fetch_changed_files", return_value=[".github/workflows/build.yml"]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_called_once()
+        args, kwargs = mock_api.call_args
+        self.assertEqual(args[0], "repos/owner/repo/issues/42/labels")
+        self.assertEqual(kwargs["method"], "POST")
+        self.assertEqual(kwargs["body"], {"labels": ["ci"]})
+
+    def test_exit_1_on_fetch_http_error(self):
+        error = urllib.error.HTTPError(url=None, code=404, msg="Not Found", hdrs=None, fp=None)
+        with patch.object(lbf, "fetch_changed_files", side_effect=error):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_on_fetch_url_error(self):
+        error = urllib.error.URLError("network error")
+        with patch.object(lbf, "fetch_changed_files", side_effect=error):
+            result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_on_apply_http_error(self):
+        error = urllib.error.HTTPError(url=None, code=422, msg="Unprocessable", hdrs=None, fp=None)
+        with patch.object(lbf, "fetch_changed_files", return_value=[".github/workflows/build.yml"]):
+            with patch.object(lbf.label_by_title, "gh_api", side_effect=error):
+                result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_1_on_apply_url_error(self):
+        error = urllib.error.URLError("network error")
+        with patch.object(lbf, "fetch_changed_files", return_value=[".github/workflows/build.yml"]):
+            with patch.object(lbf.label_by_title, "gh_api", side_effect=error):
+                result = lbf.main()
+        self.assertEqual(result, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `scripts/ci/labels/label_by_title.py` matches only on the PR/issue title, so a PR that is entirely test or CI-infrastructure work slips past every label when its title happens to use no trigger word. #775 cites #735 (touches only `app/src/androidTest`, `sharedTest`, and `test` sources) and #665 (a pure `.github/workflows/*.yml` version bump) as examples.
- Adds `scripts/ci/labels/label_by_files.py`, a sibling module that fetches a PR's changed files via the GitHub PR Files API and applies a label only when *every* changed path maps to that label:
  - Gradle test source-set directories (`test`, `androidTest`, `sharedTest`, matched as path segments so any module's test tree is covered) and `test_*.py` / `test_*.sh` scripts give `automated tests`.
  - Paths under `.github/workflows/` give `ci`.
  - An unclassified path contributes the empty label set, which empties the intersection across all paths in the PR. So any file the map doesn't recognize disables the file signal entirely for that PR: adding a path mapping can only ever make the signal fire more, and a gap in the map can only ever make it fire less. The empty file list also returns no labels rather than vacuously matching everything.
- `fetch_changed_files` paginates `pulls/{n}/files?per_page=100`, stopping on the first short page. If `MAX_PAGES` (10, so 1000 files) is exhausted without ever seeing a short page, it returns `None` ("possibly truncated"), and `main()` treats that exactly like "nothing matched": prints why, applies nothing, exits 0.
- Wires it up via a new `.github/workflows/label-by-files.yml`, separate from `label-by-title.yml` because the two signals want different triggers: title labeling only needs to run when the title itself changes (or on `issues` events), while the file signal needs `synchronize` (a later push can make a PR become all-test) and has nothing to do with title edits or issue events.
- Labels are only ever added, never removed, matching `label_by_title.py`'s existing contract.

This is the cheap slice of #775 described in that issue's implementation plan: no line-count thresholds, no new label taxonomy, no conflict resolution between the title and file signals, no backfill path. Those stay in #775.

Fixes #781.

## Implementation notes

- PR #780 (narrowing the `agents` title rule's `verif\w+` sub-pattern) is already merged, so this branches cleanly from current `main` with no rebase needed.
- Step 5 of #781's plan (narrowing the `agents` rule's `verif\w+` sub-pattern further, to cut a companion-word requirement) is explicitly scoped as a separate PR and is not included here.
- No change needed in `scripts/ci/test_label_existence_integration.py`: both `ci` and `automated tests` are already in `REQUIRED_LABELS` via `.github/release.yml`'s changelog-exclude list.

## Test plan

- [x] `python3 -m unittest discover -s scripts/ci/labels -p "test_*.py"`: all 289 tests pass, including 28 new ones in `test_label_by_files.py` (path classification table, `matching_labels` unanimity cases, regression fixtures pinning the real file lists of #735 and #665, `fetch_changed_files` pagination, and `main()`).
- [x] `ruff check` / `ruff format --check` clean on the new files.
- [ ] After merge, confirm from a PR touching only `.github/workflows/` that it picks up `ci` with no title trigger, per #781's verification note.

