### PR TITLE
Move scripts/test_ci_monitor.py into scripts/ci_monitor/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
             echo "==> Discovering tests in $dir"
             python3 -m unittest discover -s "$dir" -p "test_*.py" -v && rc=0 || rc=$?
             # Python 3.12+ exits 5 for "no tests were collected" instead of 0.
-            # scripts/ itself hits this legitimately: its only test_*.py is
+            # scripts/ci_monitor itself hits this legitimately: its only test_*.py is
             # test_ci_monitor.py, which defines no unittest.TestCase tests (see
             # below). Tolerate 5; any other nonzero code is a real failure.
             if [[ $rc -ne 0 && $rc -ne 5 ]]; then
@@ -168,7 +168,7 @@ jobs:
           # test_ci_monitor.py is a procedural check()-based suite, not built from
           # unittest.TestCase classes, so `unittest discover` imports it but runs
           # none of its checks (issue #619). Run it directly too.
-          python3 scripts/test_ci_monitor.py
+          python3 scripts/ci_monitor/test_ci_monitor.py
 
       - name: Set up JDK 17
         if: needs.check-diff.outputs.needs_full_build == 'true'

--- a/scripts/ci_monitor/test_ci_monitor.py
+++ b/scripts/ci_monitor/test_ci_monitor.py
@@ -118,7 +118,7 @@ import unittest.mock
 import urllib.error
 import zipfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor"))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import ci_monitor  # noqa: E402
 
@@ -1336,9 +1336,7 @@ def main() -> int:
     # SIGTERM to that exact PID, and confirm the process exits via the signal. A
     # bogus token + the unreachable real API_BASE means the loop never gets past the
     # SHA fetch, so it stays alive (sleeping) until we signal it; no network needed.
-    _MONITOR_PATH = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "ci_monitor", "ci_monitor.py"
-    )
+    _MONITOR_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor.py")
     _proc = subprocess.Popen(
         [sys.executable, _MONITOR_PATH, "--pr", "1"],
         stdout=subprocess.PIPE,
@@ -3154,7 +3152,7 @@ def main() -> int:
 
     # The committed repo config carries this repo's values, including the dual marker.
     _repo_cfg_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "ci_monitor", "ci_monitor.config.json"
+        os.path.dirname(os.path.abspath(__file__)), "ci_monitor.config.json"
     )
     cfg_repo = ci_monitor.load_config(_repo_cfg_path)
     check(
@@ -3324,7 +3322,7 @@ def main() -> int:
     )
 
     _MONITOR_SRC = open(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor", "ci_monitor.py"),
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor.py"),
         encoding="utf-8",
     ).read()
 
@@ -3808,7 +3806,7 @@ def main() -> int:
 
     # Committed repo config carries 'No blocking labels'.
     _repo_cfg_path_ai = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "ci_monitor", "ci_monitor.config.json"
+        os.path.dirname(os.path.abspath(__file__)), "ci_monitor.config.json"
     )
     cfg_ai_repo = ci_monitor.load_config(_repo_cfg_path_ai)
     check(
@@ -3944,7 +3942,7 @@ def main() -> int:
     )
 
     _MONITOR_SRC_AK = open(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor", "ci_monitor.py"),
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "ci_monitor.py"),
         encoding="utf-8",
     ).read()
 


### PR DESCRIPTION
Fixes #787.

`scripts/test_ci_monitor.py` was the only unit test in the repository that did not sit beside its subject: it reached one directory up to import `scripts/ci_monitor/ci_monitor.py`, via a `sys.path.insert` that named `"ci_monitor"` explicitly.

## Changes

- `git mv scripts/test_ci_monitor.py scripts/ci_monitor/test_ci_monitor.py`.
- Reverted the `sys.path.insert` and `_MONITOR_PATH` expressions to their pre-#384 `dirname(__file__)` forms (the two spots #384 patched when it moved `ci_monitor.py` but left the test behind).
- Also reverted four more path expressions in the same file (added after #384, by #500 and #516) that likewise joined a literal `"ci_monitor"` segment onto `dirname(__file__)` to reach `ci_monitor.config.json` and `ci_monitor.py`: with the test now living in that directory, the segment is redundant and was dropped the same way.
- Updated `.github/workflows/build.yml` line 171's direct invocation to the new path, and the comments at lines 160-163 and 168-170 that named `scripts/` as the directory expected to legitimately collect no `unittest.TestCase` tests; after the move that directory is `scripts/ci_monitor`.

With the move, every unit test in the tree now uses the plain `sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))` form, and `scripts/` itself no longer matches `find scripts -name "test_*.py"`.

## What does not change

- The separate `python3 scripts/ci_monitor/test_ci_monitor.py` invocation in `build.yml` stays (only its path changes): the suite is procedural and `check()`-based rather than built from `unittest.TestCase` classes (#619), so `unittest discover` imports it but runs none of its checks.
- The discover loop's exit-5 tolerance stays, now scoped to `scripts/ci_monitor` instead of bare `scripts`.
- Case (al)'s self-import subprocess checks needed no change: they already run with `cwd=os.path.dirname(os.path.abspath(__file__))`, so they followed the file automatically. Confirmed by running the suite after the move.

## Verification

- `python3 scripts/ci_monitor/test_ci_monitor.py`: all 375 checks pass (same count as before the move).
- `find scripts -name "test_*.py" -printf '%h\n' | sort -u` no longer lists bare `scripts`; the `build.yml` discover loop was run locally over the resulting directory list and returned rc=0 for every directory, including `scripts/ci_monitor`.
- `scripts/lint/lint.sh --check --only python --all`: all checks passed, 31 files already formatted.
