### PR TITLE
Point the toolchain-bump entry points at gradle/README.md

### DIFF
--- a/.github/workflows/regenerate-gradle-toolchain.yml
+++ b/.github/workflows/regenerate-gradle-toolchain.yml
@@ -3,6 +3,11 @@ name: Regenerate Gradle toolchain (wrapper + verification metadata)
 # Manual, deliberate trigger only. Lives on main so workflow_dispatch registers;
 # dispatch it with ref=<branch> to run a branch's version. Produces an artifact
 # for human review and commit; it never pushes.
+#
+# Dispatching this is step 3 of "Performing a toolchain bump" in gradle/README.md.
+# Read that first: the env: block below duplicates pins declared elsewhere, and
+# nothing compares them, so a bump that edits one and not the other can produce a
+# green run whose artifact reverts the version change.
 on:
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
 - If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
 - If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.
+- If bumping the Gradle, AGP, KGP, or Compose-plugin version, read `./gradle/README.md`.

--- a/scripts/regenerate-gradle-verification.sh
+++ b/scripts/regenerate-gradle-verification.sh
@@ -22,6 +22,9 @@
 #   * This script MERGES into the existing gradle/verification-metadata.xml. That
 #     is the safe local behaviour: an interrupted or failed run never leaves the
 #     working tree with verification silently switched off.
+#     Merge mode is for iterating on an unchanged toolchain. During a version
+#     bump, re-dispatch the generator workflow instead; see "Performing a
+#     toolchain bump" in gradle/README.md.
 #   * The generator workflow DELETES the file first, so the regenerated one is
 #     built from scratch and carries no stale pins. That rm lives in the workflow
 #     (never here) precisely because this script also runs on developer machines.

--- a/scripts/test_verification_metadata.sh
+++ b/scripts/test_verification_metadata.sh
@@ -10,6 +10,10 @@
 # resolve on the full Android toolchain can do that, which is what CI exercises end to
 # end); they assert the file's structural invariants.
 #
+# If a check here fails during a version bump, see "Performing a toolchain bump"
+# in gradle/README.md: the constants below are duplicated in the generator
+# workflow, and a bump has to move both.
+#
 # Covers:
 #   (a) gradle/verification-metadata.xml exists and is well-formed XML
 #   (b) verify-metadata is "true" (metadata files are pinned)


### PR DESCRIPTION
Follow-up to #802. Refs #789.

#802 landed the toolchain-bump procedure into `gradle/README.md`, but nothing in the tree referenced that file. A grep for `gradle/README.md` across every `.md`, `.sh`, and `.yml` returned zero hits, so the procedure was not discoverable from any of the files it tells you to edit. That is the same decay that let #774's recipe sit unread in a closed issue, which is what #789 was filed about in the first place.

## The four pointers

Placed where someone actually starts, or lands, during a bump:

- **`AGENTS.md`** routes agents by task and had no toolchain-bump row. An agent assigned an issue like #789 reads this file first and would otherwise never learn the procedure exists.
- **`.github/workflows/regenerate-gradle-toolchain.yml`** is the entry point for anyone dispatching a regeneration. Its note also names the `env:` block duplication, because that is the trap the procedure exists to warn about and this workflow is where a reader meets it.
- **`scripts/test_verification_metadata.sh`** is where a bump that missed a pin actually surfaces, so the pointer goes from the failure back to the procedure.
- **`scripts/regenerate-gradle-verification.sh`** describes merge mode in its header without the toolchain-bump exception. This was a second copy of guidance that #802 corrected in `gradle/README.md` only, so it had already begun to drift.

## Test plan

Comments plus one Markdown list item; no behavior change and no new code paths, so no automated tests accompany it.

- [x] `scripts/lint/lint.sh --check --only markdown --all` clean
- [x] `scripts/lint/lint.sh --check --only hygiene --all` clean
- [x] `.github/workflows/regenerate-gradle-toolchain.yml` parses as YAML
- [x] Full shell suite (`find scripts -name 'test_*.sh'`) run locally: all pass except `test_summarize_preflight_integration.sh`, which fails identically on unmodified `main` for a missing local `defusedxml` module and is unrelated to this change

