### PR TITLE
Narrow the agents rule's verif\w+ sub-pattern with a companion-word requirement

### DIFF
--- a/scripts/ci/labels/label_by_title.py
+++ b/scripts/ci/labels/label_by_title.py
@@ -48,6 +48,13 @@ _E2E_TEST_IDENTIFIER = r"\w*e2etest\w*"
 _MERGE_COMPANION = rf"{_B}gat(ing|e[ds]?){_B}|{_B}(un)?block\w*|{_B}prs?{_B}"
 _MERGE = rf"(?=.*{_B}merg\w+)(?=.*({_MERGE_COMPANION}))"
 
+# "verif\w+" is only recognized alongside a companion word, since it
+# otherwise sweeps in unrelated Gradle dependency-verification work (#714,
+# #760). "agent" is deliberately excluded from the companion list: a title
+# containing it already matches the agent\w* sub-rule independently.
+_VERIF_COMPANION = rf"{_B}planner{_B}|{_B}labels?{_B}|{_B}prs?{_B}"
+_VERIF = rf"(?=.*{_B}verif\w+{_B})(?=.*({_VERIF_COMPANION}))"
+
 LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
     "ci": re.compile(
         rf"{_B}ci{_B}"
@@ -66,7 +73,7 @@ LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
         rf"|{_B}rules?{_B}"
         rf"|{_B}attributions?{_B}"
         rf"|{_B}bylines?{_B}"
-        rf"|{_B}verif\w+{_B}"
+        rf"|{_VERIF}"
         rf"|{_B}author{_B}"
         rf"|{_B}reviewers?{_B}"
         rf"|{_B}orchestrat\w*"

--- a/scripts/ci/labels/test_label_by_title.py
+++ b/scripts/ci/labels/test_label_by_title.py
@@ -165,6 +165,26 @@ class TestMatchingLabelsAgents(unittest.TestCase):
         self.assertIn("agents", lpt.matching_labels("Add PR verification agent instructions"))
         self.assertIn("agents", lpt.matching_labels("Test PR: verify remove-verified-on-push"))
 
+    def test_verif_with_planner_companion_matches(self):
+        self.assertIn(
+            "agents", lpt.matching_labels("Verification Planner should file tracking issues")
+        )
+
+    def test_verif_without_companion_does_not_match(self):
+        # "verif\\w+" alone is too generic: it sweeps in unrelated Gradle
+        # dependency-verification work (#714, #760) without a companion word.
+        self.assertNotIn(
+            "agents",
+            lpt.matching_labels("Harden the Gradle build with dependency verification metadata"),
+        )
+        self.assertNotIn(
+            "agents",
+            lpt.matching_labels(
+                "Migrate to Gradle 9.x: generate the wrapper and verification metadata"
+                " via a manual CI workflow"
+            ),
+        )
+
     def test_author_exact_word_matches(self):
         self.assertIn(
             "agents", lpt.matching_labels("Empower Author to file issues for review requests")


### PR DESCRIPTION
Fixes #784

`{_B}verif\w+{_B}` in `scripts/ci/labels/label_by_title.py`'s `agents` pattern currently matches unrelated Gradle dependency-verification work, so titles like 714 ("Harden the Gradle build with dependency verification metadata") and 760 ("Migrate to Gradle 9.x: generate the wrapper and verification metadata via a manual CI workflow") were false-positive `agents` matches even though neither touches AGENTS.md, CLAUDE.md, or `agents/`.

This narrows `verif\w+` with the same companion-word idiom already used for `merge` in the same file: it now only matches alongside `planner`, `label(s)`, or `PR(s)`. `agent` is deliberately excluded from the companion list, since a title containing it already matches the `agent\w*` sub-rule independently.

## Changes

- Added `_VERIF_COMPANION` and `_VERIF` in `scripts/ci/labels/label_by_title.py`, mirroring the existing `_MERGE_COMPANION` / `_MERGE` pattern, and swapped the bare `verif\w+` alternative in the `agents` rule for `_VERIF`.
- Added regression tests in `scripts/ci/labels/test_label_by_title.py` covering:
  - 714 and 760 titles as non-matches (bare `verif\w+`, no companion word).
  - "Verification Planner should file tracking issues" as a new match (the `planner` companion).
  - The existing matches ("Add PR verification agent instructions" via `agent\w*`, "Test PR: verify remove-verified-on-push" via the `prs?` companion) continue to pass.

## Test plan

- [x] `python3 -m unittest scripts/ci/labels/test_label_by_title.py` (63 tests, all pass)
- [x] `python3 -m unittest scripts/ci/labels/test_backfill_labels_by_title.py` (60 tests, all pass; no changes needed there)
- [x] `ruff check` / `ruff format --check` on both changed files



