### PR TITLE
Do not merge: verify PR #794 - connectedDebugAndroidTest on emulator

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,12 +116,15 @@ android {
 
     // Shared pure-JVM test helpers compiled into both test and androidTest source sets.
     // AGP testFixtures does not support Kotlin on application modules (b/139438662).
+    // `directories` arrives prepopulated with the source set's defaults (src/<name>/java
+    // and src/<name>/kotlin) and is mutated in place, so `+=` adds to those defaults
+    // rather than replacing them.
     sourceSets {
         getByName("test") {
-            kotlin.srcDir("src/sharedTest/java")
+            kotlin.directories += "src/sharedTest/java"
         }
         getByName("androidTest") {
-            kotlin.srcDir("src/sharedTest/java")
+            kotlin.directories += "src/sharedTest/java"
         }
     }
 


### PR DESCRIPTION
Do not merge. Test PR created by the Verification Agent to exercise the `build.yml` CI workflow's `:app:connectedDebugAndroidTest` job (real Android emulator) against PR #794's head commit, per the before-merging item in tracking issue #798.

Item under test: does `:app:connectedDebugAndroidTest` pass on this branch, with `ShapeMatcher`, `ScreenshotNaming`, `PixelMask`, `ShapeTemplates`, and `MaskData` present and executed in the instrumentation suite?

This PR will be closed once verification completes.
