### PR TITLE
Migrate sharedTest sourceSets wiring from srcDir to the directories set

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,12 +116,15 @@ android {
 
     // Shared pure-JVM test helpers compiled into both test and androidTest source sets.
     // AGP testFixtures does not support Kotlin on application modules (b/139438662).
+    // `directories` arrives prepopulated with the source set's defaults (src/<name>/java
+    // and src/<name>/kotlin) and is mutated in place, so `+=` adds to those defaults
+    // rather than replacing them.
     sourceSets {
         getByName("test") {
-            kotlin.srcDir("src/sharedTest/java")
+            kotlin.directories += "src/sharedTest/java"
         }
         getByName("androidTest") {
-            kotlin.srcDir("src/sharedTest/java")
+            kotlin.directories += "src/sharedTest/java"
         }
     }
 


### PR DESCRIPTION
🤖 Author

Fixes #793.

## The problem

AGP 9.1 deprecates `AndroidSourceDirectorySet.srcDir`, so configuring `app/build.gradle.kts` emitted a warning once per consuming source set:

```text
w: app/build.gradle.kts:121:20: 'fun srcDir(srcDir: Any): Any' is deprecated. Use `directories` mutable set instead.
w: app/build.gradle.kts:124:20: 'fun srcDir(srcDir: Any): Any' is deprecated. Use `directories` mutable set instead.
```

Deprecations of this shape become removals at the next major, so this lands before any AGP/Gradle 10 planning starts.

## The change

Both `kotlin.srcDir("src/sharedTest/java")` calls become `kotlin.directories += "src/sharedTest/java"`. That is the entire diff: five lines added, two removed, in one file.

## The behavior question that kept this out of #774's scope

#793 asked whether mutating `directories` appends to or replaces the default source directories. It appends.

`directories` is declared `val directories: MutableSet<String>` on `AndroidSourceDirectorySet` (confirmed against the AGP 9.1.0 `gradle-api` jar; `srcDir`, `srcDirs`, and `setSrcDirs` are all deprecated there, and `directories` is the only non-deprecated member besides `getName`). It arrives prepopulated with the source set's defaults, and it is the live set rather than a defensive copy, so `+=` adds to the defaults in place. Verified by printing the set on both sides of the mutation during configuration:

```text
test         BEFORE=[src/test/java, src/test/kotlin]
test         AFTER =[src/test/java, src/test/kotlin, src/sharedTest/java]
androidTest  BEFORE=[src/androidTest/java, src/androidTest/kotlin]
androidTest  AFTER =[src/androidTest/java, src/androidTest/kotlin, src/sharedTest/java]
```

The defensive-copy case was the real risk here: had `getDirectories()` returned a copy, `+=` would have silently done nothing and the shared helpers would have vanished from both suites. The output comparison below rules that out.

A comment in `app/build.gradle.kts` now records the append-not-replace semantics so the next reader does not have to re-derive it.

## Verification

Verified the same way #774 did, comparing against a pre-change baseline built from the same tree.

The full `*.class` listings under `built_in_kotlinc/debugUnitTest/` and `built_in_kotlinc/debugAndroidTest/` are byte-for-byte identical before and after (53 and 56 classes respectively). `ShapeMatcher`, `ScreenshotNaming`, `PixelMask`, `ShapeTemplates`, and `MaskData` all appear under both outputs, alongside every default-sourced class.

`:app:compileDebugUnitTestKotlin`, `:app:compileDebugAndroidTestKotlin`, and `:app:testDebugUnitTest` all pass locally: 305 unit tests, 305 PASS, 0 failures. The `srcDir` deprecation warning is gone, and no new build-script warning replaces it.

## Sweep for other deprecated srcDir uses

`srcDir`, `srcDirs`, and `setSrcDirs` appear nowhere else in the repository. The two `app/build.gradle.kts` sites this PR changes were the only ones, matching the issue's expectation.

## No new tests

This is a pure build-configuration refactor with no behavior change, and the regression guard already exists: `app/src/test/.../ShapeMatcherTest.kt` and `ScreenshotNamingTest.kt` consume the shared helpers from the unit-test source set, and five `androidTest` files consume them from the instrumentation source set. If this wiring ever stops appending to the defaults, both suites fail to compile. No existing test's requirements were loosened.

## Test plan

- [ ] Instrumentation suite (`:app:connectedDebugAndroidTest`) on a device or emulator. The androidTest source set is compiled but not executed here, since no device was available in this environment; its compilation is what proves the shared helpers are wired in.

