### PR TITLE
Document the KGP compatibility row and the toolchain-bump procedure in gradle/README.md

### DIFF
--- a/gradle/README.md
+++ b/gradle/README.md
@@ -89,23 +89,44 @@ A specific ceiling read off the tag on a given day decays silently as the tag mo
 Separately from the CodeQL ceiling, the Kotlin Gradle plugin documents which Gradle and AGP versions each KGP row supports, in the compatibility table on [Configure a Gradle project](https://kotlinlang.org/docs/gradle-configure-project.html).
 The row for the KGP version in use must cover both the intended Gradle version and the intended AGP version.
 
-This constraint usually binds before the CodeQL one.
-At the Gradle 9.5.1 / AGP 9.1.0 / KGP 2.4.0 pin (#774), the table's highest fully-supported Gradle is 9.5.0, on the row covering KGP 2.4.0 to 2.4.10, so no stable KGP row reaches Gradle 9.6 or above.
+Read that table at bump time.
+Like the CodeQL ceiling, it moves without notice, so no value from it is recorded here.
+
+The two constraints are independent, and neither subsumes the other: this row bounds Gradle and AGP for a given KGP, while the CodeQL ceiling bounds the Kotlin version itself.
+A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-only bump by the CodeQL ceiling alone.
+Check both, every time.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
-#774 accepted Gradle 9.5.1, one patch above KGP 2.4.x's fully-supported maximum of 9.5.0, because 9.5.0 is EOL (Gradle backports only to the latest minor of a major) and carries an OOM regression that 9.5.1 exists to fix.
+#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on, because Gradle had already superseded that maximum with 9.5.1 (fixes ship only in the newest patch of the newest minor, so the older patch would receive none) and because 9.5.1 exists to fix an OOM regression.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
 ## Performing a toolchain bump
 
 1. Check the KGP compatibility row and the CodeQL Kotlin ceiling, both above.
    Do this **before** editing any version, not after a red CI run.
+
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
-   A Gradle bump additionally touches every pin listed under the distribution-pin section above; the guard scripts named there fail the build if any is forgotten.
-3. Dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against the branch.
-   It regenerates the wrapper matched set and `verification-metadata.xml` from scratch, and uploads them as an artifact rather than committing them.
-4. Review the artifact, amend the regenerated files into the same commit as the step 2 edits, and open the PR.
-   #774's Step 5 records the review recipe: verify the wrapper JAR against its published checksum, reproduce the wrapper with `cmp` and `stat` (not `diff`, which is mode-blind), and diff the component listing rather than the checksum hashes.
+   Other pin sets travel with a bump depending on what moved:
+
+   - **A Gradle bump** touches every pin listed under the distribution-pin section above, *and* the `GRADLE_VERSION`, `DIST_SHA256`, and `WRAPPER_JAR_SHA256` values in `.github/workflows/regenerate-gradle-toolchain.yml`.
+     Miss those three and step 3 downloads the old Gradle and rewrites `gradle-wrapper.properties` back to it, so the run fails its own guard step and uploads no artifact, only the `DO-NOT-COMMIT` diagnostic.
+   - **An AGP bump** may move the required Android build-tools version, pinned in `.claude/hooks/session-start.sh`, `.claude/setup-environment.sh`, `.github/workflows/regenerate-gradle-toolchain.yml`, and the "Full Android toolchain" requirement above.
+
+   Know which of these are enforced.
+   `scripts/test_verification_metadata.sh` and `scripts/test_setup_environment.sh` fail the build on drift among the pins they compare, but nothing checks the generator workflow's three values against them, and nothing can check that `.claude/setup-environment.sh` has been re-pasted into the web form (see `.claude/environment.md`).
+   Those last two are human steps.
+
+3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
+   The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
+   It rebuilds the wrapper matched set and `verification-metadata.xml` from scratch and uploads them as an artifact rather than committing them.
+
+4. Review the artifact, then amend it into the step 2 commit and force-push.
+   #774's Step 5 records the review recipe: verify the wrapper JAR against its published checksum; regenerate the wrapper from the verified distribution and compare with `cmp` for content **and** `stat` for modes, since neither `cmp` nor `diff` sees the exec bit that the tarball packaging exists to preserve; and diff the artifact's `metadata-components.txt` against the same listing derived from the committed file (the generator's "Emit the pinned-component listing" step holds the script that produces it) rather than reading the checksum hashes.
+   Unpack the tarball outside the repository: `metadata-components.txt` is review-only and is not gitignored.
+
+5. Open the PR and let the complete `build.yml` run validate it, per the regeneration requirements above.
+   That full run is the only thing that catches a configuration whose dependencies were missed during generation; on a verification failure, re-run the merge-mode script and repeat until green.
+   #774 also requires a check CI cannot perform: after merge, install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
 
 The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -80,3 +80,32 @@ Read `2.4.1x` the same way: up to but not including 2.4.20.
 
 Note that `codeql-action@v4` is a force-moved tag, not an immutable one.
 A previously red `analyze-kotlin` can turn green on a plain re-run once the tag moves to a bundle whose CLI supports the Kotlin version in use, with no change to this repository.
+
+This section deliberately records the procedure for recomputing the ceiling rather than a cached answer.
+A specific ceiling read off the tag on a given day decays silently as the tag moves; the procedure stays correct.
+
+## KGP compatibility row
+
+Separately from the CodeQL ceiling, the Kotlin Gradle plugin documents which Gradle and AGP versions each KGP row supports, in the compatibility table on [Configure a Gradle project](https://kotlinlang.org/docs/gradle-configure-project.html).
+The row for the KGP version in use must cover both the intended Gradle version and the intended AGP version.
+
+This constraint usually binds before the CodeQL one.
+At the Gradle 9.5.1 / AGP 9.1.0 / KGP 2.4.0 pin (#774), the table's highest fully-supported Gradle is 9.5.0, on the row covering KGP 2.4.0 to 2.4.10, so no stable KGP row reaches Gradle 9.6 or above.
+
+Exceeding a row is a decision to record, not an error to avoid at all costs.
+#774 accepted Gradle 9.5.1, one patch above KGP 2.4.x's fully-supported maximum of 9.5.0, because 9.5.0 is EOL (Gradle backports only to the latest minor of a major) and carries an OOM regression that 9.5.1 exists to fix.
+Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
+
+## Performing a toolchain bump
+
+1. Check the KGP compatibility row and the CodeQL Kotlin ceiling, both above.
+   Do this **before** editing any version, not after a red CI run.
+2. Edit the versions.
+   The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
+   A Gradle bump additionally touches every pin listed under the distribution-pin section above; the guard scripts named there fail the build if any is forgotten.
+3. Dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against the branch.
+   It regenerates the wrapper matched set and `verification-metadata.xml` from scratch, and uploads them as an artifact rather than committing them.
+4. Review the artifact, amend the regenerated files into the same commit as the step 2 edits, and open the PR.
+   #774's Step 5 records the review recipe: verify the wrapper JAR against its published checksum, reproduce the wrapper with `cmp` and `stat` (not `diff`, which is mode-blind), and diff the component listing rather than the checksum hashes.
+
+The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -64,7 +64,8 @@ The regenerated `gradlew` launches with the standard `-jar gradle/wrapper/gradle
 
 When bumping the Gradle version, update both `distributionUrl` and `distributionSha256Sum` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256`), then regenerate `verification-metadata.xml`.
 Also update the same two pins in `.claude/setup-environment.sh`, which seeds that distribution into the Claude web environment's Gradle cache, and re-derive the `EXPECTED_DIST_HASH` in `scripts/test_setup_environment.sh` (that guard script fails the build if either is forgotten; `.claude/environment.md` explains why the pasted copy also has to be refreshed by hand).
-If the wrapper JAR itself changes, also update its pinned SHA-256 in `scripts/test_verification_metadata.sh` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`), along with the version and distribution constants next to it.
+Update the version and distribution constants in `scripts/test_verification_metadata.sh` on every Gradle bump, and the wrapper-JAR SHA-256 next to them whenever that JAR changes (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`).
+The JAR often does not change, since Gradle republishes it across releases, but the other two constants move regardless and the guard fails if they are left behind.
 
 ## CodeQL Kotlin ceiling
 
@@ -92,10 +93,9 @@ Neither value is recorded anywhere in this file: both move without notice, so a 
 
 The two constraints are independent, and neither subsumes the other: this row bounds Gradle and AGP for a given KGP, while the CodeQL ceiling bounds the Kotlin version itself.
 A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-only bump by the CodeQL ceiling alone.
-Check both, every time.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
-#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on, because that maximum carries an OOM regression and 9.5.1 is the release that fixes it.
+#774 accepted Gradle 9.5.1, one patch above whatever the row's fully-supported maximum was at the time, because that maximum carries an OOM regression and 9.5.1 is the release that fixes it.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
 ## Performing a toolchain bump
@@ -108,27 +108,29 @@ A JDK change has a wider blast radius and is not covered here.
 
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
-   A Gradle bump additionally touches every pin listed under the distribution-pin section above; several of those are checksums rather than version strings, and have to be re-derived from the published `.sha256` URLs named there.
-   An AGP bump can also move the Android build-tools version and the `compileSdk`/`targetSdk` in the three module build files.
+   A Gradle bump also moves every pin in the distribution-pin section above, plus the two places this file states the current Gradle version in prose: the docs link at the top and the distribution-pin paragraph.
+   An AGP bump can move the Android build-tools version, pinned in the generator workflow, in the `.claude/` provisioning scripts and their guard, and in the toolchain requirement above; it may also move `compileSdk`/`targetSdk` in the three module build files.
 
-   One further site is named here because no other section covers it: the `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml`, which repeats the Gradle version and both checksums.
-   Step 3 regenerates the wrapper for whatever that block declares rather than for what you edited, so leaving it stale either fails the run or, if the guard constants happen to be stale in the same direction, yields an artifact that reverts the bump.
-   No guard compares that block against anything: the two `scripts/test_*.sh` guards check only the pins they own, and the workflow's own `sha256sum -c` catches a version and checksum that disagree, not a pair that is uniformly out of date.
+   One site sits outside every section here and outside every guard: the `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml`, which repeats the Gradle version and both checksums.
+   Step 3 regenerates for whatever that block declares rather than for what you edited, so a stale block can fail the run, or quietly produce an artifact that reverts the bump.
+   Nothing compares it against the constants it duplicates.
 
    Do not grep-and-replace a version across the tree.
-   `gradle/verification-metadata.xml` holds hundreds of incidental matches and is regenerated wholesale in step 3, and this file cites past versions deliberately (the wrapper-JAR sharing note above, #774's decision below) and must keep them.
+   `gradle/verification-metadata.xml` holds hundreds of incidental matches and is regenerated wholesale in step 3, and the wrapper-JAR sharing note above and the #774 rationale in the previous section both cite past versions on purpose.
 
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
-   It rebuilds the wrapper matched set and `verification-metadata.xml` from scratch and uploads them for review rather than committing them.
-   A **failed** run uploads a different artifact, named `DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
+   It rebuilds `verification-metadata.xml` from scratch and then the wrapper matched set, an order chosen so the wrapper step runs under enforcement of the fresh pins, and uploads them as `gradle-toolchain-regenerated`.
+   A **failed** run instead uploads `gradle-toolchain-partial-DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
 4. Review the artifact per #774's Step 5, then amend it into the step 2 commit and force-push.
-   That recipe verifies the wrapper JAR against its published checksum, reproduces the wrapper from the verified distribution and compares content with `cmp` and modes with `stat`, and diffs the artifact's `metadata-components.txt` against the same listing derived from the committed file (the generator's "Emit the pinned-component listing" step holds the script that produces it) rather than reading the checksum hashes.
-   Unpack the tarball outside the repository: `metadata-components.txt` is review-only and is not gitignored.
+   That recipe verifies the wrapper JAR against its published checksum, reproduces the wrapper from the verified distribution and compares content with `cmp` and modes with `stat`, and diffs the artifact's component listing against the same listing derived from the committed file rather than reading the checksum hashes.
+   Unpack the tarball outside the repository: it carries a review-only `metadata-components.txt` that is not gitignored.
+   Extract rather than copy when bringing the files in, and confirm `git diff` reports no mode change on `gradlew`; the tarball exists precisely because `upload-artifact` strips permissions.
 
-5. Open the PR and let the complete `build.yml` run validate it, under "Review the diff" in the regeneration requirements above.
-   If it fails verification, re-dispatch the generator and re-amend rather than re-running the regeneration script locally: that script merges, which would reintroduce exactly the stale pins the from-scratch run exists to prune.
+5. Open the PR and let the complete `build.yml` run validate it end to end, which is the only thing that catches a configuration whose dependencies were missed during generation.
+   Before merging, delete the branch's Gradle cache entries and re-run it once, so at least one enforcing run resolves everything from the live registries (#774 Step 6).
+   On a verification failure, re-dispatch the generator and re-amend; do not re-run the regeneration script locally, since it merges and would reintroduce the pins the from-scratch run just pruned.
 
 6. Finish what CI cannot check.
    Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,6 +1,7 @@
 # Gradle build integrity
 
 This directory carries two "verify what you download" controls for the Gradle build, matching the posture already applied to ktlint (SHA-256 verified in `scripts/lint/install-ktlint.sh`) and the Python lint tools (pip `--require-hashes`, issue #723).
+It also carries the procedure for moving the toolchain those controls pin, which reaches beyond this directory; see "Performing a toolchain bump" at the end.
 
 ## `verification-metadata.xml` -- dependency verification (issue #714)
 
@@ -81,52 +82,56 @@ Read `2.4.1x` the same way: up to but not including 2.4.20.
 Note that `codeql-action@v4` is a force-moved tag, not an immutable one.
 A previously red `analyze-kotlin` can turn green on a plain re-run once the tag moves to a bundle whose CLI supports the Kotlin version in use, with no change to this repository.
 
-This section deliberately records the procedure for recomputing the ceiling rather than a cached answer.
-A specific ceiling read off the tag on a given day decays silently as the tag moves; the procedure stays correct.
-
 ## KGP compatibility row
 
 Separately from the CodeQL ceiling, the Kotlin Gradle plugin documents which Gradle and AGP versions each KGP row supports, in the compatibility table on [Configure a Gradle project](https://kotlinlang.org/docs/gradle-configure-project.html).
 The row for the KGP version in use must cover both the intended Gradle version and the intended AGP version.
 
-Read that table at bump time.
-Like the CodeQL ceiling, it moves without notice, so no value from it is recorded here.
+Read that table at bump time, and recompute the CodeQL ceiling the same way.
+Neither value is recorded anywhere in this file: both move without notice, so a cached answer decays silently while a procedure stays correct.
 
 The two constraints are independent, and neither subsumes the other: this row bounds Gradle and AGP for a given KGP, while the CodeQL ceiling bounds the Kotlin version itself.
 A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-only bump by the CodeQL ceiling alone.
 Check both, every time.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
-#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on, because Gradle had already superseded that maximum with 9.5.1 (fixes ship only in the newest patch of the newest minor, so the older patch would receive none) and because 9.5.1 exists to fix an OOM regression.
+#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on.
+At that moment 9.5 was Gradle's newest minor and 9.5.1 its newest patch, so the row's maximum would receive no further fixes while 9.5.1 would, and 9.5.1 exists to fix an OOM regression in it.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
 ## Performing a toolchain bump
+
+This covers a Gradle, AGP, KGP, or Compose-plugin bump.
+A JDK change has a wider blast radius and is not covered here.
 
 1. Check the KGP compatibility row and the CodeQL Kotlin ceiling, both above.
    Do this **before** editing any version, not after a red CI run.
 
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
-   Other pin sets travel with a bump depending on what moved:
 
-   - **A Gradle bump** touches every pin listed under the distribution-pin section above, *and* the `GRADLE_VERSION`, `DIST_SHA256`, and `WRAPPER_JAR_SHA256` values in `.github/workflows/regenerate-gradle-toolchain.yml`.
-     Miss those three and step 3 downloads the old Gradle and rewrites `gradle-wrapper.properties` back to it, so the run fails its own guard step and uploads no artifact, only the `DO-NOT-COMMIT` diagnostic.
-   - **An AGP bump** may move the required Android build-tools version, pinned in `.claude/hooks/session-start.sh`, `.claude/setup-environment.sh`, `.github/workflows/regenerate-gradle-toolchain.yml`, and the "Full Android toolchain" requirement above.
+   Every one of these versions is also written down outside the build files, and no enumeration here stays accurate.
+   **Grep the tree for the version string you are replacing and work through every hit.**
+   A Gradle version currently appears in the wrapper properties, two `.claude/` files, three `scripts/` files, the generator workflow, and this file's own prose; an Android build-tools version, which an AGP bump can move, appears in six files.
 
-   Know which of these are enforced.
-   `scripts/test_verification_metadata.sh` and `scripts/test_setup_environment.sh` fail the build on drift among the pins they compare, but nothing checks the generator workflow's three values against them, and nothing can check that `.claude/setup-environment.sh` has been re-pasted into the web form (see `.claude/environment.md`).
-   Those last two are human steps.
+   The generator workflow's `env:` block is the one worth naming, because it is the one that can silently undo the bump.
+   Step 3 regenerates the wrapper for whatever version that block declares, not the one you edited.
+   A stale block therefore either fails the run's own guard step, or, when the old and new releases happen to share a wrapper JAR, produces a **green** run whose artifact quietly reverts your version change.
+
+   Know what is enforced.
+   `scripts/test_verification_metadata.sh` and `scripts/test_setup_environment.sh` fail the build on drift among the pins they compare, but nothing reads `.github/workflows/regenerate-gradle-toolchain.yml` at all, and nothing can check that `.claude/setup-environment.sh` has been re-pasted into the web form (see `.claude/environment.md`).
+   Those are human steps.
 
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
    It rebuilds the wrapper matched set and `verification-metadata.xml` from scratch and uploads them as an artifact rather than committing them.
 
 4. Review the artifact, then amend it into the step 2 commit and force-push.
+   Unpack the tarball outside the repository: it carries a review-only `metadata-components.txt` that is not gitignored.
    #774's Step 5 records the review recipe: verify the wrapper JAR against its published checksum; regenerate the wrapper from the verified distribution and compare with `cmp` for content **and** `stat` for modes, since neither `cmp` nor `diff` sees the exec bit that the tarball packaging exists to preserve; and diff the artifact's `metadata-components.txt` against the same listing derived from the committed file (the generator's "Emit the pinned-component listing" step holds the script that produces it) rather than reading the checksum hashes.
-   Unpack the tarball outside the repository: `metadata-components.txt` is review-only and is not gitignored.
+   Once reviewed, extract the tracked files over the working tree with `tar` rather than copying them, so `gradlew` keeps the exec bit the tarball exists to preserve.
 
-5. Open the PR and let the complete `build.yml` run validate it, per the regeneration requirements above.
-   That full run is the only thing that catches a configuration whose dependencies were missed during generation; on a verification failure, re-run the merge-mode script and repeat until green.
-   #774 also requires a check CI cannot perform: after merge, install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
+5. Open the PR and let the complete `build.yml` run validate it, under "Review the diff" in the regeneration requirements above.
+   #774 additionally requires a check CI cannot perform: after merge, install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
 
 The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -110,6 +110,11 @@ Weigh any future overage the same way, and write down the reasoning: a patch abo
 This covers a Gradle, AGP, KGP, or Compose-plugin bump.
 A JDK change has a wider blast radius and is not covered here.
 
+> [!WARNING]
+> This procedure was reconstructed by reading the repository and #774, not by performing a bump.
+> No step below has been executed end to end.
+> Treat it as a checklist to verify against the current tree, and correct it from what you observe on the first real bump.
+
 1. Check the KGP compatibility row above, which binds on every bump this section covers.
    Add the CodeQL Kotlin ceiling check when the bump moves Kotlin, KGP, or the Kotlin compiler, per that section's own scope.
    Do this **before** editing any version, not after a red CI run.
@@ -126,6 +131,10 @@ A JDK change has a wider blast radius and is not covered here.
    Do not grep-and-replace a version across the tree.
    `gradle/verification-metadata.xml` carries dozens of incidental matches per version and is regenerated wholesale by step 3, so exclude it from any search.
 
+   > [!WARNING]
+   > Every version of this inventory has turned out incomplete when checked against the tree.
+   > Treat it as a starting point, search deliberately for the rest, and add what you find.
+
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    Do not open the PR yet: `build.yml` runs on pull requests, so opening one now spends a full build on a commit that is still half-migrated by design.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
@@ -141,6 +150,11 @@ A JDK change has a wider blast radius and is not covered here.
    `codeql.yml`'s `analyze-kotlin` job is what actually tests the ceiling computed in step 1, but on a pull request it runs only when the diff touches `.kt`, `.kts`, or `.java`, so a Gradle-only bump does not exercise it until the post-merge push to `main`.
    #774 Step 6 also asks for one enforcing run against live registries before merge; note that `build.yml`'s cache falls back through a `restore-keys` prefix, so clearing the branch's own entries is not sufficient on its own to force a cold resolve.
    On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
+
+   > [!WARNING]
+   > Review could not settle which remedy is correct here.
+   > A re-dispatch is deterministic, so it will reproduce the same pin set unless the task list in `scripts/regenerate-gradle-verification.sh` is what needs extending.
+   > Diagnose which of the two you are facing before spending a 20-45 minute run on it.
 
 6. Finish what CI cannot check.
    Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -87,7 +87,7 @@ A previously red `analyze-kotlin` can turn green on a plain re-run once the tag 
 Separately from the CodeQL ceiling, the Kotlin Gradle plugin documents which Gradle and AGP versions each KGP row supports, in the compatibility table on [Configure a Gradle project](https://kotlinlang.org/docs/gradle-configure-project.html).
 The row for the KGP version in use must cover both the intended Gradle version and the intended AGP version.
 
-Read that table at bump time, and recompute the CodeQL ceiling the same way.
+Read that table at bump time, and recompute the CodeQL ceiling by its own procedure above.
 Neither value is recorded anywhere in this file: both move without notice, so a cached answer decays silently while a procedure stays correct.
 
 The two constraints are independent, and neither subsumes the other: this row bounds Gradle and AGP for a given KGP, while the CodeQL ceiling bounds the Kotlin version itself.
@@ -95,8 +95,7 @@ A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-on
 Check both, every time.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
-#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on.
-At that moment 9.5 was Gradle's newest minor and 9.5.1 its newest patch, so the row's maximum would receive no further fixes while 9.5.1 would, and 9.5.1 exists to fix an OOM regression in it.
+#774 accepted Gradle 9.5.1, one patch above the fully-supported maximum of the KGP row it was on, because that maximum carries an OOM regression and 9.5.1 is the release that fixes it.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
 ## Performing a toolchain bump
@@ -109,29 +108,29 @@ A JDK change has a wider blast radius and is not covered here.
 
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
+   A Gradle bump additionally touches every pin listed under the distribution-pin section above; several of those are checksums rather than version strings, and have to be re-derived from the published `.sha256` URLs named there.
+   An AGP bump can also move the Android build-tools version and the `compileSdk`/`targetSdk` in the three module build files.
 
-   Every one of these versions is also written down outside the build files, and no enumeration here stays accurate.
-   **Grep the tree for the version string you are replacing and work through every hit.**
-   A Gradle version currently appears in the wrapper properties, two `.claude/` files, three `scripts/` files, the generator workflow, and this file's own prose; an Android build-tools version, which an AGP bump can move, appears in six files.
+   One further site is named here because no other section covers it: the `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml`, which repeats the Gradle version and both checksums.
+   Step 3 regenerates the wrapper for whatever that block declares rather than for what you edited, so leaving it stale either fails the run or, if the guard constants happen to be stale in the same direction, yields an artifact that reverts the bump.
+   No guard compares that block against anything: the two `scripts/test_*.sh` guards check only the pins they own, and the workflow's own `sha256sum -c` catches a version and checksum that disagree, not a pair that is uniformly out of date.
 
-   The generator workflow's `env:` block is the one worth naming, because it is the one that can silently undo the bump.
-   Step 3 regenerates the wrapper for whatever version that block declares, not the one you edited.
-   A stale block therefore either fails the run's own guard step, or, when the old and new releases happen to share a wrapper JAR, produces a **green** run whose artifact quietly reverts your version change.
-
-   Know what is enforced.
-   `scripts/test_verification_metadata.sh` and `scripts/test_setup_environment.sh` fail the build on drift among the pins they compare, but nothing reads `.github/workflows/regenerate-gradle-toolchain.yml` at all, and nothing can check that `.claude/setup-environment.sh` has been re-pasted into the web form (see `.claude/environment.md`).
-   Those are human steps.
+   Do not grep-and-replace a version across the tree.
+   `gradle/verification-metadata.xml` holds hundreds of incidental matches and is regenerated wholesale in step 3, and this file cites past versions deliberately (the wrapper-JAR sharing note above, #774's decision below) and must keep them.
 
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
-   It rebuilds the wrapper matched set and `verification-metadata.xml` from scratch and uploads them as an artifact rather than committing them.
+   It rebuilds the wrapper matched set and `verification-metadata.xml` from scratch and uploads them for review rather than committing them.
+   A **failed** run uploads a different artifact, named `DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
-4. Review the artifact, then amend it into the step 2 commit and force-push.
-   Unpack the tarball outside the repository: it carries a review-only `metadata-components.txt` that is not gitignored.
-   #774's Step 5 records the review recipe: verify the wrapper JAR against its published checksum; regenerate the wrapper from the verified distribution and compare with `cmp` for content **and** `stat` for modes, since neither `cmp` nor `diff` sees the exec bit that the tarball packaging exists to preserve; and diff the artifact's `metadata-components.txt` against the same listing derived from the committed file (the generator's "Emit the pinned-component listing" step holds the script that produces it) rather than reading the checksum hashes.
-   Once reviewed, extract the tracked files over the working tree with `tar` rather than copying them, so `gradlew` keeps the exec bit the tarball exists to preserve.
+4. Review the artifact per #774's Step 5, then amend it into the step 2 commit and force-push.
+   That recipe verifies the wrapper JAR against its published checksum, reproduces the wrapper from the verified distribution and compares content with `cmp` and modes with `stat`, and diffs the artifact's `metadata-components.txt` against the same listing derived from the committed file (the generator's "Emit the pinned-component listing" step holds the script that produces it) rather than reading the checksum hashes.
+   Unpack the tarball outside the repository: `metadata-components.txt` is review-only and is not gitignored.
 
 5. Open the PR and let the complete `build.yml` run validate it, under "Review the diff" in the regeneration requirements above.
-   #774 additionally requires a check CI cannot perform: after merge, install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
+   If it fails verification, re-dispatch the generator and re-amend rather than re-running the regeneration script locally: that script merges, which would reintroduce exactly the stale pins the from-scratch run exists to prune.
+
+6. Finish what CI cannot check.
+   Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
 
 The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -44,7 +44,7 @@ Requirements, and why they exist:
 - **Review the diff** (`git diff gradle/verification-metadata.xml`) before committing, then let the complete `build.yml` run (including the instrumented and E2E steps) validate it end to end.
   That full run is the only way to catch a configuration whose dependencies were missed during generation; on a verification failure Gradle names the offending artifact, so re-run the script (it merges into the existing file) and repeat until CI is green.
   That merge-mode remedy is for iterating on an unchanged toolchain.
-  During a toolchain bump, re-dispatch the generator workflow instead, since merging would reintroduce the pins its from-scratch run deliberately pruned (see "Performing a toolchain bump" below).
+  During a toolchain bump, re-dispatch the generator workflow instead: a local merge records the missing pin from whatever machine you are on, losing the Linux classifier guarantee and the CI provenance that make the generated file reviewable (see "Performing a toolchain bump" below).
 
 Contributors on macOS or Windows who only need a local build can pass `--dependency-verification lenient` to downgrade a verification failure to a warning.
 Never commit that flag into CI, and do not commit a file regenerated on a non-Linux machine.
@@ -66,8 +66,8 @@ The regenerated `gradlew` launches with the standard `-jar gradle/wrapper/gradle
 
 When bumping the Gradle version, update both `distributionUrl` and `distributionSha256Sum` (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-bin.zip.sha256`), then regenerate `verification-metadata.xml`.
 Also update the same two pins in `.claude/setup-environment.sh`, which seeds that distribution into the Claude web environment's Gradle cache, and re-derive the `EXPECTED_DIST_HASH` in `scripts/test_setup_environment.sh` (that guard script fails the build if either is forgotten; `.claude/environment.md` explains why the pasted copy also has to be refreshed by hand).
-Update the version and distribution constants in `scripts/test_verification_metadata.sh` on every Gradle bump, and the wrapper-JAR SHA-256 next to them whenever that JAR changes (the published checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`).
-The JAR often does not change, since Gradle republishes it across releases, but the other two constants move regardless and the guard fails if they are left behind.
+On every Gradle bump, re-read all three constants in `scripts/test_verification_metadata.sh` from their published URLs in one change, as that script's own header instructs (the wrapper-JAR checksum is at `https://services.gradle.org/distributions/gradle-<version>-wrapper.jar.sha256`).
+The JAR value often turns out unchanged, since Gradle republishes it across releases, but you only learn that by fetching it.
 
 ## CodeQL Kotlin ceiling
 
@@ -112,29 +112,30 @@ A JDK change has a wider blast radius and is not covered here.
 
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
-   For the surrounding pins, work from two lists rather than one written here: the distribution-pin section above for a Gradle bump, and #774 Step 3 for the wider set a migration touches, including the build-tools and SDK-platform pins an AGP bump can move.
-   Expect a residue of version literals in prose and in script headers that no guard reads.
+   For a Gradle bump the surrounding pins are the ones named in the distribution-pin section above.
+   Beyond those, a handful of version literals sit in prose and script headers that no guard reads: the docs URL and the toolchain requirement near the top of this file, the header of `scripts/regenerate-gradle-verification.sh`, and the AGP comment in `.claude/hooks/session-start.sh`.
 
-   One site is easy to miss because no section above names it.
-   The `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml` duplicates the Gradle version and both checksums.
-   The workflow runs the build-integrity guard in the same job, so a block that disagrees with `scripts/test_verification_metadata.sh` fails the run loudly; a bump that leaves **both** of them stale passes instead, and the resulting artifact silently reverts the version change.
+   Two sites in `.github/workflows/regenerate-gradle-toolchain.yml` are easy to miss because no section above names them.
+   Its `env:` block duplicates the Gradle version and both checksums; the workflow runs the build-integrity guard in the same job, so a block that disagrees with `scripts/test_verification_metadata.sh` fails the run loudly, but a bump that leaves **both** of them stale passes instead, and the artifact then reverts the version change.
+   Its `sdkmanager --install` line pins the build-tools and SDK platform separately from the `.claude/` provisioning scripts, and nothing cross-checks it against them.
 
    Do not grep-and-replace a version across the tree.
-   `gradle/verification-metadata.xml` alone holds hundreds of incidental matches, and it is regenerated wholesale in step 3.
+   `gradle/verification-metadata.xml` carries dozens of incidental matches per version and is regenerated wholesale by step 3, so exclude it from any search.
 
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
-   Do not open the PR yet.
-   `build.yml` runs on pull requests, so opening one now puts a full build against a half-migrated commit and auto-files an issue for every failure.
+   Do not open the PR yet: `build.yml` runs on pull requests, so opening one now spends a full build on a commit that is still half-migrated by design.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
    It rebuilds `verification-metadata.xml` from scratch and then the wrapper matched set, an order chosen so the wrapper step runs under enforcement of the fresh pins, and uploads them as `gradle-toolchain-regenerated`.
    A **failed** run instead uploads `gradle-toolchain-partial-DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
-4. Review the artifact against #774's Step 5, which holds the recipe verbatim, then amend it into the step 2 commit and force-push.
+4. Review the downloaded artifact, then bring the files into the tree, amend them into the step 2 commit, and force-push.
+   #774's Step 5 holds the review recipe, but it is written with 9.5.1 literals throughout, so substitute your own version and checksum rather than running its commands as printed.
    Unpack the tarball somewhere outside the working tree: it carries a review-only `metadata-components.txt` whose path inside the archive is the repository root, and which is not gitignored.
-   When you bring the reviewed files in, keep `gradlew` executable and confirm `git diff` reports no mode change on it; the tarball format exists because `upload-artifact` strips permissions.
+   Keep `gradlew` executable, and confirm `git diff` reports no mode change on it; the tarball format exists because `upload-artifact` strips permissions.
 
-5. Open the PR and let the full gate set validate it: `build.yml` end to end, and `codeql.yml`, whose `analyze-kotlin` job is what actually tests the ceiling you computed in step 1.
-   Before merging, delete the branch's Gradle cache entries and re-run `build.yml` once, so at least one enforcing run resolves everything from the live registries (#774 Step 6).
+5. Open the PR and let `build.yml` validate it end to end.
+   `codeql.yml`'s `analyze-kotlin` job is what actually tests the ceiling computed in step 1, but on a pull request it runs only when the diff touches `.kt`, `.kts`, or `.java`, so a Gradle-only bump does not exercise it until the post-merge push to `main`.
+   #774 Step 6 also asks for one enforcing run against live registries before merge; note that `build.yml`'s cache falls back through a `restore-keys` prefix, so clearing the branch's own entries is not sufficient on its own to force a cold resolve.
    On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
 
 6. Finish what CI cannot check.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -91,14 +91,17 @@ Separately from the CodeQL ceiling, the Kotlin Gradle plugin documents which Gra
 The row for the KGP version in use must cover both the intended Gradle version and the intended AGP version.
 
 Read that table at bump time, and recompute the CodeQL ceiling by its own procedure above.
-Neither value is recorded anywhere in this file: both move without notice, so a cached answer decays silently while a procedure stays correct.
+Treat no version printed anywhere in this file as a current bound: the wildcard forms above illustrate the notation, not today's ceiling, and both limits move without notice.
 
-The two constraints are independent, and neither subsumes the other: this row bounds Gradle and AGP for a given KGP, while the CodeQL ceiling bounds the Kotlin version itself.
-A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-only bump by the CodeQL ceiling alone.
+The row constrains in both directions, which is what makes it easy to underestimate.
+For a given KGP it bounds Gradle and AGP, so a Gradle-only or AGP-only bump can be blocked by it.
+For a given Gradle and AGP pair it also bounds which KGP rows are available at all: #774 found KGP 2.4.x forced rather than chosen, because it was the only row covering Gradle 9.5.x together with AGP 9.1.0.
+So a KGP-only bump is governed by this row too, not by the CodeQL ceiling alone.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
 #774 accepted Gradle 9.5.1, one patch above whatever the row's fully-supported maximum was at the time.
-That maximum carries an OOM regression, 9.5.1 is the release that fixes it, and no further patch of it will ever exist, so staying inside the row meant shipping a known bug.
+That maximum carries an OOM regression, and the fix for it shipped only in 9.5.1, outside the row.
+Gradle patches only its newest minor, so no later release inside the row would ever carry that fix, and staying in-row meant shipping a known bug indefinitely.
 #774 also rejected the obvious workaround of raising the daemon heap instead.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
@@ -107,7 +110,8 @@ Weigh any future overage the same way, and write down the reasoning: a patch abo
 This covers a Gradle, AGP, KGP, or Compose-plugin bump.
 A JDK change has a wider blast radius and is not covered here.
 
-1. Check the KGP compatibility row and the CodeQL Kotlin ceiling, both above.
+1. Check the KGP compatibility row above, which binds on every bump this section covers.
+   Add the CodeQL Kotlin ceiling check when the bump moves Kotlin, KGP, or the Kotlin compiler, per that section's own scope.
    Do this **before** editing any version, not after a red CI run.
 
 2. Edit the versions.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -43,6 +43,8 @@ Requirements, and why they exist:
   A JDK-only environment cannot resolve the Android dependency graph, which is why this was split out of the pip-hashing work in issue #699.
 - **Review the diff** (`git diff gradle/verification-metadata.xml`) before committing, then let the complete `build.yml` run (including the instrumented and E2E steps) validate it end to end.
   That full run is the only way to catch a configuration whose dependencies were missed during generation; on a verification failure Gradle names the offending artifact, so re-run the script (it merges into the existing file) and repeat until CI is green.
+  That merge-mode remedy is for iterating on an unchanged toolchain.
+  During a toolchain bump, re-dispatch the generator workflow instead, since merging would reintroduce the pins its from-scratch run deliberately pruned (see "Performing a toolchain bump" below).
 
 Contributors on macOS or Windows who only need a local build can pass `--dependency-verification lenient` to downgrade a verification failure to a warning.
 Never commit that flag into CI, and do not commit a file regenerated on a non-Linux machine.
@@ -95,7 +97,9 @@ The two constraints are independent, and neither subsumes the other: this row bo
 A Gradle-only or AGP-only bump can be blocked by this row alone, and a Kotlin-only bump by the CodeQL ceiling alone.
 
 Exceeding a row is a decision to record, not an error to avoid at all costs.
-#774 accepted Gradle 9.5.1, one patch above whatever the row's fully-supported maximum was at the time, because that maximum carries an OOM regression and 9.5.1 is the release that fixes it.
+#774 accepted Gradle 9.5.1, one patch above whatever the row's fully-supported maximum was at the time.
+That maximum carries an OOM regression, 9.5.1 is the release that fixes it, and no further patch of it will ever exist, so staying inside the row meant shipping a known bug.
+#774 also rejected the obvious workaround of raising the daemon heap instead.
 Weigh any future overage the same way, and write down the reasoning: a patch above the row is a far smaller step than a minor above it.
 
 ## Performing a toolchain bump
@@ -108,29 +112,30 @@ A JDK change has a wider blast radius and is not covered here.
 
 2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
-   A Gradle bump also moves every pin in the distribution-pin section above, plus the two places this file states the current Gradle version in prose: the docs link at the top and the distribution-pin paragraph.
-   An AGP bump can move the Android build-tools version, pinned in the generator workflow, in the `.claude/` provisioning scripts and their guard, and in the toolchain requirement above; it may also move `compileSdk`/`targetSdk` in the three module build files.
+   For the surrounding pins, work from two lists rather than one written here: the distribution-pin section above for a Gradle bump, and #774 Step 3 for the wider set a migration touches, including the build-tools and SDK-platform pins an AGP bump can move.
+   Expect a residue of version literals in prose and in script headers that no guard reads.
 
-   One site sits outside every section here and outside every guard: the `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml`, which repeats the Gradle version and both checksums.
-   Step 3 regenerates for whatever that block declares rather than for what you edited, so a stale block can fail the run, or quietly produce an artifact that reverts the bump.
-   Nothing compares it against the constants it duplicates.
+   One site is easy to miss because no section above names it.
+   The `env:` block of `.github/workflows/regenerate-gradle-toolchain.yml` duplicates the Gradle version and both checksums.
+   The workflow runs the build-integrity guard in the same job, so a block that disagrees with `scripts/test_verification_metadata.sh` fails the run loudly; a bump that leaves **both** of them stale passes instead, and the resulting artifact silently reverts the version change.
 
    Do not grep-and-replace a version across the tree.
-   `gradle/verification-metadata.xml` holds hundreds of incidental matches and is regenerated wholesale in step 3, and the wrapper-JAR sharing note above and the #774 rationale in the previous section both cite past versions on purpose.
+   `gradle/verification-metadata.xml` alone holds hundreds of incidental matches, and it is regenerated wholesale in step 3.
 
 3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
+   Do not open the PR yet.
+   `build.yml` runs on pull requests, so opening one now puts a full build against a half-migrated commit and auto-files an issue for every failure.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
    It rebuilds `verification-metadata.xml` from scratch and then the wrapper matched set, an order chosen so the wrapper step runs under enforcement of the fresh pins, and uploads them as `gradle-toolchain-regenerated`.
    A **failed** run instead uploads `gradle-toolchain-partial-DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
-4. Review the artifact per #774's Step 5, then amend it into the step 2 commit and force-push.
-   That recipe verifies the wrapper JAR against its published checksum, reproduces the wrapper from the verified distribution and compares content with `cmp` and modes with `stat`, and diffs the artifact's component listing against the same listing derived from the committed file rather than reading the checksum hashes.
-   Unpack the tarball outside the repository: it carries a review-only `metadata-components.txt` that is not gitignored.
-   Extract rather than copy when bringing the files in, and confirm `git diff` reports no mode change on `gradlew`; the tarball exists precisely because `upload-artifact` strips permissions.
+4. Review the artifact against #774's Step 5, which holds the recipe verbatim, then amend it into the step 2 commit and force-push.
+   Unpack the tarball somewhere outside the working tree: it carries a review-only `metadata-components.txt` whose path inside the archive is the repository root, and which is not gitignored.
+   When you bring the reviewed files in, keep `gradlew` executable and confirm `git diff` reports no mode change on it; the tarball format exists because `upload-artifact` strips permissions.
 
-5. Open the PR and let the complete `build.yml` run validate it end to end, which is the only thing that catches a configuration whose dependencies were missed during generation.
-   Before merging, delete the branch's Gradle cache entries and re-run it once, so at least one enforcing run resolves everything from the live registries (#774 Step 6).
-   On a verification failure, re-dispatch the generator and re-amend; do not re-run the regeneration script locally, since it merges and would reintroduce the pins the from-scratch run just pruned.
+5. Open the PR and let the full gate set validate it: `build.yml` end to end, and `codeql.yml`, whose `analyze-kotlin` job is what actually tests the ceiling you computed in step 1.
+   Before merging, delete the branch's Gradle cache entries and re-run `build.yml` once, so at least one enforcing run resolves everything from the live registries (#774 Step 6).
+   On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
 
 6. Finish what CI cannot check.
    Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -131,7 +131,7 @@ A JDK change has a wider blast radius and is not covered here.
    Do not grep-and-replace a version across the tree.
    `gradle/verification-metadata.xml` carries dozens of incidental matches per version and is regenerated wholesale by step 3, so exclude it from any search.
 
-   > [!WARNING]
+   > [!IMPORTANT]
    > Every version of this inventory has turned out incomplete when checked against the tree.
    > Treat it as a starting point, search deliberately for the rest, and add what you find.
 
@@ -151,7 +151,7 @@ A JDK change has a wider blast radius and is not covered here.
    #774 Step 6 also asks for one enforcing run against live registries before merge; note that `build.yml`'s cache falls back through a `restore-keys` prefix, so clearing the branch's own entries is not sufficient on its own to force a cold resolve.
    On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
 
-   > [!WARNING]
+   > [!CAUTION]
    > Review could not settle which remedy is correct here.
    > A re-dispatch is deterministic, so it will reproduce the same pin set unless the task list in `scripts/regenerate-gradle-verification.sh` is what needs extending.
    > Diagnose which of the two you are facing before spending a 20-45 minute run on it.


### PR DESCRIPTION
Refs #789.

Captures into `gradle/README.md` the two parts of a toolchain bump that #789 identified as recorded only in #774, which is closed.

## What was missing

Most of #789's recipe was already in `gradle/README.md`: the CodeQL Kotlin ceiling check, and the Gradle distribution-pin file list. Two things were not written down anywhere in the repo:

- **The KGP compatibility row constraint.** `KGP` appeared exactly once in the whole tree, inside the CodeQL section. The requirement that the row must cover the intended Gradle *and* AGP versions was recorded nowhere. It also binds in the reverse direction, which is the case that bit #774: KGP 2.4.x was forced rather than chosen, as the only row covering Gradle 9.5.x with AGP 9.1.0.
- **The bump procedure.** `regenerate-gradle-toolchain.yml` appeared once, only to explain why it deletes `verification-metadata.xml`. Nothing said that dispatching it against the branch, reviewing the artifact, amending, and then opening the PR is how a bump is performed.

Also carried over: #774's rationale for accepting a Gradle version above the row's maximum, including the EOL half and its explicit rejection of raising the daemon heap instead.

## Deliberately not carried over

Any current ceiling value, including #789's "KGP 2.4.10 is now clear of the CodeQL ceiling". Those are snapshots of a force-moved tag and an upstream table, and they decay silently. The document stores the procedures for recomputing them.

## Confidence is not uniform, and the document says so

Seven review passes at maximum effort produced roughly 90 findings, and the count never declined (11, 12, 14, 15, 14, 13, 12). The two halves behaved very differently, and that difference is now marked in the text rather than smoothed over:

- **The KGP compatibility row section converged.** Substantively stable since the third pass, with every claim verified against the kotlinlang compatibility table, #774, and the build files. It carries no alert.
- **The bump procedure did not.** It was reconstructed by reading the repository, not by performing a bump, and successive passes reversed each other on the same sentences. Three graded alerts mark this: a section-level `WARNING` that no step has been executed end to end, an `IMPORTANT` on the pin inventory (found incomplete in four separate passes, under both the enumerate-here and point-at-#774 forms), and a `CAUTION` on the step 5 remedy, where review could not settle whether a re-dispatch or a local merge is correct.

Landing it in this form is deliberate. An unverified procedure labelled as unverified is more useful than no procedure and safer than an authoritative-looking one, and the alerts tell the first person to perform a real bump exactly where to correct it.

## Fixes to existing text

Two pre-existing defects surfaced during review and are fixed here, since the new procedure depends on both:

- The distribution-pin section gated all three `scripts/test_verification_metadata.sh` constants on the wrapper JAR changing. That JAR is shared across releases, so a reader could correctly evaluate the condition as false and still leave two stale constants that fail the guard.
- The "Review the diff" bullet's merge-mode remedy had no toolchain-bump exception, and now scopes itself to an unchanged toolchain.

## Test plan

Docs-only; no behavior change and no new code paths, so no automated tests accompany it.

- [x] `scripts/lint/lint.sh --check --only markdown --all` clean
- [x] `scripts/lint/lint.sh --check --only hygiene --all` clean
