### PR TITLE
Seed the Gradle distribution, SDK, and Temurin 17 from a web-environment Setup script

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -32,7 +32,17 @@ It also provisions the Android SDK once into the cached image instead of once pe
 
 The Setup script and the session must agree on one home directory, because the wrapper looks for its cached distribution under the session's home.
 Here they do: sessions run as root with `HOME=/root`, which the script's default follows.
-If sessions ever run as a different user, set `SESSION_HOME` in the pasted block; the script fails rather than provisioning a home nothing reads, and logs which home it used.
+
+The script cannot confirm that agreement, and does not try to.
+It fails only when the resolved home does not exist, which is not the case that matters: if sessions move to another user while the Setup script still runs as root, `/root` is a perfectly good directory, so the script would seed `/root/.gradle`, report success, and provision a home no session ever reads.
+What it does instead is state its answer, as the first line of its output:
+
+```text
+[setup-environment] Provisioning for session home /root (owner root)
+```
+
+So if sessions ever run as a different user, set `SESSION_HOME` in the pasted block.
+Nothing will stop you if you forget; that log line is the only place it shows, which is why it is worth reading after a rebuild.
 
 ### Installing it
 

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -16,14 +16,54 @@ script for implementation details; each step is commented.
 
 ______________________________________________________________________
 
+## The environment Setup script (optional)
+
+`.claude/setup-environment.sh` is the checked-in copy of the block that goes in the **Setup script** field of the Claude Code for Web environment configuration (issue #792).
+That field runs as root once per environment build, before any session starts, and its filesystem output is cached across sessions.
+
+It is optional.
+Without it, sessions still work: the `SessionStart` hook provisions everything a build needs on its own.
+With it, two things stop being luck:
+
+- **The Gradle distribution.** The hook cannot cache it across sessions, so every session re-downloads it from `services.gradle.org`, which redirects to a `github.com` release asset. Whether the session proxy allows that has been observed to vary (hard-blocked in 2026-07 sessions, open in 2026-08 ones; see the comments on #774). The Setup script seeds the wrapper's own cache, so `./gradlew` starts offline.
+- **The JDK.** The base image ships JDK 21; CI and the generator workflow build on Temurin 17. The Setup script installs Temurin 17 to `/opt/java/temurin-17`, and the hook (STEP 0b) points `JAVA_HOME` there when it finds it, so a local run reproduces CI.
+
+It also provisions the Android SDK once into the cached image instead of once per session, using the same pins as the hook, whose skip guards then turn those steps into fast no-ops.
+
+### Installing it
+
+Paste the entire contents of `.claude/setup-environment.sh` into the environment's Setup script field, then rebuild the environment.
+The script is idempotent, so a rebuild over an already provisioned image is fast.
+
+### Keeping it in sync
+
+The pasted copy lives in a web form that CI cannot read, so **re-paste it whenever `.claude/setup-environment.sh` changes**, most importantly on a Gradle version bump.
+A stale copy fails quietly: it seeds the previous distribution, the wrapper ignores it, and sessions silently go back to downloading.
+
+`scripts/test_setup_environment.sh` guards the half CI can see.
+It fails the build when the committed copy drifts from `gradle/wrapper/gradle-wrapper.properties` (version, distribution URL, checksum) or from `.claude/hooks/session-start.sh` (command-line tools URL, `ANDROID_HOME`, SDK package list, license hashes, Temurin path), when the checksum verification stops being fail-closed, or when the wrapper cache path stops matching the one the wrapper actually reads.
+
+### What it deliberately does not do
+
+- It never regenerates `gradle/verification-metadata.xml`. The generator workflow is that file's only provenance (#774).
+- It provisions no emulator. The E2E suites need KVM, which web sessions do not have, so they stay CI-only.
+- It never trusts a hash published by whatever served the bytes. Both downloads are checked against a SHA-256 pinned in the script and refused on mismatch. `GRADLE_DIST_DOWNLOAD_URL` and `TEMURIN_DOWNLOAD_URL` can redirect the *download* to a mirror if a host is blocked; the pin still gates what that mirror serves.
+
+That last point carries more weight than it looks.
+The wrapper verifies a distribution it downloads against `distributionSha256Sum`, but a distribution it finds already installed is taken as given, and the zip is deleted once unpacked, so nothing is left to re-check.
+Seeding the cache moves that verification from the wrapper into the Setup script, which is why the script's check is fail-closed and why its pin is guarded by `scripts/test_setup_environment.sh`.
+
+______________________________________________________________________
+
 ## Environment variables
 
-| Variable            | Value                      | Set by             | Notes                                                      |
-| ------------------- | -------------------------- | ------------------ | ---------------------------------------------------------- |
-| `ANDROID_HOME`      | `/home/user/android-sdk`   | hook + `~/.bashrc` | Required by Gradle Android plugin and `adb`                |
-| `JAVA_TOOL_OPTIONS` | *(modified, not replaced)* | hook + `~/.bashrc` | Strips `*.google.com` from `nonProxyHosts` (see script §0) |
-| `PATH`              | `+$ANDROID_HOME/...`       | hook + `~/.bashrc` | Adds `sdkmanager`, `adb` to path                           |
-| `GITHUB_TOKEN`      | *(fine-grained PAT)*       | container          | Use with `curl` to query the GitHub REST API               |
+| Variable            | Value                      | Set by             | Notes                                                         |
+| ------------------- | -------------------------- | ------------------ | ------------------------------------------------------------- |
+| `ANDROID_HOME`      | `/home/user/android-sdk`   | hook + `~/.bashrc` | Required by Gradle Android plugin and `adb`                   |
+| `JAVA_HOME`         | `/opt/java/temurin-17`     | hook (§0b)         | Only when the Setup script provisioned it; else image default |
+| `JAVA_TOOL_OPTIONS` | *(modified, not replaced)* | hook + `~/.bashrc` | Strips `*.google.com` from `nonProxyHosts` (see script §0)    |
+| `PATH`              | `+$ANDROID_HOME/...`       | hook + `~/.bashrc` | Adds `sdkmanager`, `adb` to path                              |
+| `GITHUB_TOKEN`      | *(fine-grained PAT)*       | container          | Use with `curl` to query the GitHub REST API                  |
 
 `~/.bashrc` carries the same fixes for interactive terminal sessions.
 The proxy credentials in `JAVA_TOOL_OPTIONS` are a session-scoped JWT injected

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -26,14 +26,19 @@ Without it, sessions still work: the `SessionStart` hook provisions everything a
 With it, two things stop being luck:
 
 - **The Gradle distribution.** The hook cannot cache it across sessions, so every session re-downloads it from `services.gradle.org`, which redirects to a `github.com` release asset. Whether the session proxy allows that has been observed to vary (hard-blocked in 2026-07 sessions, open in 2026-08 ones; see the comments on #774). The Setup script seeds the wrapper's own cache, so `./gradlew` starts offline.
-- **The JDK.** The base image ships JDK 21; CI and the generator workflow build on Temurin 17. The Setup script installs Temurin 17 to `/opt/java/temurin-17`, and the hook (STEP 0b) points `JAVA_HOME` there when it finds it, so a local run reproduces CI.
+- **The JDK.** The base image ships JDK 21; CI and the generator workflow build on Temurin 17. The Setup script installs Temurin 17 to `/opt/java/temurin-17`, and the hook (STEP 0b) points `JAVA_HOME` there when it finds it. This matches CI at the major version, which is what makes a local run reproduce CI's Java behaviour; the workflows ask for `java-version: '17'` and float to the newest 17.x, while the script pins an exact build, so patch levels will diverge and nothing detects that.
 
 It also provisions the Android SDK once into the cached image instead of once per session, using the same pins as the hook, whose skip guards then turn those steps into fast no-ops.
+
+The Setup script and the session must agree on one home directory, because the wrapper looks for its cached distribution under the session's home.
+Here they do: sessions run as root with `HOME=/root`, which the script's default follows.
+If sessions ever run as a different user, set `SESSION_HOME` in the pasted block; the script fails rather than provisioning a home nothing reads, and logs which home it used.
 
 ### Installing it
 
 Paste the entire contents of `.claude/setup-environment.sh` into the environment's Setup script field, then rebuild the environment.
 The script is idempotent, so a rebuild over an already provisioned image is fast.
+Each step skips only when the work is already done *at the pinned version*, so a rebuild after a version bump reinstalls rather than reporting a stale install as present.
 
 ### Keeping it in sync
 
@@ -41,15 +46,29 @@ The pasted copy lives in a web form that CI cannot read, so **re-paste it whenev
 A stale copy fails quietly: it seeds the previous distribution, the wrapper ignores it, and sessions silently go back to downloading.
 
 `scripts/test_setup_environment.sh` guards the half CI can see.
-It fails the build when the committed copy drifts from `gradle/wrapper/gradle-wrapper.properties` (version, distribution URL, checksum) or from `.claude/hooks/session-start.sh` (command-line tools URL, `ANDROID_HOME`, SDK package list, license hashes, Temurin path), when the checksum verification stops being fail-closed, or when the wrapper cache path stops matching the one the wrapper actually reads.
+It fails the build when the committed copy drifts from `gradle/wrapper/gradle-wrapper.properties` (version, distribution URL, checksum) or from `.claude/hooks/session-start.sh` (command-line tools URL, `ANDROID_HOME`, SDK package list, license hashes, Temurin path), when the checksum verification stops being fail-closed, when the wrapper cache path stops matching the one the wrapper actually reads, or when a step would skip its work on an image already holding a different version.
 
 ### What it deliberately does not do
 
 - It never regenerates `gradle/verification-metadata.xml`. The generator workflow is that file's only provenance (#774).
 - It provisions no emulator. The E2E suites need KVM, which web sessions do not have, so they stay CI-only.
-- It never trusts a hash published by whatever served the bytes. Both downloads are checked against a SHA-256 pinned in the script and refused on mismatch. `GRADLE_DIST_DOWNLOAD_URL` and `TEMURIN_DOWNLOAD_URL` can redirect the *download* to a mirror if a host is blocked; the pin still gates what that mirror serves.
+- It never trusts a hash published by whatever served the bytes. `GRADLE_DIST_DOWNLOAD_URL` and `TEMURIN_DOWNLOAD_URL` can redirect those *downloads* to a mirror if a host is blocked; the pinned SHA-256 still gates what that mirror serves.
 
-That last point carries more weight than it looks.
+### What is and is not checksummed
+
+The script makes three downloads, and two of them are checksum-pinned:
+
+| Download                   | Step | Verification                                 |
+| -------------------------- | ---- | -------------------------------------------- |
+| Gradle distribution        | 2    | SHA-256 pinned in the script, fail-closed    |
+| Temurin 17                 | 1    | SHA-256 pinned in the script, fail-closed    |
+| Android command-line tools | 3a   | **Not checksummed**; version-pinned URL only |
+
+The command-line tools are the exception because Google publishes no stable checksum for that archive, and the SDK packages `sdkmanager` subsequently fetches are verified by `sdkmanager` against its own repository manifest.
+This is the same trust boundary the `SessionStart` hook and the generator workflow already operate on (#774).
+It is stated explicitly because "everything here is checksummed" would be false, and this is the wrong place to be loose about which bytes are verified.
+
+The Gradle pin in particular carries more weight than it looks.
 The wrapper verifies a distribution it downloads against `distributionSha256Sum`, but a distribution it finds already installed is taken as given, and the zip is deleted once unpacked, so nothing is left to re-check.
 Seeding the cache moves that verification from the wrapper into the Setup script, which is why the script's check is fail-closed and why its pin is guarded by `scripts/test_setup_environment.sh`.
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -18,6 +18,9 @@ ANDROID_HOME_DIR=/home/user/android-sdk
 CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
 SDKMANAGER="$ANDROID_HOME_DIR/cmdline-tools/latest/bin/sdkmanager"
 GRADLE_INIT="$HOME/.gradle/init.d/proxy-auth.gradle"
+# Where .claude/setup-environment.sh installs Temurin 17, if that environment
+# Setup script is configured (issue #792). Absent on an unconfigured environment.
+TEMURIN_HOME=/opt/java/temurin-17
 
 echo "[session-start] GB4PC environment setup..."
 
@@ -44,6 +47,32 @@ if echo "${JAVA_TOOL_OPTIONS:-}" | grep -qE '\*\.(google|googleapis)\.com'; then
     echo "[session-start] Step 0: stripped *.google.com from nonProxyHosts"
 else
     echo "[session-start] Step 0: JAVA_TOOL_OPTIONS already clean--skip"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────────
+# STEP 0b: Use the environment's Temurin 17, when it provisioned one.
+#
+# The base image ships a newer JDK (21), while CI and the generator workflow build
+# on Temurin 17, so a local run on 17 is the one that reproduces them.  The JDK is
+# installed by .claude/setup-environment.sh, the environment Setup script
+# (issue #792), which runs as root before the session and is cached across
+# sessions.  That script is optional, so this step is conditional: without it the
+# session simply keeps the image's default JDK, exactly as before.
+#
+# Exported ahead of every Java-using step below (sdkmanager in 2a/2c, and Gradle
+# for the rest of the session).
+# ───────────────────────────────────────────────────────────────────────────────
+if [[ -x "$TEMURIN_HOME/bin/java" ]]; then
+    export JAVA_HOME="$TEMURIN_HOME"
+    export PATH="$JAVA_HOME/bin:$PATH"
+    if [[ -n "${CLAUDE_ENV_FILE:-}" ]] \
+            && ! grep -q 'JAVA_HOME' "${CLAUDE_ENV_FILE}" 2>/dev/null; then
+        echo "export JAVA_HOME=$TEMURIN_HOME" >> "$CLAUDE_ENV_FILE"
+        echo "export PATH=$TEMURIN_HOME/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
+    fi
+    echo "[session-start] Step 0b: JAVA_HOME=$TEMURIN_HOME"
+else
+    echo "[session-start] Step 0b: no Setup-script JDK at $TEMURIN_HOME--using the image default"
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/.claude/setup-environment.sh
+++ b/.claude/setup-environment.sh
@@ -42,11 +42,21 @@
 #
 # INTEGRITY
 #
-# Every download is checked against a pinned SHA-256 and the script refuses to
-# install on a mismatch. The URLs are overridable (GRADLE_DIST_DOWNLOAD_URL,
-# TEMURIN_DOWNLOAD_URL) for an environment that blocks the canonical hosts, but
-# the checksum is not: a mirror is only ever trusted through the pin below, never
-# through a hash the mirror publishes about itself.
+# This script makes three downloads, and two of them are checksum-pinned:
+#
+#   - the Gradle distribution (Step 2) and Temurin (Step 1) are each checked
+#     against a SHA-256 pinned below, and the script refuses to install on a
+#     mismatch. Their URLs are overridable (GRADLE_DIST_DOWNLOAD_URL,
+#     TEMURIN_DOWNLOAD_URL) for an environment that blocks the canonical hosts,
+#     but the checksums are not: a mirror is only ever trusted through the pin
+#     here, never through a hash the mirror publishes about itself.
+#   - the Android command-line tools (Step 3a) are NOT checksum-verified. Google
+#     publishes no stable checksum for that archive, the URL is version-pinned,
+#     and the SDK packages sdkmanager then fetches are verified by sdkmanager
+#     against its own repository manifest. This matches what
+#     .claude/hooks/session-start.sh already does and the trust boundary issue
+#     #774 recorded for the generator workflow. It is called out rather than
+#     glossed, because "everything here is checksummed" would be false.
 #
 # KEEPING THE PINS IN SYNC
 #
@@ -57,8 +67,9 @@
 # than silently seeding the wrong Gradle. After changing this file, re-paste it
 # into the environment configuration; CI cannot see what is in the web form.
 #
-# Idempotent: every block checks whether its work is already done, so a re-run on a
-# partly provisioned image is safe and fast.
+# Idempotent: every block checks whether the work is already done *at the pinned
+# version*, not merely that something is there, so a re-run on a partly
+# provisioned image is safe and fast while a pin change still takes effect.
 
 set -euo pipefail
 
@@ -80,8 +91,13 @@ GRADLE_DIST_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSI
 # override only if that host is blocked here. GRADLE_DIST_SHA256 gates it either way.
 GRADLE_DIST_DOWNLOAD_URL="${GRADLE_DIST_DOWNLOAD_URL:-$GRADLE_DIST_URL}"
 
-# Temurin 17: matches the JDK actions/setup-java provisions in CI and in the
-# generator workflow. Checksum from the Adoptium release's .sha256.txt.
+# Temurin 17: the same distribution and major version actions/setup-java provisions
+# in CI and in the generator workflow, which is what makes a local run reproduce
+# CI's Java behaviour. It matches at the major version only: the workflows ask for
+# java-version '17', which floats to whatever the newest 17.x is at run time, while
+# this is pinned to an exact build because it is downloaded, not resolved by an
+# action. Expect the patch levels to diverge; nothing detects that, and nothing
+# needs to. Checksum from the Adoptium release's .sha256.txt.
 TEMURIN_VERSION="17.0.20+8"
 TEMURIN_SHA256="be7668bc030d578b83d6d5ef9221d6d6729bbbca8cf94a7d52e16ac68b5a5a35"
 # Fixed path, because .claude/hooks/session-start.sh looks for exactly this one
@@ -100,8 +116,17 @@ SDK_PACKAGES=(
     "platform-tools"
 )
 
-# The home directory sessions run with. The Gradle wrapper looks for its cached
-# distribution under this home, so seeding the wrong one provisions nothing.
+# The home directory sessions run with, which is NOT automatically the home this
+# script runs with. The Gradle wrapper looks for its cached distribution under the
+# session's home, so seeding the wrong one provisions nothing, silently: every
+# session would simply download again and look no different from an environment
+# where this script was never configured.
+#
+# In this environment they are the same, and the default relies on that: sessions
+# run as root with HOME=/root, which is where the live wrapper cache sits. That is
+# an assumption about the environment, not a fact about Setup scripts, so the
+# script states it, checks what it can, and gives an override rather than quietly
+# guessing. If sessions ever run as a different user, set SESSION_HOME.
 SESSION_HOME="${SESSION_HOME:-$HOME}"
 GRADLE_USER_HOME_DIR="${GRADLE_USER_HOME:-$SESSION_HOME/.gradle}"
 
@@ -116,6 +141,17 @@ if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
     log "ERROR: missing required commands: ${MISSING_TOOLS[*]}" >&2
     exit 1
 fi
+
+# Everything Gradle-related is provisioned relative to the session home, so an
+# absent one means the seeding would go somewhere no session reads. Fail here
+# rather than "succeed" into the void, and echo the resolved value so the
+# environment build log records which home was actually provisioned.
+if [[ ! -d "$SESSION_HOME" ]]; then
+    log "ERROR: SESSION_HOME '$SESSION_HOME' is not a directory." >&2
+    log "       Set SESSION_HOME to the home directory sessions run with." >&2
+    exit 1
+fi
+log "Provisioning for session home $SESSION_HOME (owner $(stat -c '%U' "$SESSION_HOME"))"
 
 # Download to a caller-named path and refuse to proceed unless the bytes match the
 # pinned SHA-256. -f makes curl fail on an HTTP error status instead of saving a
@@ -145,9 +181,26 @@ download_verified() {
 # The base image ships a newer JDK; the build targets Java 17 and CI runs Temurin
 # 17, so a local run on 17 is the one that reproduces CI. Installed to a fixed
 # path that .claude/hooks/session-start.sh exports JAVA_HOME to when it exists.
-if [[ -x "$TEMURIN_HOME/bin/java" ]]; then
+# The skip is keyed on the version actually installed, read from the JDK's own
+# release file, rather than on something merely existing at this path.
+# TEMURIN_HOME is version-independent by design, because the session-start hook
+# has to look for one fixed path, so a presence-only check would make every future
+# TEMURIN_VERSION bump a silent no-op on an already provisioned image, and would
+# print a skip line claiming the new version was present when it was not.
+# FULL_VERSION is what Temurin records there, in the same "17.0.20+8" form pinned
+# above. An unrecognised or unversioned JDK at this path reads as a mismatch and
+# is replaced, so the pin always wins.
+INSTALLED_TEMURIN=""
+if [[ -r "$TEMURIN_HOME/release" ]]; then
+    INSTALLED_TEMURIN=$(sed -n 's/^FULL_VERSION="\(.*\)"$/\1/p' "$TEMURIN_HOME/release" | head -n 1)
+fi
+
+if [[ -x "$TEMURIN_HOME/bin/java" && "$INSTALLED_TEMURIN" == "$TEMURIN_VERSION" ]]; then
     log "Step 1: Temurin $TEMURIN_VERSION present--skip"
 else
+    if [[ -e "$TEMURIN_HOME" ]]; then
+        log "Step 1: replacing the JDK at $TEMURIN_HOME (${INSTALLED_TEMURIN:-unknown version}) with the pinned $TEMURIN_VERSION"
+    fi
     # jdk-17.0.20+8 -> tag jdk-17.0.20%2B8, file ...hotspot_17.0.20_8.tar.gz.
     # Derived from TEMURIN_VERSION so the version appears exactly once.
     TEMURIN_TAG="jdk-${TEMURIN_VERSION//+/%2B}"
@@ -319,15 +372,25 @@ else
     log "Step 3c: all SDK packages present--skip"
 fi
 
-# --- STEP 4: Ownership --------------------------------------------------------
+# --- STEP 4: Ownership and permissions ----------------------------------------
 #
-# This script runs as root. Anything it leaves root-owned is unusable by a session
-# running as another user, and Gradle in particular must be able to write inside
-# its user home. Match whatever owns the session home rather than naming a user:
-# when sessions also run as root this is a no-op.
+# The session user is the owner of the session home, whoever that is, so the trees
+# the session must WRITE are handed to that owner: Gradle writes throughout its
+# user home (the wrapper alone creates a .lck beside the distribution), and
+# sdkmanager writes into the SDK when a later session adds a package.
+#
+# The JDK is deliberately not included. It only needs to be readable and
+# executable, and giving the session write ownership of a tree whose integrity was
+# just established with a pinned checksum would hand back part of what that pin
+# bought. a+rX grants exactly what is needed (X sets the search bit on directories
+# and on files that are already executable, never on plain files).
+#
+# When Setup and sessions share a user, which is the case here, the chown is a
+# no-op and this step costs nothing.
 OWNER=$(stat -c '%u:%g' "$SESSION_HOME")
-chown -R "$OWNER" "$GRADLE_USER_HOME_DIR" "$ANDROID_HOME_DIR" "$TEMURIN_HOME"
-log "Step 4: ownership of the provisioned trees set to $OWNER"
+chown -R "$OWNER" "$GRADLE_USER_HOME_DIR" "$ANDROID_HOME_DIR"
+chmod -R a+rX "$TEMURIN_HOME"
+log "Step 4: Gradle home and SDK owned by $OWNER (session home $SESSION_HOME); JDK left read-only"
 
 log "Complete. JAVA_HOME=$TEMURIN_HOME ANDROID_HOME=$ANDROID_HOME_DIR"
 log "Gradle $GRADLE_VERSION seeded in $GRADLE_USER_HOME_DIR"

--- a/.claude/setup-environment.sh
+++ b/.claude/setup-environment.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# GB4PC: Claude Code for Web *environment* Setup script (issue #792).
+#
+# WHERE THIS RUNS
+#
+# Nothing in this repository executes this file. It is the checked-in copy of the
+# block the maintainer pastes into the Setup script field of the Claude Code for
+# Web environment configuration, which runs as root once per environment build,
+# before any session starts, with its filesystem output cached across sessions.
+# The copy lives here so the pins can be reviewed, diffed, and guarded by CI
+# (scripts/test_setup_environment.sh) instead of existing only inside a web form.
+# See .claude/environment.md for how to install it and when to re-paste it.
+#
+# WHAT IT ADDS OVER THE SESSION-START HOOK
+#
+# .claude/hooks/session-start.sh already provisions the Android SDK, but it runs
+# inside each session, so every session pays that cost again. This script does the
+# same provisioning once, into the cached image, and adds the two things the hook
+# cannot usefully do per session:
+#
+#   - the Gradle distribution itself, seeded into the wrapper cache so ./gradlew
+#     starts offline instead of depending on the session proxy allowing
+#     services.gradle.org (observed blocked in 2026-07 sessions and open in
+#     2026-08 ones; see issue #774's comments);
+#   - Temurin 17, so local validation runs the JDK that CI and the generator
+#     workflow use rather than whatever JDK the base image ships (21, at the time
+#     of writing).
+#
+# The hook stays authoritative for anything session-scoped (environment variables,
+# the proxy authenticator, lint tooling, the git hook). It is written to skip work
+# that is already done, so with this script in place its SDK steps become fast
+# no-ops, and without this script it still provisions a working session on its own.
+# Nothing here is required for a session to function; this only makes it
+# deterministic and fast.
+#
+# WHAT IT IS NOT
+#
+# It never regenerates or commits gradle/verification-metadata.xml (the generator
+# workflow is the provenance source, issue #774), and it does not provision an
+# emulator: the E2E suites need KVM, which web sessions do not have, so they stay
+# CI-only.
+#
+# INTEGRITY
+#
+# Every download is checked against a pinned SHA-256 and the script refuses to
+# install on a mismatch. The URLs are overridable (GRADLE_DIST_DOWNLOAD_URL,
+# TEMURIN_DOWNLOAD_URL) for an environment that blocks the canonical hosts, but
+# the checksum is not: a mirror is only ever trusted through the pin below, never
+# through a hash the mirror publishes about itself.
+#
+# KEEPING THE PINS IN SYNC
+#
+# GRADLE_VERSION and GRADLE_DIST_SHA256 must match
+# gradle/wrapper/gradle-wrapper.properties, and the Android SDK pins must match
+# .claude/hooks/session-start.sh. scripts/test_setup_environment.sh asserts all of
+# that in CI, so a toolchain bump that forgets this file fails the build rather
+# than silently seeding the wrong Gradle. After changing this file, re-paste it
+# into the environment configuration; CI cannot see what is in the web form.
+#
+# Idempotent: every block checks whether its work is already done, so a re-run on a
+# partly provisioned image is safe and fast.
+
+set -euo pipefail
+
+# --- Pins ---------------------------------------------------------------------
+#
+# Gradle: must match gradle/wrapper/gradle-wrapper.properties. The checksum is the
+# one Gradle publishes at
+# https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256
+GRADLE_VERSION="9.5.1"
+GRADLE_DIST_SHA256="bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f"
+
+# The URL the *wrapper* is configured with (distributionUrl in
+# gradle-wrapper.properties). The wrapper derives its cache directory name from
+# this exact string, so the seeded path is computed from it and never from a
+# mirror override.
+GRADLE_DIST_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+
+# Where the bytes are actually fetched from. Defaults to the wrapper's own URL;
+# override only if that host is blocked here. GRADLE_DIST_SHA256 gates it either way.
+GRADLE_DIST_DOWNLOAD_URL="${GRADLE_DIST_DOWNLOAD_URL:-$GRADLE_DIST_URL}"
+
+# Temurin 17: matches the JDK actions/setup-java provisions in CI and in the
+# generator workflow. Checksum from the Adoptium release's .sha256.txt.
+TEMURIN_VERSION="17.0.20+8"
+TEMURIN_SHA256="be7668bc030d578b83d6d5ef9221d6d6729bbbca8cf94a7d52e16ac68b5a5a35"
+# Fixed path, because .claude/hooks/session-start.sh looks for exactly this one
+# when it decides whether to point the session's JAVA_HOME here. Overridable only
+# so scripts/test_setup_environment.sh can exercise the script against a sandbox.
+TEMURIN_HOME="${TEMURIN_HOME:-/opt/java/temurin-17}"
+
+# Android SDK: must match .claude/hooks/session-start.sh.
+ANDROID_HOME_DIR="${ANDROID_HOME:-/home/user/android-sdk}"
+CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+SDK_PACKAGES=(
+    "platforms;android-35"
+    "build-tools;36.0.0"
+    "build-tools;35.0.0"
+    "build-tools;34.0.0"
+    "platform-tools"
+)
+
+# The home directory sessions run with. The Gradle wrapper looks for its cached
+# distribution under this home, so seeding the wrong one provisions nothing.
+SESSION_HOME="${SESSION_HOME:-$HOME}"
+GRADLE_USER_HOME_DIR="${GRADLE_USER_HOME:-$SESSION_HOME/.gradle}"
+
+log() { echo "[setup-environment] $*"; }
+
+# --- Preflight ----------------------------------------------------------------
+MISSING_TOOLS=()
+for tool in curl unzip tar sha256sum python3 stat; do
+    command -v "$tool" >/dev/null 2>&1 || MISSING_TOOLS+=("$tool")
+done
+if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
+    log "ERROR: missing required commands: ${MISSING_TOOLS[*]}" >&2
+    exit 1
+fi
+
+# Download to a caller-named path and refuse to proceed unless the bytes match the
+# pinned SHA-256. -f makes curl fail on an HTTP error status instead of saving a
+# proxy error page as if it were the artifact (issue #667).
+download_verified() {
+    local url="$1" expected_sha="$2" dest="$3" label="$4"
+    log "$label: downloading $url"
+    if ! curl -fsSL "$url" -o "$dest"; then
+        log "ERROR: $label: download failed from $url" >&2
+        log "       If this host is blocked here, re-run with a mirror URL; the" >&2
+        log "       pinned SHA-256 still gates whatever that mirror serves." >&2
+        return 1
+    fi
+    local actual_sha
+    actual_sha=$(sha256sum "$dest" | cut -d' ' -f1)
+    if [[ "$actual_sha" != "$expected_sha" ]]; then
+        log "ERROR: $label: SHA-256 mismatch (refusing to install)" >&2
+        log "       expected $expected_sha" >&2
+        log "       actual   $actual_sha" >&2
+        return 1
+    fi
+    log "$label: SHA-256 verified"
+}
+
+# --- STEP 1: Temurin 17 -------------------------------------------------------
+#
+# The base image ships a newer JDK; the build targets Java 17 and CI runs Temurin
+# 17, so a local run on 17 is the one that reproduces CI. Installed to a fixed
+# path that .claude/hooks/session-start.sh exports JAVA_HOME to when it exists.
+if [[ -x "$TEMURIN_HOME/bin/java" ]]; then
+    log "Step 1: Temurin $TEMURIN_VERSION present--skip"
+else
+    # jdk-17.0.20+8 -> tag jdk-17.0.20%2B8, file ...hotspot_17.0.20_8.tar.gz.
+    # Derived from TEMURIN_VERSION so the version appears exactly once.
+    TEMURIN_TAG="jdk-${TEMURIN_VERSION//+/%2B}"
+    TEMURIN_FILE="OpenJDK17U-jdk_x64_linux_hotspot_${TEMURIN_VERSION//+/_}.tar.gz"
+    TEMURIN_DOWNLOAD_URL="${TEMURIN_DOWNLOAD_URL:-https://github.com/adoptium/temurin17-binaries/releases/download/${TEMURIN_TAG}/${TEMURIN_FILE}}"
+
+    TMP_JDK=$(mktemp /tmp/temurin17-XXXXXX.tar.gz)
+    TMP_JDK_DIR=$(mktemp -d /tmp/temurin17-extract-XXXXXX)
+    trap 'rm -rf "$TMP_JDK" "$TMP_JDK_DIR"' EXIT
+    download_verified "$TEMURIN_DOWNLOAD_URL" "$TEMURIN_SHA256" "$TMP_JDK" "Step 1"
+    tar -xzf "$TMP_JDK" -C "$TMP_JDK_DIR"
+    # The tarball unpacks to a single jdk-<version> directory; move it into place
+    # under a stable name rather than encoding the version in the path.
+    EXTRACTED_JDK=$(find "$TMP_JDK_DIR" -maxdepth 1 -mindepth 1 -type d | head -n 1)
+    if [[ -z "$EXTRACTED_JDK" || ! -x "$EXTRACTED_JDK/bin/java" ]]; then
+        log "ERROR: Step 1: the unpacked archive has no bin/java" >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$TEMURIN_HOME")"
+    rm -rf "$TEMURIN_HOME"
+    mv "$EXTRACTED_JDK" "$TEMURIN_HOME"
+    rm -rf "$TMP_JDK" "$TMP_JDK_DIR"
+    trap - EXIT
+    log "Step 1: Temurin installed to $TEMURIN_HOME"
+fi
+
+# Use the pinned JDK for the rest of this script (sdkmanager is a Java program).
+export JAVA_HOME="$TEMURIN_HOME"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+# The image's JAVA_TOOL_OPTIONS lists *.google.com in nonProxyHosts, so Java tries
+# a direct connection to dl.google.com, which has no direct DNS here. Strip those
+# entries for this script's sdkmanager runs, exactly as the session-start hook
+# does for the session (see its STEP 0).
+if echo "${JAVA_TOOL_OPTIONS:-}" | grep -qE '\*\.(google|googleapis)\.com'; then
+    JAVA_TOOL_OPTIONS=$(echo "$JAVA_TOOL_OPTIONS" \
+        | sed 's/|\*\.googleapis\.com//' \
+        | sed 's/|\*\.google\.com//')
+    export JAVA_TOOL_OPTIONS
+    log "Stripped *.google.com from nonProxyHosts for this script"
+fi
+
+# --- STEP 2: Gradle distribution, seeded into the wrapper cache ---------------
+#
+# ./gradlew resolves its distribution to
+#   <GRADLE_USER_HOME>/wrapper/dists/<dist name>/<hash>/<unpacked dir>/
+# where <hash> is Gradle's base-36 MD5 of the configured distributionUrl. Writing
+# the unpacked distribution there, plus the .ok marker the wrapper writes on a
+# successful install, makes the wrapper find the distribution already installed
+# and skip the download entirely.
+#
+# The hash is derived from GRADLE_DIST_URL (what the wrapper is configured with),
+# never from a mirror override, or the wrapper would look in a different directory
+# than the one seeded.
+#
+# Note what seeding costs: the wrapper normally verifies the zip it downloaded
+# against distributionSha256Sum, but a distribution it finds already installed is
+# taken as given, and it deletes the zip after unpacking so there is nothing left
+# to re-check. The verification below is therefore not belt-and-braces, it is the
+# only check that stands between a substituted distribution and every build in
+# every session, which is why it is fail-closed and why the pin lives in the
+# script rather than being read from whatever was downloaded.
+DIST_BASE="${GRADLE_DIST_URL##*/}"          # gradle-9.5.1-bin.zip
+DIST_NAME="${DIST_BASE%.zip}"               # gradle-9.5.1-bin
+DIST_HASH=$(python3 -c '
+import hashlib
+import sys
+
+digest = hashlib.md5(sys.argv[1].encode()).digest()
+value = int.from_bytes(digest, "big")
+digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+out = ""
+while value:
+    value, remainder = divmod(value, 36)
+    out = digits[remainder] + out
+print(out or "0")
+' "$GRADLE_DIST_URL")
+DIST_DIR="$GRADLE_USER_HOME_DIR/wrapper/dists/$DIST_NAME/$DIST_HASH"
+DIST_MARKER="$DIST_DIR/$DIST_BASE.ok"
+DIST_UNPACKED="$DIST_DIR/gradle-$GRADLE_VERSION"
+
+if [[ -x "$DIST_UNPACKED/bin/gradle" && -f "$DIST_MARKER" ]]; then
+    log "Step 2: Gradle $GRADLE_VERSION already seeded at $DIST_DIR--skip"
+else
+    TMP_DIST=$(mktemp /tmp/gradle-dist-XXXXXX.zip)
+    TMP_DIST_DIR=$(mktemp -d /tmp/gradle-dist-extract-XXXXXX)
+    trap 'rm -rf "$TMP_DIST" "$TMP_DIST_DIR"' EXIT
+    download_verified "$GRADLE_DIST_DOWNLOAD_URL" "$GRADLE_DIST_SHA256" "$TMP_DIST" "Step 2"
+    unzip -q "$TMP_DIST" -d "$TMP_DIST_DIR"
+    if [[ ! -x "$TMP_DIST_DIR/gradle-$GRADLE_VERSION/bin/gradle" ]]; then
+        log "ERROR: Step 2: the archive has no gradle-$GRADLE_VERSION/bin/gradle" >&2
+        exit 1
+    fi
+    # Replace any half-seeded directory rather than merging into it, so an
+    # interrupted earlier run cannot leave a mixed distribution behind.
+    rm -rf "$DIST_DIR"
+    mkdir -p "$DIST_DIR"
+    mv "$TMP_DIST_DIR/gradle-$GRADLE_VERSION" "$DIST_UNPACKED"
+    # The marker is written last: it is what tells the wrapper the install
+    # completed, so it must not exist before the distribution is fully in place.
+    # The wrapper deletes the zip once it has unpacked it, so a correctly seeded
+    # cache holds the unpacked distribution and this marker, and no archive.
+    touch "$DIST_MARKER"
+    rm -rf "$TMP_DIST" "$TMP_DIST_DIR"
+    trap - EXIT
+    log "Step 2: Gradle $GRADLE_VERSION seeded at $DIST_DIR"
+fi
+
+# --- STEP 3: Android SDK ------------------------------------------------------
+#
+# Same command-line tools, licenses, and package pins as
+# .claude/hooks/session-start.sh (its STEP 2a-2c); doing it here puts them in the
+# cached image so sessions find them already installed.
+#
+# No checksum pin here, unlike the two downloads above, and the asymmetry is
+# deliberate rather than an oversight: Google publishes no stable checksum for
+# these, and the packages sdkmanager then fetches are verified by sdkmanager
+# against its own repository manifest. What is pinned is the version of every
+# component (issue #774 records the same reasoning for the generator workflow).
+SDKMANAGER="$ANDROID_HOME_DIR/cmdline-tools/latest/bin/sdkmanager"
+
+if [[ -x "$SDKMANAGER" ]]; then
+    log "Step 3a: sdkmanager present--skip"
+else
+    TMP_TOOLS=$(mktemp /tmp/cmdline-tools-XXXXXX.zip)
+    TMP_TOOLS_DIR=$(mktemp -d /tmp/cmdline-tools-extract-XXXXXX)
+    trap 'rm -rf "$TMP_TOOLS" "$TMP_TOOLS_DIR"' EXIT
+    log "Step 3a: downloading the Android command-line tools..."
+    curl -fsSL "$CMDLINE_TOOLS_URL" -o "$TMP_TOOLS"
+    unzip -q "$TMP_TOOLS" -d "$TMP_TOOLS_DIR"
+    mkdir -p "$ANDROID_HOME_DIR/cmdline-tools"
+    rm -rf "$ANDROID_HOME_DIR/cmdline-tools/latest"
+    mv "$TMP_TOOLS_DIR/cmdline-tools" "$ANDROID_HOME_DIR/cmdline-tools/latest"
+    rm -rf "$TMP_TOOLS" "$TMP_TOOLS_DIR"
+    trap - EXIT
+    log "Step 3a: cmdline-tools installed"
+fi
+
+export ANDROID_HOME="$ANDROID_HOME_DIR"
+
+if [[ -f "$ANDROID_HOME_DIR/licenses/android-sdk-license" ]]; then
+    log "Step 3b: SDK licenses present--skip"
+else
+    mkdir -p "$ANDROID_HOME_DIR/licenses"
+    printf '\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee' \
+        > "$ANDROID_HOME_DIR/licenses/android-sdk-license"
+    printf '\n84831b9409646a918e30573bab4c9c91346d8abd' \
+        > "$ANDROID_HOME_DIR/licenses/android-sdk-preview-license"
+    log "Step 3b: licenses written"
+fi
+
+MISSING_PACKAGES=()
+for pkg in "${SDK_PACKAGES[@]}"; do
+    # "build-tools;36.0.0" installs to $ANDROID_HOME/build-tools/36.0.0.
+    if [[ -d "$ANDROID_HOME_DIR/${pkg//;//}" ]]; then
+        log "Step 3c: $pkg present--skip"
+    else
+        MISSING_PACKAGES+=("$pkg")
+    fi
+done
+
+if [[ ${#MISSING_PACKAGES[@]} -gt 0 ]]; then
+    log "Step 3c: installing: ${MISSING_PACKAGES[*]}"
+    yes | "$SDKMANAGER" --licenses > /dev/null 2>&1 \
+        || log "Step 3c: warning: sdkmanager --licenses failed--install may fail if a license is unaccepted"
+    "$SDKMANAGER" "${MISSING_PACKAGES[@]}"
+    log "Step 3c: done"
+else
+    log "Step 3c: all SDK packages present--skip"
+fi
+
+# --- STEP 4: Ownership --------------------------------------------------------
+#
+# This script runs as root. Anything it leaves root-owned is unusable by a session
+# running as another user, and Gradle in particular must be able to write inside
+# its user home. Match whatever owns the session home rather than naming a user:
+# when sessions also run as root this is a no-op.
+OWNER=$(stat -c '%u:%g' "$SESSION_HOME")
+chown -R "$OWNER" "$GRADLE_USER_HOME_DIR" "$ANDROID_HOME_DIR" "$TEMURIN_HOME"
+log "Step 4: ownership of the provisioned trees set to $OWNER"
+
+log "Complete. JAVA_HOME=$TEMURIN_HOME ANDROID_HOME=$ANDROID_HOME_DIR"
+log "Gradle $GRADLE_VERSION seeded in $GRADLE_USER_HOME_DIR"

--- a/.claude/setup-environment.sh
+++ b/.claude/setup-environment.sh
@@ -125,8 +125,15 @@ SDK_PACKAGES=(
 # In this environment they are the same, and the default relies on that: sessions
 # run as root with HOME=/root, which is where the live wrapper cache sits. That is
 # an assumption about the environment, not a fact about Setup scripts, so the
-# script states it, checks what it can, and gives an override rather than quietly
-# guessing. If sessions ever run as a different user, set SESSION_HOME.
+# script states it and gives an override rather than quietly guessing.
+#
+# What it can check is only that the resolved home exists. That does not catch the
+# case that would actually hurt: sessions moving to another user while this script
+# still runs as root, where /root exists either way and the seeding would go
+# somewhere no session reads. Nothing available here can detect which user a future
+# session will run as, so the resolved home is logged rather than guessed at, and
+# reading that line is the check. If sessions ever run as a different user, set
+# SESSION_HOME.
 SESSION_HOME="${SESSION_HOME:-$HOME}"
 GRADLE_USER_HOME_DIR="${GRADLE_USER_HOME:-$SESSION_HOME/.gradle}"
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -62,6 +62,7 @@ The same guard script therefore also pins the expected version and distribution 
 The regenerated `gradlew` launches with the standard `-jar gradle/wrapper/gradle-wrapper.jar`, and the vestigial `CLASSPATH="\"\""` assignment and `-classpath "$CLASSPATH"` argument that older Gradle wrapper scripts carried are simply gone.
 
 When bumping the Gradle version, update both `distributionUrl` and `distributionSha256Sum` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256`), then regenerate `verification-metadata.xml`.
+Also update the same two pins in `.claude/setup-environment.sh`, which seeds that distribution into the Claude web environment's Gradle cache, and re-derive the `EXPECTED_DIST_HASH` in `scripts/test_setup_environment.sh` (that guard script fails the build if either is forgotten; `.claude/environment.md` explains why the pasted copy also has to be refreshed by hand).
 If the wrapper JAR itself changes, also update its pinned SHA-256 in `scripts/test_verification_metadata.sh` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`), along with the version and distribution constants next to it.
 
 ## CodeQL Kotlin ceiling

--- a/scripts/test_setup_environment.sh
+++ b/scripts/test_setup_environment.sh
@@ -26,7 +26,11 @@
 #   (e) it computes the Gradle wrapper's cache directory the way the wrapper does
 #       (behavioral: a correctly seeded cache is detected and no download starts)
 #   (f) a checksum mismatch is fatal and installs nothing (behavioral)
-#   (g) it never writes gradle/verification-metadata.xml, which only the generator
+#   (g) a TEMURIN_VERSION bump reaches an image that already has a different JDK
+#       at the fixed path, rather than being skipped as "present" (behavioral)
+#   (h) the pinned JDK already installed is skipped, so rebuilds stay fast
+#       (behavioral)
+#   (i) it never writes gradle/verification-metadata.xml, which only the generator
 #       workflow may produce (issue #774)
 #
 # Always exits 0 on success, non-zero on failure.
@@ -159,10 +163,22 @@ else
 fi
 
 # License hashes are 40-hex SHA-1 digests inside the printf lines that write the
-# licence files. Scoped to those lines so the 64-hex artifact checksums elsewhere
-# in the file cannot match.
-SETUP_LICENSES=$(grep 'printf' "$SETUP" | grep -oE '[0-9a-f]{40}' | sort)
-HOOK_LICENSES=$(grep 'printf' "$HOOK" | grep -oE '[0-9a-f]{40}' | sort)
+# licence files. Anchored on both sides rather than matching a bare run of 40 hex
+# characters, which would also match the first 40 of a 64-hex SHA-256 if one ever
+# landed on such a line.
+extract_license_hashes() {
+    grep 'printf' "$1" | python3 -c '
+import re
+import sys
+
+pattern = re.compile(r"(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])")
+for line in sys.stdin:
+    for match in pattern.findall(line):
+        print(match)
+' | sort
+}
+SETUP_LICENSES=$(extract_license_hashes "$SETUP")
+HOOK_LICENSES=$(extract_license_hashes "$HOOK")
 if [ -n "$HOOK_LICENSES" ] && [ "$SETUP_LICENSES" = "$HOOK_LICENSES" ]; then
     pass "SDK license hashes match the session-start hook"
 else
@@ -171,6 +187,7 @@ fi
 
 # (d) the JDK path the Setup script installs to is the one the hook looks for.
 SETUP_TEMURIN=$(read_var "$SETUP" TEMURIN_HOME)
+SETUP_TEMURIN_VERSION=$(read_var "$SETUP" TEMURIN_VERSION)
 HOOK_TEMURIN=$(sed -n 's/^TEMURIN_HOME=//p' "$HOOK" | head -n 1)
 if [ -n "$HOOK_TEMURIN" ] && [ "$SETUP_TEMURIN" = "$HOOK_TEMURIN" ]; then
     pass "TEMURIN_HOME matches the path the session-start hook exports ($HOOK_TEMURIN)"
@@ -180,19 +197,29 @@ fi
 
 # --- Behavioral checks --------------------------------------------------------
 #
-# Both run the real script against a sandbox home, with every download URL
-# pointed at a nonexistent file:// path. Nothing touches the network: if the
-# script tries to download anything it is supposed to have found already, curl
-# fails and the case reports it.
+# Each case runs the real script against a sandbox home. Both overridable
+# download URLs are always pointed at a nonexistent file:// path, so any fetch the
+# script was supposed to have skipped fails loudly here instead of pulling ~190 MB
+# of JDK or ~130 MB of Gradle into a CI job.
+#
+# That accounts for two of the script's three downloads. The third, Step 3a's
+# Android command-line tools, has no URL override, so it cannot be redirected at
+# all; the sandbox instead pre-creates the sdkmanager and every package directory
+# so Step 3 finds its work done and never reaches that fetch. Both mechanisms are
+# load-bearing: neither alone isolates the script.
 SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/setup-env-test-XXXXXX")
 trap 'rm -rf "$SANDBOX"' EXIT
 
-# A stub JDK and SDK, so only the behavior under test is exercised.
+# A stub JDK and SDK, so only the behavior under test is exercised. The JDK gets a
+# release file carrying the pinned version, because Step 1 skips on the installed
+# version rather than on mere presence.
 make_sandbox() {
     local root="$1" pkg
     mkdir -p "$root/home" "$root/jdk/bin" "$root/sdk/cmdline-tools/latest/bin"
     : > "$root/jdk/bin/java"
     chmod +x "$root/jdk/bin/java"
+    printf 'IMPLEMENTOR="Eclipse Adoptium"\nFULL_VERSION="%s"\n' \
+        "$SETUP_TEMURIN_VERSION" > "$root/jdk/release"
     : > "$root/sdk/cmdline-tools/latest/bin/sdkmanager"
     chmod +x "$root/sdk/cmdline-tools/latest/bin/sdkmanager"
     mkdir -p "$root/sdk/licenses"
@@ -203,13 +230,29 @@ make_sandbox() {
     done
 }
 
+# Plant a distribution where the wrapper itself would put one: the observed
+# EXPECTED_DIST_HASH directory, holding an executable bin/gradle and the .ok marker
+# the wrapper writes on a successful install.
+seed_gradle_cache() {
+    local root="$1"
+    local dist="$root/home/.gradle/wrapper/dists/gradle-${SETUP_GRADLE_VERSION}-bin/$EXPECTED_DIST_HASH"
+    mkdir -p "$dist/gradle-${SETUP_GRADLE_VERSION}/bin"
+    : > "$dist/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
+    chmod +x "$dist/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
+    : > "$dist/gradle-${SETUP_GRADLE_VERSION}-bin.zip.ok"
+}
+
+# Every override the script accepts is set here, so no case can silently depend on
+# the network by forgetting one. The Gradle download URL is the only knob a case
+# needs to vary, so it is the optional argument.
 run_setup() {
     local root="$1"
+    local gradle_url="${2:-file://$root/absent-gradle.zip}"
     SESSION_HOME="$root/home" \
         GRADLE_USER_HOME="$root/home/.gradle" \
         ANDROID_HOME="$root/sdk" \
         TEMURIN_HOME="$root/jdk" \
-        GRADLE_DIST_DOWNLOAD_URL="file://$root/absent-gradle.zip" \
+        GRADLE_DIST_DOWNLOAD_URL="$gradle_url" \
         TEMURIN_DOWNLOAD_URL="file://$root/absent-jdk.tar.gz" \
         bash "$SETUP" > "$root/out.log" 2>&1
 }
@@ -220,11 +263,7 @@ run_setup() {
 # the (unreachable) download, and fail.
 SEED="$SANDBOX/seed"
 make_sandbox "$SEED"
-SEED_DIST="$SEED/home/.gradle/wrapper/dists/gradle-${SETUP_GRADLE_VERSION}-bin/$EXPECTED_DIST_HASH"
-mkdir -p "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin"
-: > "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
-chmod +x "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
-: > "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}-bin.zip.ok"
+seed_gradle_cache "$SEED"
 if run_setup "$SEED"; then
     if grep -q "already seeded" "$SEED/out.log"; then
         pass "a cache seeded at the wrapper's own directory ($EXPECTED_DIST_HASH) is detected, no download"
@@ -255,12 +294,7 @@ with zipfile.ZipFile(archive, "w") as zf:
     entry.external_attr = 0o755 << 16
     zf.writestr(entry, "#!/bin/sh\necho not gradle\n")
 PY
-if SESSION_HOME="$BAD/home" \
-    GRADLE_USER_HOME="$BAD/home/.gradle" \
-    ANDROID_HOME="$BAD/sdk" \
-    TEMURIN_HOME="$BAD/jdk" \
-    GRADLE_DIST_DOWNLOAD_URL="file://$BAD/tampered.zip" \
-    bash "$SETUP" > "$BAD/out.log" 2>&1; then
+if run_setup "$BAD" "file://$BAD/tampered.zip"; then
     fail "a distribution failing the SHA-256 pin was accepted"
 elif grep -q "SHA-256 mismatch" "$BAD/out.log" \
     && [ ! -d "$BAD/home/.gradle/wrapper/dists/gradle-${SETUP_GRADLE_VERSION}-bin/$EXPECTED_DIST_HASH/gradle-${SETUP_GRADLE_VERSION}" ]; then
@@ -270,11 +304,50 @@ else
     sed 's/^/    /' "$BAD/out.log"
 fi
 
-# (g) the Setup script must never produce gradle/verification-metadata.xml. The
+# (g) a bump to TEMURIN_VERSION must actually reach an already provisioned image.
+# TEMURIN_HOME is version-independent on purpose (the session-start hook needs one
+# fixed path to look for), so a skip guard testing only that something exists there
+# would make every future JDK pin change a silent no-op, while printing a line
+# claiming the new version was installed. The sandbox holds a JDK at a different
+# version and the download is unreachable, so a correct script tries to replace it
+# and fails on the download; a script that skips on presence alone exits 0.
+#
+# The Gradle cache is seeded here too, so every other step is a skip and the JDK
+# is the only thing that can make the run fail. A script that wrongly skips the
+# JDK therefore exits 0 and is reported as such, rather than failing later for an
+# unrelated reason.
+STALE="$SANDBOX/stale"
+make_sandbox "$STALE"
+seed_gradle_cache "$STALE"
+printf 'IMPLEMENTOR="Eclipse Adoptium"\nFULL_VERSION="17.0.1+1"\n' > "$STALE/jdk/release"
+if run_setup "$STALE"; then
+    fail "a JDK at a version other than the pin was left in place (a TEMURIN_VERSION bump would be a no-op)"
+elif grep -q "replacing the JDK" "$STALE/out.log"; then
+    pass "a JDK at the wrong version is replaced rather than skipped"
+else
+    fail "the script failed, but not because it tried to replace the stale JDK"
+    sed 's/^/    /' "$STALE/out.log"
+fi
+
+# (h) the converse: the pinned version already installed is left alone, so a
+# rebuild over a provisioned image stays fast and does not re-download the JDK.
+# make_sandbox writes a release file carrying the pinned version.
+FRESH="$SANDBOX/fresh"
+make_sandbox "$FRESH"
+seed_gradle_cache "$FRESH"
+if run_setup "$FRESH" && grep -q "Temurin $SETUP_TEMURIN_VERSION present--skip" "$FRESH/out.log"; then
+    pass "the pinned JDK already installed is skipped, no download"
+else
+    fail "a fully provisioned sandbox did not skip the JDK"
+    sed 's/^/    /' "$FRESH/out.log"
+fi
+
+# (i) the Setup script must never produce gradle/verification-metadata.xml. The
 # generator workflow is that file's only provenance (issue #774), and a locally
 # generated one would look identical while carrying no review trail.
-if grep -q 'verification-metadata\.xml' "$SETUP" \
-    && grep 'verification-metadata\.xml' "$SETUP" | grep -qvE '^[[:space:]]*#'; then
+# Comments are stripped before looking, so a full-line OR a trailing inline comment
+# mentioning the file reads as prose rather than as an action.
+if sed 's/#.*$//' "$SETUP" | grep -q 'verification-metadata\.xml'; then
     fail "setup-environment.sh acts on verification-metadata.xml; only the generator workflow may"
 else
     pass "setup-environment.sh never writes verification-metadata.xml"

--- a/scripts/test_setup_environment.sh
+++ b/scripts/test_setup_environment.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# test_setup_environment.sh: guard tests for .claude/setup-environment.sh, the
+# Claude Code for Web environment Setup script (issue #792).
+#
+# That script is a copy. The executable original lives in the Claude web
+# environment configuration, where CI cannot see it, and it duplicates pins that
+# are declared elsewhere in this repository: the Gradle version and distribution
+# checksum (gradle/wrapper/gradle-wrapper.properties) and the Android SDK
+# provisioning (.claude/hooks/session-start.sh). Duplication that nothing checks
+# is duplication that rots, and the failure is quiet: a Gradle bump would leave
+# every session seeded with the previous distribution, which the wrapper would
+# then silently re-download, undoing the whole point of the script.
+#
+# These checks make that drift loud at merge time. They cannot see the web form,
+# so they guarantee the committed copy is correct, not that it has been pasted;
+# re-pasting after a change stays a human step (see .claude/environment.md).
+#
+# Covers:
+#   (a) the script exists, is executable, parses, and runs under set -euo pipefail
+#   (b) its Gradle version, distribution URL, and checksum match
+#       gradle/wrapper/gradle-wrapper.properties
+#   (c) its Android SDK pins (command-line tools URL, ANDROID_HOME, package list,
+#       license hashes) match .claude/hooks/session-start.sh
+#   (d) its Temurin install path matches the one the session-start hook exports
+#       JAVA_HOME to
+#   (e) it computes the Gradle wrapper's cache directory the way the wrapper does
+#       (behavioral: a correctly seeded cache is detected and no download starts)
+#   (f) a checksum mismatch is fatal and installs nothing (behavioral)
+#   (g) it never writes gradle/verification-metadata.xml, which only the generator
+#       workflow may produce (issue #774)
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP="$REPO_ROOT/.claude/setup-environment.sh"
+HOOK="$REPO_ROOT/.claude/hooks/session-start.sh"
+WRAPPER_PROPS="$REPO_ROOT/gradle/wrapper/gradle-wrapper.properties"
+
+# The wrapper cache directory name for the pinned distributionUrl: Gradle's
+# base-36 rendering of the MD5 of that URL string. Pinned rather than recomputed,
+# because recomputing it with the same algorithm the script uses would assert
+# nothing. It was read from a cache that the Gradle wrapper itself populated
+# (~/.gradle/wrapper/dists/gradle-9.5.1-bin/<this>/), which is what makes it
+# independent evidence.
+#
+# On a Gradle version bump this value changes with the URL. Re-derive it the same
+# way: let ./gradlew download the new distribution once, then read the directory
+# name it created under wrapper/dists/gradle-<version>-bin/.
+EXPECTED_DIST_HASH="iq79hdu3mqx29lgffhp8bfmx"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Read a top-level FOO="bar" assignment out of a script, without executing it.
+# An overridable pin is written FOO="${OTHER:-default}"; this returns the default,
+# which is the value that ships.
+read_var() {
+    local file="$1" name="$2" raw
+    raw=$(sed -n "s/^${name}=//p" "$file" | head -n 1)
+    printf '%s' "$raw" | sed -e 's/^"//' -e 's/"$//' \
+        -e 's/^\${[A-Za-z_][A-Za-z0-9_]*:-//' -e 's/}$//'
+}
+
+if [ ! -f "$SETUP" ]; then
+    echo "  FAIL: .claude/setup-environment.sh is missing"
+    echo
+    echo "test_setup_environment.sh: 0 passed, 1 failed"
+    exit 1
+fi
+
+# (a) structural: executable, parses, and fails fast.
+if [ -x "$SETUP" ]; then
+    pass "setup-environment.sh is executable"
+else
+    fail "setup-environment.sh must be executable (chmod +x)"
+fi
+
+if bash -n "$SETUP" 2>/dev/null; then
+    pass "setup-environment.sh parses as bash"
+else
+    fail "setup-environment.sh has a syntax error"
+fi
+
+if grep -q '^set -euo pipefail$' "$SETUP"; then
+    pass "setup-environment.sh runs under set -euo pipefail"
+else
+    fail "setup-environment.sh must set -euo pipefail (a half-provisioned image is worse than none)"
+fi
+
+# (b) the Gradle pins agree with the wrapper the repository actually commits.
+# distributionUrl is escaped in the .properties format (https\://...), so the
+# backslash comes out before comparing.
+SETUP_GRADLE_VERSION=$(read_var "$SETUP" GRADLE_VERSION)
+SETUP_GRADLE_SHA=$(read_var "$SETUP" GRADLE_DIST_SHA256)
+SETUP_GRADLE_URL=$(read_var "$SETUP" GRADLE_DIST_URL)
+SETUP_GRADLE_URL="${SETUP_GRADLE_URL//\$\{GRADLE_VERSION\}/$SETUP_GRADLE_VERSION}"
+
+PROPS_URL=$(sed -n 's/^distributionUrl=//p' "$WRAPPER_PROPS" | head -n 1)
+PROPS_URL="${PROPS_URL//\\/}"
+PROPS_SHA=$(sed -n 's/^distributionSha256Sum=//p' "$WRAPPER_PROPS" | head -n 1)
+
+if [ -n "$SETUP_GRADLE_URL" ] && [ "$SETUP_GRADLE_URL" = "$PROPS_URL" ]; then
+    pass "GRADLE_DIST_URL matches gradle-wrapper.properties distributionUrl"
+else
+    fail "GRADLE_DIST_URL is '$SETUP_GRADLE_URL', gradle-wrapper.properties says '$PROPS_URL'"
+fi
+
+if [ -n "$SETUP_GRADLE_SHA" ] && [ "$SETUP_GRADLE_SHA" = "$PROPS_SHA" ]; then
+    pass "GRADLE_DIST_SHA256 matches gradle-wrapper.properties distributionSha256Sum"
+else
+    fail "GRADLE_DIST_SHA256 is '$SETUP_GRADLE_SHA', gradle-wrapper.properties says '$PROPS_SHA'"
+fi
+
+case "$PROPS_URL" in
+    *"gradle-${SETUP_GRADLE_VERSION}-bin.zip")
+        pass "GRADLE_VERSION ($SETUP_GRADLE_VERSION) is the version the wrapper downloads"
+        ;;
+    *)
+        fail "GRADLE_VERSION is '$SETUP_GRADLE_VERSION', which does not name the distribution in '$PROPS_URL'"
+        ;;
+esac
+
+# (c) the Android SDK pins agree with the session-start hook. Both provision the
+# same SDK; the hook per session, the Setup script once into the cached image.
+SETUP_TOOLS_URL=$(read_var "$SETUP" CMDLINE_TOOLS_URL)
+HOOK_TOOLS_URL=$(read_var "$HOOK" CMDLINE_TOOLS_URL)
+if [ -n "$HOOK_TOOLS_URL" ] && [ "$SETUP_TOOLS_URL" = "$HOOK_TOOLS_URL" ]; then
+    pass "CMDLINE_TOOLS_URL matches the session-start hook"
+else
+    fail "CMDLINE_TOOLS_URL is '$SETUP_TOOLS_URL', the hook uses '$HOOK_TOOLS_URL'"
+fi
+
+SETUP_ANDROID_HOME=$(read_var "$SETUP" ANDROID_HOME_DIR)
+HOOK_ANDROID_HOME=$(sed -n 's/^ANDROID_HOME_DIR=//p' "$HOOK" | head -n 1)
+if [ -n "$HOOK_ANDROID_HOME" ] && [ "$SETUP_ANDROID_HOME" = "$HOOK_ANDROID_HOME" ]; then
+    pass "ANDROID_HOME_DIR default matches the session-start hook ($HOOK_ANDROID_HOME)"
+else
+    fail "ANDROID_HOME_DIR is '$SETUP_ANDROID_HOME', the hook uses '$HOOK_ANDROID_HOME'"
+fi
+
+# The Setup script lists packages in an indexed array; the hook keys an
+# associative array by the same package strings. Compare them as sets.
+SETUP_PACKAGES=$(awk '/^SDK_PACKAGES=\(/ { inside = 1; next }
+                      inside && /^\)/ { inside = 0 }
+                      inside { gsub(/[" \t]/, ""); if ($0 != "") print }' "$SETUP" | sort)
+HOOK_PACKAGES=$(sed -n 's/^[[:space:]]*\["\([^"]*\)"\]=.*/\1/p' "$HOOK" | sort)
+if [ -n "$HOOK_PACKAGES" ] && [ "$SETUP_PACKAGES" = "$HOOK_PACKAGES" ]; then
+    pass "SDK package list matches the session-start hook ($(echo "$SETUP_PACKAGES" | wc -l) packages)"
+else
+    fail "SDK package list differs from the session-start hook"
+    echo "    Setup script: $(echo "$SETUP_PACKAGES" | tr '\n' ' ')"
+    echo "    hook:         $(echo "$HOOK_PACKAGES" | tr '\n' ' ')"
+fi
+
+# License hashes are 40-hex SHA-1 digests inside the printf lines that write the
+# licence files. Scoped to those lines so the 64-hex artifact checksums elsewhere
+# in the file cannot match.
+SETUP_LICENSES=$(grep 'printf' "$SETUP" | grep -oE '[0-9a-f]{40}' | sort)
+HOOK_LICENSES=$(grep 'printf' "$HOOK" | grep -oE '[0-9a-f]{40}' | sort)
+if [ -n "$HOOK_LICENSES" ] && [ "$SETUP_LICENSES" = "$HOOK_LICENSES" ]; then
+    pass "SDK license hashes match the session-start hook"
+else
+    fail "SDK license hashes differ from the session-start hook"
+fi
+
+# (d) the JDK path the Setup script installs to is the one the hook looks for.
+SETUP_TEMURIN=$(read_var "$SETUP" TEMURIN_HOME)
+HOOK_TEMURIN=$(sed -n 's/^TEMURIN_HOME=//p' "$HOOK" | head -n 1)
+if [ -n "$HOOK_TEMURIN" ] && [ "$SETUP_TEMURIN" = "$HOOK_TEMURIN" ]; then
+    pass "TEMURIN_HOME matches the path the session-start hook exports ($HOOK_TEMURIN)"
+else
+    fail "TEMURIN_HOME is '$SETUP_TEMURIN', the hook looks in '$HOOK_TEMURIN'"
+fi
+
+# --- Behavioral checks --------------------------------------------------------
+#
+# Both run the real script against a sandbox home, with every download URL
+# pointed at a nonexistent file:// path. Nothing touches the network: if the
+# script tries to download anything it is supposed to have found already, curl
+# fails and the case reports it.
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/setup-env-test-XXXXXX")
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# A stub JDK and SDK, so only the behavior under test is exercised.
+make_sandbox() {
+    local root="$1" pkg
+    mkdir -p "$root/home" "$root/jdk/bin" "$root/sdk/cmdline-tools/latest/bin"
+    : > "$root/jdk/bin/java"
+    chmod +x "$root/jdk/bin/java"
+    : > "$root/sdk/cmdline-tools/latest/bin/sdkmanager"
+    chmod +x "$root/sdk/cmdline-tools/latest/bin/sdkmanager"
+    mkdir -p "$root/sdk/licenses"
+    : > "$root/sdk/licenses/android-sdk-license"
+    for pkg in "platforms/android-35" "build-tools/36.0.0" "build-tools/35.0.0" \
+        "build-tools/34.0.0" "platform-tools"; do
+        mkdir -p "$root/sdk/$pkg"
+    done
+}
+
+run_setup() {
+    local root="$1"
+    SESSION_HOME="$root/home" \
+        GRADLE_USER_HOME="$root/home/.gradle" \
+        ANDROID_HOME="$root/sdk" \
+        TEMURIN_HOME="$root/jdk" \
+        GRADLE_DIST_DOWNLOAD_URL="file://$root/absent-gradle.zip" \
+        TEMURIN_DOWNLOAD_URL="file://$root/absent-jdk.tar.gz" \
+        bash "$SETUP" > "$root/out.log" 2>&1
+}
+
+# (e) a cache seeded at the path the Gradle wrapper actually uses is recognised.
+# The seeded directory name is the independently observed EXPECTED_DIST_HASH, so
+# if the script computed the hash differently it would find nothing there, attempt
+# the (unreachable) download, and fail.
+SEED="$SANDBOX/seed"
+make_sandbox "$SEED"
+SEED_DIST="$SEED/home/.gradle/wrapper/dists/gradle-${SETUP_GRADLE_VERSION}-bin/$EXPECTED_DIST_HASH"
+mkdir -p "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin"
+: > "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
+chmod +x "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}/bin/gradle"
+: > "$SEED_DIST/gradle-${SETUP_GRADLE_VERSION}-bin.zip.ok"
+if run_setup "$SEED"; then
+    if grep -q "already seeded" "$SEED/out.log"; then
+        pass "a cache seeded at the wrapper's own directory ($EXPECTED_DIST_HASH) is detected, no download"
+    else
+        fail "the script did not report the seeded distribution; it looked somewhere else"
+        sed 's/^/    /' "$SEED/out.log"
+    fi
+else
+    fail "the script failed against a correctly seeded cache (wrong cache path?)"
+    sed 's/^/    /' "$SEED/out.log"
+fi
+
+# (f) fail closed: bytes that do not match the pin must install nothing. The
+# distribution here is a valid zip carrying a plausible-looking Gradle tree, so
+# only the checksum can reject it.
+BAD="$SANDBOX/bad"
+make_sandbox "$BAD"
+# Structurally a valid distribution, down to the executable bit on bin/gradle, so
+# the checksum is the only thing that can reject it. If verification were ever
+# removed, this archive would install cleanly and the case below would say so.
+python3 - "$BAD/tampered.zip" "gradle-${SETUP_GRADLE_VERSION}" <<'PY'
+import sys
+import zipfile
+
+archive, dist = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(archive, "w") as zf:
+    entry = zipfile.ZipInfo(f"{dist}/bin/gradle")
+    entry.external_attr = 0o755 << 16
+    zf.writestr(entry, "#!/bin/sh\necho not gradle\n")
+PY
+if SESSION_HOME="$BAD/home" \
+    GRADLE_USER_HOME="$BAD/home/.gradle" \
+    ANDROID_HOME="$BAD/sdk" \
+    TEMURIN_HOME="$BAD/jdk" \
+    GRADLE_DIST_DOWNLOAD_URL="file://$BAD/tampered.zip" \
+    bash "$SETUP" > "$BAD/out.log" 2>&1; then
+    fail "a distribution failing the SHA-256 pin was accepted"
+elif grep -q "SHA-256 mismatch" "$BAD/out.log" \
+    && [ ! -d "$BAD/home/.gradle/wrapper/dists/gradle-${SETUP_GRADLE_VERSION}-bin/$EXPECTED_DIST_HASH/gradle-${SETUP_GRADLE_VERSION}" ]; then
+    pass "a distribution failing the SHA-256 pin is rejected and nothing is seeded"
+else
+    fail "the script rejected the distribution, but not for the checksum, or it seeded anyway"
+    sed 's/^/    /' "$BAD/out.log"
+fi
+
+# (g) the Setup script must never produce gradle/verification-metadata.xml. The
+# generator workflow is that file's only provenance (issue #774), and a locally
+# generated one would look identical while carrying no review trail.
+if grep -q 'verification-metadata\.xml' "$SETUP" \
+    && grep 'verification-metadata\.xml' "$SETUP" | grep -qvE '^[[:space:]]*#'; then
+    fail "setup-environment.sh acts on verification-metadata.xml; only the generator workflow may"
+else
+    pass "setup-environment.sh never writes verification-metadata.xml"
+fi
+
+echo
+echo "test_setup_environment.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
🤖 Author

Fixes #792.

Adds `.claude/setup-environment.sh`, the checked-in copy of the block that goes in the Setup script field of the Claude web environment configuration, plus the CI guard that keeps it honest and the documentation that tells the maintainer what to do with it.

## What the script does

- **Seeds the Gradle distribution into the wrapper's own cache**, so `./gradlew` starts offline instead of depending on the session proxy allowing `services.gradle.org` (blocked in 2026-07 sessions, open in 2026-08 ones, per #774's comments). The cache directory is Gradle's base-36 MD5 of the configured `distributionUrl`; the script computes it from `distributionUrl` itself, never from a mirror override, or the wrapper would read a different directory than the one seeded.
- **Installs Temurin 17** to `/opt/java/temurin-17`, so local validation matches CI's Java major version instead of the image's JDK 21. (CI asks for `java-version: '17'` and floats within 17.x; this pins an exact build, so patch levels will diverge.)
- **Provisions the Android SDK** from the same pins `.claude/hooks/session-start.sh` uses, once into the cached image rather than once per session. The hook's existing skip guards then make its SDK steps fast no-ops.

The script makes three downloads. The Gradle distribution and Temurin are each verified against a SHA-256 pinned in the script and refused on mismatch; their URLs are overridable for a blocked host, the pins are not, so a mirror is only ever trusted through the pin. The Android command-line tools fetch is **not** checksummed, because Google publishes no stable checksum for it and `sdkmanager` verifies the packages it subsequently fetches against its own manifest. That is the same trust boundary the hook and the generator workflow already operate on (#774), and it is stated in the script header and the docs rather than glossed.

The Gradle pin is load-bearing rather than belt-and-braces: the wrapper checks a distribution it downloads against `distributionSha256Sum`, but takes one it finds already installed as given, and deletes the zip once unpacked, so nothing is left to re-check. Seeding moves that check from the wrapper into this script.

Each step skips only when the work is already done *at the pinned version*, so a rebuild after a version bump reinstalls instead of reporting a stale install as present.

`session-start.sh` gains STEP 0b, pointing `JAVA_HOME` at that JDK when it is present. The Setup script is optional, so the step is conditional: on an environment where it was never configured, the session keeps the image's default JDK exactly as before.

## Why a guard test

The executable copy lives in a web form CI cannot read, and the script necessarily duplicates pins declared elsewhere in the tree. Duplication nothing checks rots, and this failure is quiet: a Gradle bump would leave sessions seeded with the previous distribution, the wrapper would ignore the seed, and sessions would silently go back to downloading.

`scripts/test_setup_environment.sh` (picked up automatically by the existing `shell-tests` job, which discovers `scripts/**/test_*.sh`) fails the build when the committed copy drifts from `gradle/wrapper/gradle-wrapper.properties` or from the session-start hook, when the checksum stops being fail-closed, when the seeded path stops matching the directory the wrapper reads, or when a step would skip its work on an image holding a different version. It cannot see the web form, so re-pasting after a change stays a human step; `gradle/README.md`'s Gradle-bump instructions and `.claude/environment.md` both say so.

## Validation

Run in this session, not inferred:

- The Setup script end to end: Temurin downloaded and SHA-256 verified, Gradle seeded, SDK steps correctly skipped as already present.
- `./gradlew --version` from the seeded cache with **all HTTPS egress broken** (proxy pointed at a dead port): started Gradle 9.5.1 on `Launcher JVM: 17.0.20 (Eclipse Adoptium)`. This is the offline claim, tested rather than assumed.
- `./gradlew testDebugUnitTest` on Temurin 17: BUILD SUCCESSFUL.
- The same build out of a Gradle home provisioned **only** by the Setup script, with a cold dependency cache: BUILD SUCCESSFUL, so the seeded distribution runs real builds under dependency verification, not just `--version`.
- The cache-directory hash the script computes (`iq79hdu3mqx29lgffhp8bfmx`) matches the directory the Gradle wrapper itself created. The guard test pins that observed value rather than recomputing it, which would assert nothing.
- Hook re-run both ways: with the JDK present (`Step 0b: JAVA_HOME=/opt/java/temurin-17`) and with it hidden (`no Setup-script JDK ... using the image default`), confirming the optional path stays fail-soft.
- Guard test 16/16, mutated seven ways (forgotten Gradle bump, SDK package added to the hook only, moved Temurin path, checksum verification disabled, wrapper cache path broken, version-blind JDK skip guard, stale JDK left in place) to confirm each is caught rather than passing vacuously.
- Network isolation of the behavioral cases proven with a `curl` shim that fails any non-`file://` URL: no case reaches the network.
- Full `shell-tests` suite green, and green in CI on the first push.

No existing test had its requirements loosened.

## Before merging

This is environment configuration, so the repo change alone does nothing until the block is installed, and nothing in CI can observe the result:

- [ ] Paste the contents of `.claude/setup-environment.sh` into the environment's Setup script field and rebuild the environment.
- [ ] In a fresh session afterwards, confirm the payoff: `./gradlew --version` starts without downloading a distribution (the wrapper prints no `Downloading` line), and `echo $JAVA_HOME` is `/opt/java/temurin-17`.

## Notes

`compileDebugJavaWithJavac` fails AGP's `jdkImage` transform when `GRADLE_USER_HOME` is put under this session's long `/tmp` scratch path. It is not related to this change (the script defaults that home to `$HOME/.gradle`, and the same build passes there and in a seeded home under `$HOME`), but it is recorded here in case it resurfaces.

The branch name predates the work and does not describe it; renaming mid-review is more churn than it is worth.