### PR TITLE
Install the helper-script lock at session start, through a shared pinned-requirements installer

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -62,7 +62,7 @@ It fails the build when the committed copy drifts from `gradle/wrapper/gradle-wr
 
 - It never regenerates `gradle/verification-metadata.xml`. The generator workflow is that file's only provenance (#774).
 - It provisions no emulator. The E2E suites need KVM, which web sessions do not have, so they stay CI-only.
-- It installs no pip packages. The two hash-pinned locks a session needs (`scripts/lint/requirements-lint.txt` and `scripts/requirements.txt`) are installed by the hook into the session user's `~/.local`, and its SHA-256 markers already make that a no-op once a lock is in place. They come to about a megabyte of wheels, against the ~130 MB Gradle distribution and ~190 MB JDK this script exists to keep out of every session, so seeding them here would duplicate the marker logic to save a few seconds (#806).
+- It installs no pip packages (#806). Both hash-pinned locks (`scripts/lint/requirements-lint.txt` and `scripts/requirements.txt`) are installed per session by the hook, into the session user's `~/.local`. Seeding them here would inherit the `SESSION_HOME` guess above, and a wrong guess would be invisible: the session would simply install them itself and look no different, where a mis-seeded Gradle at least shows up as a download. It would also put a second copy of the marker logic in a script CI can only partly verify, and to be coherent it would have to seed both locks, including the much larger lint one (about 31 MB installed, nearly all of it `ruff`). What that buys back is one `pip install` per session, about 5 MB installed for the helper deps and about 31 MB for the lint tools, from PyPI, which is not the path that has actually proved flaky here. That is the same cost this script exists to eliminate for the ~130 MB Gradle distribution and ~190 MB JDK, at a scale where it does not pay.
 - It never trusts a hash published by whatever served the bytes. `GRADLE_DIST_DOWNLOAD_URL` and `TEMURIN_DOWNLOAD_URL` can redirect those *downloads* to a mirror if a host is blocked; the pinned SHA-256 still gates what that mirror serves.
 
 ### What is and is not checksummed
@@ -128,6 +128,8 @@ Nothing is git-cloned or fetched from GitHub Releases at commit time (issue #667
 | Python lint tools | 3b   | PyPI (`scripts/lint/requirements-lint.txt`)        | `ruff`, `pre-commit-hooks` checks, `mdformat` + plugins; in `~/.local/bin`  |
 | git hook          | 3c   | `core.hooksPath` = `scripts/git-hooks`             | runs `scripts/lint/lint.sh` on staged files on every `git commit`           |
 
+That table is the lint stack only, not everything the hook installs: step 4 also installs the Python helper scripts' runtime dependencies, covered in its own section below.
+
 The `ktlint` JAR is stored under `~/.local/lib/ktlint/`.
 `ruff` version tracks the ruff-pre-commit pin (issue #673); `pre-commit-hooks` is the same upstream project as before, now installed from PyPI instead of cloned, and exposes each generic check as a console script.
 
@@ -174,11 +176,13 @@ The Python helper scripts' runtime deps (`defusedxml`, `requests`, `PyYAML`) com
 Regenerate the lock with the `uv pip compile` command recorded in that `.in` file's header.
 
 Both sides install it: CI in `.github/workflows/build.yml`, and the `SessionStart` hook in step 4 (issue #806).
-The session install is what makes the whole test suite runnable locally; without it, four of the Python test modules and `scripts/ci/test-support/test_summarize_preflight_integration.sh` fail with `No module named 'defusedxml'` whatever the change under test is.
-It also makes the versions this repository declares the ones a session runs: `requests` and `PyYAML` happen to resolve from the base image, so a change there would extend the same failure to them with no other signal.
+The session install is what makes the whole test suite runnable in a session; without it, four of the Python test modules and `scripts/ci/test-support/test_summarize_preflight_integration.sh` fail with `No module named 'defusedxml'` whatever the change under test is.
+The hook returns immediately unless `CLAUDE_CODE_REMOTE=true`, so a checkout on your own machine is not covered by it: install the lock there yourself with `pip install --require-hashes -r scripts/requirements.txt`, the command CI runs.
+The install also makes the versions this repository declares the ones a session runs: `requests` and `PyYAML` happen to resolve from the base image, so a change there would extend the same failure to them with no other signal.
 
 Steps 3b and 4 both install through `scripts/install-pinned-requirements.sh`, which records the SHA-256 of the lock it installed under `~/.local/share/gb4pc/`.
-An unchanged lock is therefore a no-op on later sessions, an edited one reinstalls, and a failed install writes no marker and is retried.
+A re-run against an unchanged lock is therefore a no-op, an edited lock reinstalls, and a failed install writes no marker and is retried.
+That marker sits in the session's own home rather than in the cached image, so it makes the hook cheap to re-run within a container; it does not carry across sessions, and a later session installs again.
 `scripts/test_install_pinned_requirements.sh` covers that behavior, and fails the build if `build.yml` installs a lock the hook does not.
 
 ______________________________________________________________________

--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -62,6 +62,7 @@ It fails the build when the committed copy drifts from `gradle/wrapper/gradle-wr
 
 - It never regenerates `gradle/verification-metadata.xml`. The generator workflow is that file's only provenance (#774).
 - It provisions no emulator. The E2E suites need KVM, which web sessions do not have, so they stay CI-only.
+- It installs no pip packages. The two hash-pinned locks a session needs (`scripts/lint/requirements-lint.txt` and `scripts/requirements.txt`) are installed by the hook into the session user's `~/.local`, and its SHA-256 markers already make that a no-op once a lock is in place. They come to about a megabyte of wheels, against the ~130 MB Gradle distribution and ~190 MB JDK this script exists to keep out of every session, so seeding them here would duplicate the marker logic to save a few seconds (#806).
 - It never trusts a hash published by whatever served the bytes. `GRADLE_DIST_DOWNLOAD_URL` and `TEMURIN_DOWNLOAD_URL` can redirect those *downloads* to a mirror if a host is blocked; the pinned SHA-256 still gates what that mirror serves.
 
 ### What is and is not checksummed
@@ -165,10 +166,20 @@ Findings block the PR.
 The engine is installed from `scripts/ci/requirements-semgrep.txt`, a hash-pinned lock (top-level pin in `scripts/ci/requirements-semgrep.in`), with `--require-hashes` (issue #723); the rulesets are still fetched from the Semgrep registry at scan time, so the weekly run keeps picking up new rules.
 Regenerate the lock with the `uv pip compile` command recorded in that `.in` file's header.
 
-### CI helper-script dependencies
+______________________________________________________________________
 
-The Python helper scripts' runtime deps (`defusedxml`, `requests`, `PyYAML`) install in CI (`.github/workflows/build.yml`) from `scripts/requirements.txt`, a hash-pinned lock (top-level pins in `scripts/requirements.in`), with `--require-hashes` (issue #723).
+## Python helper-script dependencies
+
+The Python helper scripts' runtime deps (`defusedxml`, `requests`, `PyYAML`) come from `scripts/requirements.txt`, a hash-pinned lock (top-level pins in `scripts/requirements.in`), installed with `--require-hashes` (issue #723).
 Regenerate the lock with the `uv pip compile` command recorded in that `.in` file's header.
+
+Both sides install it: CI in `.github/workflows/build.yml`, and the `SessionStart` hook in step 4 (issue #806).
+The session install is what makes the whole test suite runnable locally; without it, four of the Python test modules and `scripts/ci/test-support/test_summarize_preflight_integration.sh` fail with `No module named 'defusedxml'` whatever the change under test is.
+It also makes the versions this repository declares the ones a session runs: `requests` and `PyYAML` happen to resolve from the base image, so a change there would extend the same failure to them with no other signal.
+
+Steps 3b and 4 both install through `scripts/install-pinned-requirements.sh`, which records the SHA-256 of the lock it installed under `~/.local/share/gb4pc/`.
+An unchanged lock is therefore a no-op on later sessions, an edited one reinstalls, and a failed install writes no marker and is retried.
+`scripts/test_install_pinned_requirements.sh` covers that behavior, and fails the build if `build.yml` installs a lock the hook does not.
 
 ______________________________________________________________________
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -223,30 +223,13 @@ echo "[session-start] Step 3a: ensuring ktlint is installed..."
 # See requirements-lint.in for the per-package rationale and the top-level pins
 # the lock is generated from.
 #
-# --require-hashes makes pip refuse to install anything whose artifact does not
-# match a hash in the lock, so a compromised or substituted wheel on PyPI (or an
-# intercepted download) cannot slip in (issue #699).  It also forces every
-# dependency to be hash-pinned, which is why the lock lists the full transitive
-# closure rather than just the top-level tools.
-#
-# The install is gated on the SHA-256 of requirements-lint.txt: a marker file
-# records the hash that was last installed, so any edit to the pinned versions
-# triggers a reinstall on the next session while an unchanged file skips the
-# work.  --force-reinstall recreates the console-script entry points even if a
-# prior run left a package's dist-info without its scripts (PATH may not include
-# $LOCAL_BIN when pip decides whether to write them).
-LINT_REQ="$REPO_ROOT/scripts/lint/requirements-lint.txt"
-LINT_MARKER="$HOME/.local/share/gb4pc/requirements-lint.sha256"
-REQ_SHA=$(sha256sum "$LINT_REQ" | cut -d' ' -f1)
-if [[ -f "$LINT_MARKER" && "$(cat "$LINT_MARKER" 2>/dev/null)" == "$REQ_SHA" ]]; then
-    echo "[session-start] Step 3b: Python lint tools up to date--skip"
-else
-    echo "[session-start] Step 3b: installing Python lint tools..."
-    pip install --user --force-reinstall --require-hashes --quiet -r "$LINT_REQ"
-    mkdir -p "$(dirname "$LINT_MARKER")"
-    echo "$REQ_SHA" > "$LINT_MARKER"
-    echo "[session-start] Step 3b: Python lint tools installed"
-fi
+# The hash-pinned install and its skip marker live in
+# scripts/install-pinned-requirements.sh, which every lock a session provisions
+# goes through; see that script for why --require-hashes and --force-reinstall
+# are used and how the marker gates the work.
+echo "[session-start] Step 3b: ensuring the Python lint tools are installed..."
+"$REPO_ROOT/scripts/install-pinned-requirements.sh" \
+    "$REPO_ROOT/scripts/lint/requirements-lint.txt" "Python lint tools"
 
 # STEP 3c: wire the first-party git hook into this repo.
 #

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -247,16 +247,40 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────
-# STEP 4: Fetch remote refs.
+# STEP 4: Python helper-script runtime dependencies.
+#
+# scripts/requirements.txt is the hash-pinned lock for what this repository's own
+# Python helper scripts import at run time: defusedxml, requests, and PyYAML
+# (issue #723).  CI installs it in .github/workflows/build.yml before it runs
+# either test suite, and a session that does not is a session where part of the
+# suite cannot run: four of the Python test modules fail to import and
+# scripts/ci/test-support/test_summarize_preflight_integration.sh fails, all with
+# "No module named 'defusedxml'", for reasons unrelated to whatever is being
+# changed (issue #806).
+#
+# These are not lint tools, so they get their own step rather than joining STEP 3,
+# but they install through the same script and the same skip marker.
+#
+# Installing the lock also makes the versions this repository declares the ones a
+# session actually runs.  Only defusedxml is visibly absent today; requests and
+# PyYAML happen to resolve from the base image, so a change there would extend
+# the same failure to them with no other signal.
+# ───────────────────────────────────────────────────────────────────────────────
+echo "[session-start] Step 4: ensuring the Python helper-script dependencies are installed..."
+"$REPO_ROOT/scripts/install-pinned-requirements.sh" \
+    "$REPO_ROOT/scripts/requirements.txt" "Python helper-script dependencies"
+
+# ───────────────────────────────────────────────────────────────────────────────
+# STEP 5: Fetch remote refs.
 #
 # Keep local knowledge of the remote up to date at the start of every session.
 # git fetch is always safe (it never modifies the working tree), so no skip
 # guard is needed.  Failures are logged as warnings rather than aborting the
 # hook, so a transient network outage does not prevent the session from starting.
 # ───────────────────────────────────────────────────────────────────────────────
-echo "[session-start] Step 4: git fetch..."
+echo "[session-start] Step 5: git fetch..."
 git -C "$REPO_ROOT" fetch --prune --quiet \
-    && echo "[session-start] Step 4: fetch complete" \
-    || echo "[session-start] Step 4: warning: git fetch failed"
+    && echo "[session-start] Step 5: fetch complete" \
+    || echo "[session-start] Step 5: warning: git fetch failed"
 
 echo "[session-start] Complete. ANDROID_HOME=$ANDROID_HOME"

--- a/scripts/install-pinned-requirements.sh
+++ b/scripts/install-pinned-requirements.sh
@@ -21,15 +21,19 @@
 # --force-reinstall installs what the lock names even when something already
 # satisfies the requirement. That is what makes the lock authoritative: without
 # it, a package the base image happens to ship at the pinned version is left in
-# place and the session runs bytes the repository never declared. It also
-# recreates console-script entry points that a prior run may have left out (pip
-# skips writing them when $HOME/.local/bin is not on PATH at install time).
+# place and the session runs bytes the repository never declared.
 #
 # The install is gated on the SHA-256 of the lock: a marker file records the hash
-# that was last installed, so any edit to the pinned versions triggers a
-# reinstall on the next session while an unchanged lock skips the work. The
-# marker is named after the lock, and is written only after pip succeeds, so a
-# failed install is retried next session rather than being remembered as done.
+# that was last installed, so a re-run against an unchanged lock skips the work
+# while any edit to the pinned versions reinstalls. The marker is named after the
+# lock, and is written only after pip succeeds, so a failed install is retried
+# rather than being remembered as done.
+#
+# The marker lives under $HOME, which is the session's own filesystem and not the
+# cached image: only .claude/setup-environment.sh writes into that (see
+# .claude/environment.md). So this skips repeat runs within a container, which is
+# what the session-start hook's idempotence needs, and a later session installs
+# again from scratch.
 #
 # Idempotent: re-running against an already installed lock is a fast no-op.
 

--- a/scripts/install-pinned-requirements.sh
+++ b/scripts/install-pinned-requirements.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/install-pinned-requirements.sh -- install a hash-pinned pip lock into
+# the user site, skipping the work when that exact lock is already installed.
+#
+# Shared by the locks .claude/hooks/session-start.sh provisions per session, so
+# the install command and its skip marker are defined once instead of being
+# copied for each lock.
+#
+# Usage: install-pinned-requirements.sh <lock-file> <description>
+#
+#   <lock-file>    a fully resolved requirements lock: every package, top-level
+#                  and transitive, pinned to an exact version and a SHA-256 hash.
+#   <description>  what the lock provides, for this script's log lines.
+#
+# --require-hashes makes pip refuse to install anything whose artifact does not
+# match a hash in the lock, so a compromised or substituted wheel on PyPI (or an
+# intercepted download) cannot slip in (issue #699). It also forces every
+# dependency to be hash-pinned, which is why these locks list the full transitive
+# closure rather than just the top-level packages.
+#
+# --force-reinstall installs what the lock names even when something already
+# satisfies the requirement. That is what makes the lock authoritative: without
+# it, a package the base image happens to ship at the pinned version is left in
+# place and the session runs bytes the repository never declared. It also
+# recreates console-script entry points that a prior run may have left out (pip
+# skips writing them when $HOME/.local/bin is not on PATH at install time).
+#
+# The install is gated on the SHA-256 of the lock: a marker file records the hash
+# that was last installed, so any edit to the pinned versions triggers a
+# reinstall on the next session while an unchanged lock skips the work. The
+# marker is named after the lock, and is written only after pip succeeds, so a
+# failed install is retried next session rather than being remembered as done.
+#
+# Idempotent: re-running against an already installed lock is a fast no-op.
+
+set -euo pipefail
+
+LOCK="${1:-}"
+LABEL="${2:-}"
+
+if [[ -z "$LOCK" || -z "$LABEL" ]]; then
+    echo "[install-pinned-requirements] usage: $(basename "$0") <lock-file> <description>" >&2
+    exit 2
+fi
+
+if [[ ! -f "$LOCK" ]]; then
+    echo "[install-pinned-requirements] ERROR: no such lock file: $LOCK" >&2
+    exit 1
+fi
+
+# Two locks whose paths differ but whose file names match would share a marker,
+# and the second would be skipped as "already installed" on the strength of the
+# first. Nothing here can see the other call sites, so the guard against that
+# lives in scripts/test_install_pinned_requirements.sh, which checks that every
+# lock the session-start hook installs has a distinct file name.
+MARKER_DIR="$HOME/.local/share/gb4pc"
+MARKER="$MARKER_DIR/$(basename "$LOCK" .txt).sha256"
+LOCK_SHA=$(sha256sum "$LOCK" | cut -d' ' -f1)
+
+if [[ -f "$MARKER" && "$(cat "$MARKER" 2>/dev/null)" == "$LOCK_SHA" ]]; then
+    echo "[install-pinned-requirements] $LABEL up to date--skip"
+    exit 0
+fi
+
+echo "[install-pinned-requirements] installing $LABEL from $(basename "$LOCK")..."
+pip install --user --force-reinstall --require-hashes --quiet -r "$LOCK"
+mkdir -p "$MARKER_DIR"
+echo "$LOCK_SHA" > "$MARKER"
+echo "[install-pinned-requirements] $LABEL installed"

--- a/scripts/test_install_pinned_requirements.sh
+++ b/scripts/test_install_pinned_requirements.sh
@@ -206,6 +206,39 @@ else
     fail "two locks share a file name; their SHA-256 markers would collide"
 fi
 
+# ── (h) a session provisions every lock the test suites need ─────────────────
+#
+# The gap this closes (issue #806) was not a missing dependency but a
+# provisioning asymmetry: .github/workflows/build.yml installed
+# scripts/requirements.txt before running the Python and shell test suites, and
+# nothing on the session side did, so five of those tests failed locally with
+# "No module named 'defusedxml'" whatever the change under test was.
+#
+# Both lists are read from the files themselves, so a lock added to build.yml has
+# to be provisioned for sessions too. Only build.yml is compared: it is the
+# workflow that runs the test suites a session is expected to reproduce, whereas
+# semgrep.yml installs an engine that is deliberately CI-only.
+echo ""
+echo "=== (h) every lock CI installs to run the tests is installed for sessions ==="
+CI_LOCKS="$(grep -o -- '-r scripts/[A-Za-z0-9_./-]*\.txt' "$REPO_ROOT/.github/workflows/build.yml" \
+    | sed 's/^-r //' | sort -u)"
+if [[ -n "$CI_LOCKS" ]]; then
+    pass "build.yml installs locks: $(echo "$CI_LOCKS" | tr '\n' ' ')"
+else
+    fail "no requirements lock found in .github/workflows/build.yml (did the install steps move?)"
+fi
+
+UNPROVISIONED=""
+while IFS= read -r lock; do
+    [[ -z "$lock" ]] && continue
+    echo "$HOOK_LOCKS" | grep -qx -- "$lock" || UNPROVISIONED="$UNPROVISIONED $lock"
+done <<< "$CI_LOCKS"
+if [[ -z "$UNPROVISIONED" ]]; then
+    pass "the session-start hook installs every lock build.yml installs"
+else
+    fail "build.yml installs locks the session-start hook does not:$UNPROVISIONED"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "test_install_pinned_requirements.sh: $PASS passed, $FAIL failed"

--- a/scripts/test_install_pinned_requirements.sh
+++ b/scripts/test_install_pinned_requirements.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test_install_pinned_requirements.sh: unit tests for
+# scripts/install-pinned-requirements.sh, the shared installer the session-start
+# hook provisions every hash-pinned pip lock through.
+#
+# The behavioral cases run the real script against an isolated HOME with a stub
+# `pip` first on PATH, so they exercise the skip marker, the flags the script
+# passes, and its failure handling without touching PyPI: they run unconditionally
+# in CI and locally with no network.
+#
+# The wiring cases guard the call sites instead. The marker file is named after
+# the lock, so two locks with the same file name would share one marker and the
+# second would be skipped as "already installed" on the strength of the first.
+# The script cannot see its own call sites, so that check lives here.
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$SCRIPT_DIR/install-pinned-requirements.sh"
+HOOK="$REPO_ROOT/.claude/hooks/session-start.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/install-pinned-req-test-XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# A case directory holds its own HOME (so the marker cannot escape into the real
+# one), a stub pip that records every invocation, and a lock file to install.
+# The stub's exit status is what makes the "pip failed" case possible.
+make_case() {
+    local case_dir="$1" pip_rc="${2:-0}"
+    mkdir -p "$case_dir/home" "$case_dir/bin"
+    cat > "$case_dir/bin/pip" << EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/pip-args.log"
+exit $pip_rc
+EOF
+    chmod +x "$case_dir/bin/pip"
+    printf 'defusedxml==0.7.1 --hash=sha256:%064d\n' 1 > "$case_dir/requirements-fake.txt"
+}
+
+# Run the real script exactly as the hook does, with only HOME and PATH redirected.
+run_installer() {
+    local case_dir="$1"
+    local lock="${2:-$case_dir/requirements-fake.txt}"
+    HOME="$case_dir/home" PATH="$case_dir/bin:$PATH" \
+        "$INSTALL_SH" "$lock" "test dependencies" >> "$case_dir/out.log" 2>&1
+}
+
+pip_calls() {
+    local case_dir="$1"
+    [[ -f "$case_dir/pip-args.log" ]] && wc -l < "$case_dir/pip-args.log" | tr -d ' ' || echo 0
+}
+
+marker_of() {
+    echo "$1/home/.local/share/gb4pc/requirements-fake.sha256"
+}
+
+# ── (a) structural ───────────────────────────────────────────────────────────
+echo ""
+echo "=== (a) the installer is a well-formed script ==="
+if [[ -x "$INSTALL_SH" ]]; then
+    pass "install-pinned-requirements.sh is executable"
+else
+    fail "install-pinned-requirements.sh must be executable (chmod +x)"
+fi
+if bash -n "$INSTALL_SH" 2>/dev/null; then
+    pass "install-pinned-requirements.sh parses as bash"
+else
+    fail "install-pinned-requirements.sh has a syntax error"
+fi
+if grep -q '^set -euo pipefail$' "$INSTALL_SH"; then
+    pass "install-pinned-requirements.sh runs under set -euo pipefail"
+else
+    fail "install-pinned-requirements.sh must set -euo pipefail (a half-installed lock must not be recorded as done)"
+fi
+
+# ── (b) a lock not yet installed is installed, hash-checked, and marked ──────
+echo ""
+echo "=== (b) an uninstalled lock is installed with --require-hashes ==="
+CASE="$TMP/fresh"
+make_case "$CASE"
+if run_installer "$CASE"; then
+    pass "the installer exits 0"
+else
+    fail "the installer should exit 0 on a successful install"
+    sed 's/^/    /' "$CASE/out.log"
+fi
+if [[ "$(pip_calls "$CASE")" -eq 1 ]]; then
+    pass "pip was invoked once"
+else
+    fail "expected exactly one pip invocation, got $(pip_calls "$CASE")"
+fi
+PIP_ARGS="$(cat "$CASE/pip-args.log" 2>/dev/null)"
+if [[ "$PIP_ARGS" == *"--require-hashes"* ]]; then
+    pass "pip was passed --require-hashes"
+else
+    fail "pip must be passed --require-hashes; got: $PIP_ARGS"
+fi
+if [[ "$PIP_ARGS" == *"-r $CASE/requirements-fake.txt"* ]]; then
+    pass "pip was pointed at the lock it was given"
+else
+    fail "pip was not pointed at the lock; got: $PIP_ARGS"
+fi
+EXPECTED_SHA="$(sha256sum "$CASE/requirements-fake.txt" | cut -d' ' -f1)"
+if [[ "$(cat "$(marker_of "$CASE")" 2>/dev/null)" == "$EXPECTED_SHA" ]]; then
+    pass "the marker records the SHA-256 of the installed lock"
+else
+    fail "the marker should hold the lock's SHA-256"
+fi
+
+# ── (c) an unchanged lock is skipped ─────────────────────────────────────────
+echo ""
+echo "=== (c) an unchanged lock is a no-op on the next session ==="
+if run_installer "$CASE" && [[ "$(pip_calls "$CASE")" -eq 1 ]]; then
+    pass "the second run installed nothing"
+else
+    fail "an unchanged lock must not be reinstalled (pip calls: $(pip_calls "$CASE"))"
+fi
+if grep -q 'up to date--skip' "$CASE/out.log"; then
+    pass "the skip is reported"
+else
+    fail "the skip should be reported"
+    sed 's/^/    /' "$CASE/out.log"
+fi
+
+# ── (d) an edited lock is reinstalled ────────────────────────────────────────
+echo ""
+echo "=== (d) an edited lock reaches the next session ==="
+printf 'defusedxml==0.7.2 --hash=sha256:%064d\n' 2 > "$CASE/requirements-fake.txt"
+if run_installer "$CASE" && [[ "$(pip_calls "$CASE")" -eq 2 ]]; then
+    pass "a changed lock triggers a reinstall"
+else
+    fail "a changed lock must be reinstalled (pip calls: $(pip_calls "$CASE"))"
+    sed 's/^/    /' "$CASE/out.log"
+fi
+
+# ── (e) a failed install is not remembered as done ───────────────────────────
+echo ""
+echo "=== (e) a failed pip install writes no marker ==="
+BROKEN="$TMP/broken"
+make_case "$BROKEN" 1
+if run_installer "$BROKEN"; then
+    fail "the installer must fail when pip fails"
+else
+    pass "the installer exits non-zero when pip fails"
+fi
+if [[ ! -f "$(marker_of "$BROKEN")" ]]; then
+    pass "no marker is written, so the next session retries"
+else
+    fail "a failed install must not write its marker"
+fi
+
+# ── (f) a missing lock is an error, not a silent skip ────────────────────────
+echo ""
+echo "=== (f) a missing lock fails loudly ==="
+ABSENT="$TMP/absent"
+make_case "$ABSENT"
+if run_installer "$ABSENT" "$ABSENT/no-such-lock.txt"; then
+    fail "the installer must fail when the lock does not exist"
+else
+    pass "the installer exits non-zero on a missing lock"
+fi
+if [[ "$(pip_calls "$ABSENT")" -eq 0 ]]; then
+    pass "pip is never invoked for a lock that does not exist"
+else
+    fail "pip must not run when the lock is missing"
+fi
+
+# ── (g) the locks the session-start hook installs ────────────────────────────
+#
+# Every lock path the hook names, taken from the hook itself rather than listed
+# here, so a lock added to the hook is covered without editing this test.
+echo ""
+echo "=== (g) the session-start hook's locks ==="
+HOOK_LOCKS="$(grep -o '\$REPO_ROOT/scripts/[A-Za-z0-9_./-]*\.txt' "$HOOK" | sed 's|^\$REPO_ROOT/||' | sort -u)"
+if [[ -n "$HOOK_LOCKS" ]]; then
+    pass "the hook provisions locks: $(echo "$HOOK_LOCKS" | tr '\n' ' ')"
+else
+    fail "the hook names no requirements lock at all"
+fi
+
+MISSING_LOCKS=""
+while IFS= read -r lock; do
+    [[ -z "$lock" ]] && continue
+    [[ -f "$REPO_ROOT/$lock" ]] || MISSING_LOCKS="$MISSING_LOCKS $lock"
+done <<< "$HOOK_LOCKS"
+if [[ -z "$MISSING_LOCKS" ]]; then
+    pass "every lock the hook installs exists in the repository"
+else
+    fail "the hook installs locks that do not exist:$MISSING_LOCKS"
+fi
+
+# The marker is named after the lock's file name, so same-named locks in
+# different directories would collide and the second would never be installed.
+LOCK_NAMES="$(echo "$HOOK_LOCKS" | sed 's|.*/||' | sort)"
+if [[ "$(echo "$LOCK_NAMES" | wc -l)" -eq "$(echo "$LOCK_NAMES" | sort -u | wc -l)" ]]; then
+    pass "the locks have distinct file names, so their markers cannot collide"
+else
+    fail "two locks share a file name; their SHA-256 markers would collide"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "test_install_pinned_requirements.sh: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0
+exit 1

--- a/scripts/test_install_pinned_requirements.sh
+++ b/scripts/test_install_pinned_requirements.sh
@@ -13,6 +13,22 @@
 # second would be skipped as "already installed" on the strength of the first.
 # The script cannot see its own call sites, so that check lives here.
 #
+# HOW THE WIRING CASES FIND A LOCK
+#
+# Cases (g) and (h) grep for a spelling rather than parsing bash or YAML, so an
+# install written another way drops out of the comparison silently: (h) would
+# then still pass, because its non-empty guard only proves that some lock
+# matched, not that yours did. If you add an install, match these spellings, or
+# extend the patterns here:
+#
+#   .claude/hooks/session-start.sh   "$REPO_ROOT/scripts/<path>.txt", unquoted
+#                                    path, no variable standing in for it
+#   .github/workflows/build.yml      -r scripts/<path>.txt (not --requirement,
+#                                    not a quoted or variable path)
+#
+# Comments are stripped from both files first, so prose naming a lock is not
+# counted as an install.
+#
 # Always exits 0 on success, non-zero on failure.
 
 set -uo pipefail
@@ -117,7 +133,7 @@ fi
 
 # ── (c) an unchanged lock is skipped ─────────────────────────────────────────
 echo ""
-echo "=== (c) an unchanged lock is a no-op on the next session ==="
+echo "=== (c) an unchanged lock is a no-op on a re-run ==="
 if run_installer "$CASE" && [[ "$(pip_calls "$CASE")" -eq 1 ]]; then
     pass "the second run installed nothing"
 else
@@ -132,7 +148,7 @@ fi
 
 # ── (d) an edited lock is reinstalled ────────────────────────────────────────
 echo ""
-echo "=== (d) an edited lock reaches the next session ==="
+echo "=== (d) an edited lock is reinstalled ==="
 printf 'defusedxml==0.7.2 --hash=sha256:%064d\n' 2 > "$CASE/requirements-fake.txt"
 if run_installer "$CASE" && [[ "$(pip_calls "$CASE")" -eq 2 ]]; then
     pass "a changed lock triggers a reinstall"
@@ -152,7 +168,7 @@ else
     pass "the installer exits non-zero when pip fails"
 fi
 if [[ ! -f "$(marker_of "$BROKEN")" ]]; then
-    pass "no marker is written, so the next session retries"
+    pass "no marker is written, so the next run retries"
 else
     fail "a failed install must not write its marker"
 fi
@@ -179,7 +195,8 @@ fi
 # here, so a lock added to the hook is covered without editing this test.
 echo ""
 echo "=== (g) the session-start hook's locks ==="
-HOOK_LOCKS="$(grep -o '\$REPO_ROOT/scripts/[A-Za-z0-9_./-]*\.txt' "$HOOK" | sed 's|^\$REPO_ROOT/||' | sort -u)"
+HOOK_LOCKS="$(sed 's/#.*$//' "$HOOK" \
+    | grep -o '\$REPO_ROOT/scripts/[A-Za-z0-9_./-]*\.txt' | sed 's|^\$REPO_ROOT/||' | sort -u)"
 if [[ -n "$HOOK_LOCKS" ]]; then
     pass "the hook provisions locks: $(echo "$HOOK_LOCKS" | tr '\n' ' ')"
 else
@@ -220,8 +237,8 @@ fi
 # semgrep.yml installs an engine that is deliberately CI-only.
 echo ""
 echo "=== (h) every lock CI installs to run the tests is installed for sessions ==="
-CI_LOCKS="$(grep -o -- '-r scripts/[A-Za-z0-9_./-]*\.txt' "$REPO_ROOT/.github/workflows/build.yml" \
-    | sed 's/^-r //' | sort -u)"
+CI_LOCKS="$(sed 's/#.*$//' "$REPO_ROOT/.github/workflows/build.yml" \
+    | grep -o -- '-r scripts/[A-Za-z0-9_./-]*\.txt' | sed 's/^-r //' | sort -u)"
 if [[ -n "$CI_LOCKS" ]]; then
     pass "build.yml installs locks: $(echo "$CI_LOCKS" | tr '\n' ' ')"
 else


### PR DESCRIPTION
🤖 Author

Fixes #806.

CI installed `scripts/requirements.txt` before running either test suite; nothing on the session side did.
That asymmetry made part of the suite unrunnable outside CI, and the failures pointed nowhere near the change under test.

## What changed

**`scripts/install-pinned-requirements.sh` (new).**
The hash-pinned pip install and its SHA-256 skip marker, lifted out of the hook's STEP 3b so a second lock does not mean a second copy of the flags, the marker convention, and the ordering that keeps a failed install from being recorded as done.
It follows the `scripts/lint/install-ktlint.sh` precedent: a shared, self-logging installer the hook delegates to.
The extraction commit changes no executable behavior; the flags, the marker path, and the skip condition are identical, and only the log prefix and the rationale comments differ.

**`.claude/hooks/session-start.sh` STEP 4 (new).**
Installs `scripts/requirements.txt` through that script.
It is a step of its own rather than a STEP 3 sub-step because these are runtime dependencies of the repository's Python scripts, not lint tools; the git fetch step is renumbered to STEP 5 to make room.

**`.claude/environment.md`.**
The helper-script dependency section described the CI-only install as the whole story, which was exactly the gap.
It now covers both provisioning paths and what the marker does, and `setup-environment.sh`'s "what it deliberately does not do" list records the decision the issue asked for (below).

## Why the deps are not seeded into the cached image

The issue asked whether `.claude/setup-environment.sh` should seed these the way it seeds Gradle, the SDK, and Temurin. It should not:

- `pip install --user` targets the session user's `~/.local`, so seeding would inherit the `SESSION_HOME` guess that script already documents as unverifiable. It is worse here than for Gradle: a mis-seeded distribution announces itself, because the wrapper downloads again, whereas mis-seeded wheels are invisible, since the session installs them itself and looks exactly like today.
- It would put a second copy of the marker logic in a script CI can only partly verify.
- To be coherent it would have to seed both locks, including the much larger lint one (about 31 MB installed, nearly all of it ruff), which is hook-only today for the same reasons.
- What that buys back is one `pip install` per session (about 5 MB installed for the helper deps, about 31 MB for the lint tools) from PyPI, which is not the path that has actually proved flaky here. That is the cost this script exists to eliminate for the ~130 MB Gradle distribution and ~190 MB JDK, at a scale where it does not pay.

Note what the marker does and does not do, since an earlier revision of this PR got it wrong: it lives in the session's own home, not in the cached image, so it makes the hook cheap to re-run within a container and does not carry across sessions.

## Test coverage

`scripts/test_install_pinned_requirements.sh` (new, picked up by CI's existing `find scripts -name 'test_*.sh'`) runs the real installer against an isolated `HOME` with a stub `pip` on `PATH`, so it needs no network:

- the flags passed (`--require-hashes`) and the lock pip is pointed at;
- the marker written, and the skip on an unchanged lock;
- the reinstall on an edited lock;
- no marker after a failed install, so the next run retries;
- a loud failure, and no pip call, on a missing lock;
- the call sites: every lock the hook installs exists, and their file names are distinct (the marker is named after the lock, so same-named locks would collide);
- **the regression itself**: every lock `build.yml` installs is also installed by the hook. Both lists are read from the files, so this fails against the hook as it stood before this PR, and it fails again if a future lock is wired into CI alone.

The two wiring cases match a spelling rather than parsing bash or YAML. The test header names the spellings both greps require, since an install written another way would drop out of the comparison and leave the check passing vacuously. Comments are stripped from both files first, so prose naming a lock is not counted as an install.

## Verification

Run in a session with the deps absent, which reproduced the issue's measurements exactly.

Before: 13 shell tests with `test_summarize_preflight_integration.sh` failing, and 4 Python test modules that could not be imported, all with `No module named 'defusedxml'`.

After: 14 of 14 shell tests pass (`find scripts -name 'test_*.sh'`, as CI runs them) and 375 Python tests pass across every discovered directory, plus `test_ci_monitor.py`.
The installer itself was also run for real against both locks: `defusedxml 0.7.1`, `requests 2.34.2` (upgraded from the base image's 2.33.1, so the lock is now authoritative), `PyYAML 6.0.3`, and a second run correctly reported `up to date--skip`.

`./scripts/lint/lint.sh` is clean on every changed file. No Kotlin, Gradle, or app source is touched, so the Android build is unaffected and was not run.

`build-and-test` is red on `[Instrumented Tests] PickerActivityTest#pickerScreen_loadsApps_andShowsSettingsApp` (#809), an emulator UI test. This branch touches no Kotlin, Gradle, workflow, or app source, and the shell script it adds runs only from the session-start hook, which returns immediately on a GitHub runner because `CLAUDE_CODE_REMOTE` is unset there. `shell-tests`, which runs the new test, passed.

## Before merging

Nothing outside the repository, and no manual step.
The hook is checked in and runs itself, and `.claude/setup-environment.sh` is unchanged, so the copy pasted into the environment's Setup script field does not need re-pasting.

## Out of scope

`scripts/requirements.in`, the lock, and the CI install steps are untouched, as the issue asked.

Follow-up filed as #810: CI and sessions install these locks with different pip flags (only the session passes `--force-reinstall`), and case (h) compares which locks each side installs, not how.
