### PR TITLE
Make `agents` label an if-and-only-if changed-files rule on PRs

### DIFF
--- a/.github/workflows/label-by-files.yml
+++ b/.github/workflows/label-by-files.yml
@@ -1,9 +1,10 @@
 name: Label PR by changed files
 
-# Applies labels to a pull request based on the set of files it changed,
-# when every changed file maps to the same label. See
-# scripts/ci/labels/label_by_files.py for the exact rule. Labels are only
-# ever added, never removed.
+# Applies labels to a pull request based on the set of files it changed.
+# "ci" and "automated tests" are applied when every changed file maps to the
+# label, and never removed. "agents" follows an if-and-only-if rule instead:
+# applied when any changed file maps to it, and removed when none does. See
+# scripts/ci/labels/label_by_files.py for the exact rules.
 #
 # A separate workflow from label-by-title.yml because the two signals want
 # different triggers: title labeling only needs to run when the title

--- a/.github/workflows/label-by-title.yml
+++ b/.github/workflows/label-by-title.yml
@@ -4,6 +4,10 @@ name: Label issue/PR by title
 # against its title. See scripts/ci/labels/label_by_title.py for the exact rules.
 # Labels are only ever added, never removed.
 #
+# IS_PULL_REQUEST tells the script which artifact it is labeling. On a pull
+# request it suppresses the labels label-by-files.yml determines from the
+# changed files, so the two signals never race for the same label.
+#
 # Runs on "opened" (a fresh title) or "edited" where the title itself
 # changed (github.event.changes.title is only present when the title was
 # part of the edit), so unrelated edits (body, labels, base branch) do
@@ -33,4 +37,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: python3 scripts/ci/labels/label_by_title.py

--- a/scripts/ci/labels/audit_labels_by_files.py
+++ b/scripts/ci/labels/audit_labels_by_files.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Audit merged pull requests against the changed-file label rules.
+
+Applies scripts/ci/labels/label_by_files.py's rules (see that module for the
+exact rules) to the real changed-file list of every merged pull request, and
+compares the verdict against the labels the pull request actually carries.
+
+This does two jobs with one walk. It is the repeatable dry run that makes
+re-running the evidence the cheapest regression check when the path map is
+extended, and, with -f, the backfill for pull requests that merged before a
+rule existed. label-by-files.yml only ever sees pull requests that are open
+when it runs, so history is otherwise never revisited.
+
+Before exiting, prints a JSON report of what happened (or would happen):
+
+    add     labels the rules apply that the pull request lacks
+    match   labels the rules apply that the pull request already carries
+    remove  labels the pull request carries that the rules forbid
+
+Only label_by_files.EXHAUSTIVE_LABELS can appear under "remove": the
+unanimity labels are add-only by design, since for them "no changed path
+justifies it" is an absence of evidence rather than evidence of absence.
+
+Each category maps a label name to the sorted list of pull request numbers
+it applies to.
+
+Usage:
+    python3 scripts/ci/labels/audit_labels_by_files.py (-n | -f) [-q] [--limit N]
+
+    -n, --dry-run   Compute and print the report; apply nothing.
+    -f, --force     Apply the "add" and "remove" categories, then print the
+                    report.
+    -q, --quiet     Suppress the JSON report.
+    --limit N       Consider only the N most recently opened merged pull
+                    requests.
+
+    Exactly one of -n or -f is required, matching backfill_labels_by_title.py
+    and git clean's semantics: the script refuses to guess and does nothing
+    without one.
+
+A pull request whose changed-file list may be truncated, or cannot be
+fetched, yields no verdict at all: it is skipped and counted rather than
+judged on a partial diff.
+
+Cost is roughly one API call per pull request examined, against a 5000/hour
+authenticated limit. --limit keeps a routine regression check after a
+path-map change on the recent tail instead of the whole history.
+
+Exit code:
+    0  on success (whether or not any labels were changed)
+    1  if required configuration is missing, --limit is not positive, the
+       pull request list can't be fetched at all, or (-f only) writing
+       labels to at least one pull request failed
+
+Required environment variables:
+    GITHUB_TOKEN        Token with issues: write and pull-requests: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+"""
+
+import argparse
+import os
+import sys
+import urllib.error
+from collections import defaultdict
+from typing import Callable, NamedTuple
+
+import backfill_labels_by_title
+import enforce_mutually_exclusive_labels as emxl
+import label_by_files
+import label_by_title
+
+PER_PAGE = 100
+
+
+# ---------------------------------------------------------------------------
+# Fetching
+# ---------------------------------------------------------------------------
+
+
+def fetch_merged_pulls(repo: str, token: str, limit: int | None = None) -> list[dict]:
+    """Return merged pull requests, most recently opened first.
+
+    Walks repos/{repo}/pulls?state=closed newest-first and keeps the ones
+    carrying a ``merged_at`` timestamp, since a closed pull request may
+    simply have been closed unmerged. Stops as soon as *limit* of them have
+    been collected, so a small --limit costs a page or two rather than a walk
+    of the whole history.
+    """
+    pulls: list[dict] = []
+    page = 1
+    while True:
+        batch = label_by_title.gh_api(
+            f"repos/{repo}/pulls?state=closed&sort=created&direction=desc"
+            f"&per_page={PER_PAGE}&page={page}",
+            token=token,
+        )
+        if not batch:
+            return pulls
+        for pull in batch:
+            if not pull.get("merged_at"):
+                continue
+            pulls.append(pull)
+            if limit is not None and len(pulls) >= limit:
+                return pulls
+        page += 1
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+class Report(NamedTuple):
+    """What the audit found, plus the writes -f would issue.
+
+    add/match/remove map a label name to the pull request numbers it applies
+    to (the report). to_add/to_remove map a pull request number to the labels
+    to write (the -f payload). skipped lists the pull requests that yielded
+    no verdict.
+    """
+
+    add: dict[str, list[int]]
+    match: dict[str, list[int]]
+    remove: dict[str, list[int]]
+    to_add: dict[int, list[str]]
+    to_remove: dict[int, list[str]]
+    skipped: list[int]
+
+
+def build_report(pulls: list[dict], fetch_paths: Callable[[int], list[str] | None]) -> Report:
+    """Classify each pull request in *pulls* against its own changed files.
+
+    *fetch_paths* maps a pull request number to its changed paths, or to None
+    when no reliable list is available (label_by_files.fetch_changed_files's
+    truncation contract, plus any per-pull-request fetch failure the caller
+    folds into it). None is missing evidence, so that pull request is skipped
+    entirely rather than judged on a partial diff.
+    """
+    add: dict[str, list[int]] = defaultdict(list)
+    match: dict[str, list[int]] = defaultdict(list)
+    remove: dict[str, list[int]] = defaultdict(list)
+    to_add: dict[int, list[str]] = defaultdict(list)
+    to_remove: dict[int, list[str]] = defaultdict(list)
+    skipped: list[int] = []
+
+    for pull in pulls:
+        number = pull["number"]
+        paths = fetch_paths(number)
+        if paths is None:
+            skipped.append(number)
+            continue
+
+        # Keyed by lowercase name, valued by the spelling GitHub returned, so
+        # a removal deletes the label by the name the API knows.
+        carried = {lbl["name"].lower(): lbl["name"] for lbl in pull.get("labels", [])}
+
+        for label in label_by_files.matching_labels(paths):
+            if label.lower() in carried:
+                match[label].append(number)
+            else:
+                add[label].append(number)
+                to_add[number].append(label)
+
+        for label in label_by_files.labels_to_remove(paths):
+            name = carried.get(label.lower())
+            if name is not None:
+                remove[label].append(number)
+                to_remove[number].append(name)
+
+    return Report(dict(add), dict(match), dict(remove), dict(to_add), dict(to_remove), skipped)
+
+
+def apply_changes(
+    to_add: dict[int, list[str]],
+    to_remove: dict[int, list[str]],
+    repo: str,
+    token: str,
+) -> bool:
+    """Apply every pending add and removal, logging failures without aborting.
+
+    Like backfill_labels_by_title.apply_labels, one pull request's failure
+    does not abort the run: the remaining pull requests are still processed
+    and the failure is reflected in the return value.
+
+    Returns True if every write succeeded, False if any failed.
+    """
+    all_succeeded = True
+    for number, labels in to_add.items():
+        if not label_by_files.add_labels(repo, number, labels, token):
+            all_succeeded = False
+    for number, labels in to_remove.items():
+        if not emxl.remove_labels(number, labels, repo, token):
+            all_succeeded = False
+    return all_succeeded
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_report(report: Report) -> str:
+    """Render *report*'s three categories in backfill_labels_by_title's shape."""
+    return backfill_labels_by_title.format_categories(
+        [("add", report.add), ("match", report.match), ("remove", report.remove)]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("-n", "--dry-run", action="store_true", help="Report only; apply nothing.")
+    mode.add_argument("-f", "--force", action="store_true", help="Apply the adds and removals.")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress the JSON report.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Consider only the N most recently opened merged pull requests.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    if not token:
+        print("Error: GITHUB_TOKEN not set.", file=sys.stderr)
+        return 1
+    if not repo:
+        print("Error: GITHUB_REPOSITORY not set.", file=sys.stderr)
+        return 1
+    if args.limit is not None and args.limit < 1:
+        print(f"Error: --limit must be at least 1: {args.limit}", file=sys.stderr)
+        return 1
+
+    try:
+        pulls = fetch_merged_pulls(repo, token, args.limit)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error fetching pull requests: {exc}", file=sys.stderr)
+        return 1
+
+    def changed_paths(number: int) -> list[str] | None:
+        try:
+            return label_by_files.fetch_changed_files(repo, number, token)
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            print(f"Error fetching changed files for #{number}: {exc}", file=sys.stderr)
+            return None
+
+    report = build_report(pulls, changed_paths)
+
+    exit_code = 0
+    if args.force and not apply_changes(report.to_add, report.to_remove, repo, token):
+        exit_code = 1
+
+    if report.skipped:
+        print(
+            f"Skipped {len(report.skipped)} of {len(pulls)} pull requests with no reliable "
+            f"changed-file list: {sorted(report.skipped)}",
+            file=sys.stderr,
+        )
+
+    if not args.quiet:
+        print(format_report(report))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/labels/audit_labels_by_files.py
+++ b/scripts/ci/labels/audit_labels_by_files.py
@@ -31,8 +31,7 @@ Usage:
     -f, --force     Apply the "add" and "remove" categories, then print the
                     report.
     -q, --quiet     Suppress the JSON report.
-    --limit N       Consider only the N most recently opened merged pull
-                    requests.
+    --limit N       Consider only the N most recently merged pull requests.
 
     Exactly one of -n or -f is required, matching backfill_labels_by_title.py
     and git clean's semantics: the script refuses to guess and does nothing
@@ -78,19 +77,32 @@ PER_PAGE = 100
 
 
 def fetch_merged_pulls(repo: str, token: str, limit: int | None = None) -> list[dict]:
-    """Return merged pull requests, most recently opened first.
+    """Return merged pull requests, most recently merged first.
 
-    Walks repos/{repo}/pulls?state=closed newest-first and keeps the ones
-    carrying a ``merged_at`` timestamp, since a closed pull request may
-    simply have been closed unmerged. Stops as soon as *limit* of them have
-    been collected, so a small --limit costs a page or two rather than a walk
-    of the whole history.
+    Walks repos/{repo}/pulls?state=closed by ``updated_at`` descending and
+    keeps the ones carrying a ``merged_at`` timestamp, since a closed pull
+    request may simply have been closed unmerged. Stops as soon as *limit* of
+    them have been collected, or as soon as a page comes back shorter than
+    PER_PAGE (the normal end of the list, matching
+    label_by_files.fetch_changed_files's own early stop), so a small --limit
+    costs a page or two rather than a walk of the whole history.
+
+    ``updated_at``, not ``created_at``, is what makes this "most recently
+    merged" rather than "most recently opened": the REST API has no
+    sort=merged option, but merging a pull request is itself an update to it,
+    so ``updated_at`` is set to the merge time and, for a closed and merged
+    pull request, rarely changes again. The one exception is a label added or
+    removed after merge (a manual correction, or a backfill run of this very
+    script), which would sort that pull request later than its actual merge
+    time. That is judged an acceptable approximation for a regression check
+    on the recent tail--the stated purpose of --limit--rather than a reason to
+    walk the full history client-side to sort by ``merged_at`` exactly.
     """
     pulls: list[dict] = []
     page = 1
     while True:
         batch = label_by_title.gh_api(
-            f"repos/{repo}/pulls?state=closed&sort=created&direction=desc"
+            f"repos/{repo}/pulls?state=closed&sort=updated&direction=desc"
             f"&per_page={PER_PAGE}&page={page}",
             token=token,
         )
@@ -102,6 +114,8 @@ def fetch_merged_pulls(repo: str, token: str, limit: int | None = None) -> list[
             pulls.append(pull)
             if limit is not None and len(pulls) >= limit:
                 return pulls
+        if len(batch) < PER_PAGE:
+            return pulls
         page += 1
 
 
@@ -222,7 +236,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         default=None,
         metavar="N",
-        help="Consider only the N most recently opened merged pull requests.",
+        help="Consider only the N most recently merged pull requests.",
     )
     return parser.parse_args(argv)
 

--- a/scripts/ci/labels/audit_labels_by_files.py
+++ b/scripts/ci/labels/audit_labels_by_files.py
@@ -189,7 +189,7 @@ def apply_changes(
         if not label_by_files.add_labels(repo, number, labels, token):
             all_succeeded = False
     for number, labels in to_remove.items():
-        if not emxl.remove_labels(number, labels, repo, token):
+        if not emxl.remove_labels(number, labels, repo, token, reason="unjustified"):
             all_succeeded = False
     return all_succeeded
 

--- a/scripts/ci/labels/backfill_labels_by_title.py
+++ b/scripts/ci/labels/backfill_labels_by_title.py
@@ -170,24 +170,14 @@ def apply_labels(to_apply: dict[int, list[str]], repo: str, token: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def format_report(
-    add: dict[str, list[int]],
-    match: dict[str, list[int]],
-    miss: dict[str, list[int]],
-    include_match: bool = True,
-) -> str:
-    """Render the add/match/miss categories as JSON.
+def format_categories(categories: list[tuple[str, dict[str, list[int]]]]) -> str:
+    """Render named label-to-issue-numbers *categories* as JSON.
 
     Minimized except for a newline after each ``"category":`` and after
-    each label's number list, per the requested output shape. Pass
-    ``include_match=False`` to omit the "match" key entirely (the
-    ``--skip-matches`` flag given with no value).
+    each label's number list, per the requested output shape. Shared with
+    scripts/ci/labels/audit_labels_by_files.py so both reports have the
+    same shape.
     """
-    categories = [("add", add)]
-    if include_match:
-        categories.append(("match", match))
-    categories.append(("miss", miss))
-
     category_parts = []
     for name, labels in categories:
         label_parts = [
@@ -196,6 +186,24 @@ def format_report(
         ]
         category_parts.append(f"{json.dumps(name)}:\n{{{','.join(label_parts)}}}")
     return "{" + ",".join(category_parts) + "}"
+
+
+def format_report(
+    add: dict[str, list[int]],
+    match: dict[str, list[int]],
+    miss: dict[str, list[int]],
+    include_match: bool = True,
+) -> str:
+    """Render the add/match/miss categories as JSON.
+
+    Pass ``include_match=False`` to omit the "match" key entirely (the
+    ``--skip-matches`` flag given with no value).
+    """
+    categories = [("add", add)]
+    if include_match:
+        categories.append(("match", match))
+    categories.append(("miss", miss))
+    return format_categories(categories)
 
 
 def parse_skip_matches(value: str | None) -> tuple[bool, frozenset[str]]:

--- a/scripts/ci/labels/backfill_labels_by_title.py
+++ b/scripts/ci/labels/backfill_labels_by_title.py
@@ -6,6 +6,11 @@ the exact regexes) to the title of every issue and pull request in the
 repository, and applies any label a title matches that is not already
 present. Labels are only ever added, never removed.
 
+On a pull request, label_by_title.FILE_DETERMINED_LABELS are neither applied
+nor reported: those are decided from the PR's own changed files, so applying
+one from a title would reapply exactly what the if-and-only-if rule forbids.
+scripts/ci/labels/audit_labels_by_files.py is the tool that covers them.
+
 Before exiting, prints a JSON report of what happened (or would happen):
 
     add     labels that would be applied and are not already present
@@ -111,7 +116,16 @@ def build_report(
     for item in items:
         number = item["number"]
         current = {lbl["name"] for lbl in item.get("labels", [])}
-        matched = set(label_by_title.matching_labels(item["title"]))
+        # The /issues endpoint marks a pull request with a "pull_request" key.
+        is_pr = "pull_request" in item
+        matched = set(label_by_title.matching_labels(item["title"], is_pull_request=is_pr))
+        # Narrowing "tracked" as well as "matched" matters: leave it alone and
+        # every PR carrying a file-determined label lands in "miss" on every
+        # run, which is precisely the permanent noise TRACKED_LABELS exists to
+        # avoid.
+        tracked = (
+            TRACKED_LABELS - label_by_title.FILE_DETERMINED_LABELS if is_pr else TRACKED_LABELS
+        )
 
         for label in matched:
             if label in current:
@@ -120,7 +134,7 @@ def build_report(
                 add[label].append(number)
                 to_apply[number].append(label)
 
-        for label in TRACKED_LABELS:
+        for label in tracked:
             if label in current and label not in matched:
                 miss[label].append(number)
 

--- a/scripts/ci/labels/enforce_mutually_exclusive_labels.py
+++ b/scripts/ci/labels/enforce_mutually_exclusive_labels.py
@@ -215,8 +215,19 @@ def remove_labels(
     to_remove: list[str],
     repo: str,
     token: str,
+    reason: str = "conflicting",
 ) -> bool:
     """Remove each label in *to_remove* from the issue/PR, logging each removal.
+
+    *reason* is substituted directly into the per-label log line ("Removed
+    {reason} label '<name>' from #N."). It defaults to "conflicting" for this
+    module's own mutual-exclusion callers, where that is literally what
+    happened. scripts/ci/labels/label_by_files.py and
+    scripts/ci/labels/audit_labels_by_files.py reuse this function for a
+    different kind of removal--a label no changed file justifies under an
+    if-and-only-if rule, where nothing conflicts--and pass reason="unjustified"
+    so the log line describes what actually happened instead of contradicting
+    it.
 
     Returns True if every removal succeeded or was already absent (404),
     False if any removal failed with a non-404 HTTPError or a URLError.
@@ -230,7 +241,7 @@ def remove_labels(
                 token=token,
                 method="DELETE",
             )
-            print(f"Removed conflicting label '{label}' from #{issue_number}.")
+            print(f"Removed {reason} label '{label}' from #{issue_number}.")
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 print(

--- a/scripts/ci/labels/label_by_files.py
+++ b/scripts/ci/labels/label_by_files.py
@@ -116,7 +116,14 @@ UNANIMOUS_LABELS = frozenset({"ci", "automated tests"})
 # justifies it" *is* evidence of "not this label". Apply when any changed path
 # justifies it, regardless of what else the PR changes; remove when none does.
 # This is the if-and-only-if rule the repository owner recorded on issue #775.
-EXHAUSTIVE_LABELS = frozenset({"agents"})
+#
+# References label_by_title.FILE_DETERMINED_LABELS directly rather than
+# repeating its own literal: that module suppresses these same labels from a
+# pull request's title, and propagate_issue_labels.py excludes them from
+# issue-to-PR propagation, so all three have to name the identical set for the
+# "exactly one writer owns this label on a PR" precedence claim to hold. See
+# the comment on label_by_title.FILE_DETERMINED_LABELS for the full rationale.
+EXHAUSTIVE_LABELS = label_by_title.FILE_DETERMINED_LABELS
 
 
 def matching_labels(paths: list[str]) -> list[str]:

--- a/scripts/ci/labels/label_by_files.py
+++ b/scripts/ci/labels/label_by_files.py
@@ -2,29 +2,34 @@
 """Apply labels to a pull request based on the set of files it changed.
 
 Unlike label_by_title.py (which matches a title against a regex per label),
-this module classifies each *changed path* and applies a label only when
-every changed path justifies it. See matching_labels() below for the exact
-rule--not duplicated here, to avoid this docstring drifting out of sync with
-the code.
+this module classifies each *changed path* and derives the pull request's
+labels from those classifications. Two rule shapes coexist; UNANIMOUS_LABELS
+and EXHAUSTIVE_LABELS below say which labels take which shape, and
+matching_labels()/labels_to_remove() carry the exact rules--not duplicated
+here, to avoid this docstring drifting out of sync with the code.
 
-Two properties keep the rule safe:
+Two properties keep the add-only unanimity shape safe:
 
 - An unclassified path contributes the empty label set, which empties the
   intersection across all paths. So any file the map below does not
-  recognize disables the file signal entirely for that PR: adding a path
-  mapping can only ever make the signal fire more, and a gap in the map can
+  recognize disables that half of the signal entirely for that PR: adding a
+  path mapping can only ever make it fire more, and a gap in the map can
   only ever make it fire less.
 - The empty file list returns [] (no labels) rather than vacuously matching
   every label, since intersecting zero sets has no defined result.
 
-Labels are only ever added, never removed.
+The if-and-only-if shape both adds and removes, which is sound only because
+the path map *is* that label's complete definition. It stays honest about
+missing evidence: an empty changed-file list, and one that may be truncated,
+each yield no verdict at all--neither an add nor a removal.
 
 Usage:
     python3 scripts/ci/labels/label_by_files.py
 
 Exit code:
-    0  no labels matched, the changed-file list may be truncated, or labels
-       were applied successfully.
+    0  no labels matched, the changed-file list may be truncated, or every
+       label was applied and removed successfully (a 404 on removal means
+       the label was already gone and is not a failure).
     1  required configuration is missing/invalid, or a GitHub API call
        failed.
 
@@ -40,6 +45,7 @@ import re
 import sys
 import urllib.error
 
+import enforce_mutually_exclusive_labels as emxl
 import label_by_title
 
 # ---------------------------------------------------------------------------
@@ -61,6 +67,20 @@ TEST_SCRIPT_BASENAME = re.compile(r"test_.+\.(py|sh)\Z")
 # Orchestrator's own tool rather than repo CI.
 CI_PATH_PREFIXES = (".github/workflows/", "scripts/ci/")
 
+# The repository owner's "agents" path set, recorded on issue #775 as the
+# globs **/AGENTS.md, **/CLAUDE.md, **/agents/**/*, and .claude/**/*. The
+# first two become basename matches, the third a directory segment at any
+# depth, and the fourth a root-anchored prefix, matching how each was
+# anchored. Note that .github/workflows/CLAUDE.md therefore justifies both
+# "agents" and "ci", which is the owner's stated intent.
+#
+# Matching is case-sensitive, consistent with the androidTest and sharedTest
+# segments above: a lowercase docs/agents.md is a different document, not a
+# stale spelling of AGENTS.md.
+AGENTS_BASENAMES = frozenset({"AGENTS.md", "CLAUDE.md"})
+AGENTS_DIR_SEGMENT = "agents"
+AGENTS_PATH_PREFIXES = (".claude/",)
+
 
 def labels_for_path(path: str) -> frozenset[str]:
     """Return the labels *path* alone justifies (empty when it justifies none)."""
@@ -74,14 +94,57 @@ def labels_for_path(path: str) -> frozenset[str]:
         labels.add("automated tests")
     if path.startswith(CI_PATH_PREFIXES):
         labels.add("ci")
+    # segments[:-1] for the same reason: a file literally named "agents" is
+    # not the directory the owner's **/agents/**/* glob names.
+    if (
+        segments[-1] in AGENTS_BASENAMES
+        or AGENTS_DIR_SEGMENT in segments[:-1]
+        or path.startswith(AGENTS_PATH_PREFIXES)
+    ):
+        labels.add("agents")
     return frozenset(labels)
 
 
+# Apply only when *every* changed path justifies it. "Not every path" is an
+# absence of evidence, not evidence of absence, so these are never removed:
+# the dry run on issue #785 found the title rule legitimately applying `ci`
+# to 63 of 220 recent merged PRs whose changed paths justify none of it, and
+# `automated tests` to another 28.
+UNANIMOUS_LABELS = frozenset({"ci", "automated tests"})
+
+# The path map above is this label's complete definition, so "no changed path
+# justifies it" *is* evidence of "not this label". Apply when any changed path
+# justifies it, regardless of what else the PR changes; remove when none does.
+# This is the if-and-only-if rule the repository owner recorded on issue #775.
+EXHAUSTIVE_LABELS = frozenset({"agents"})
+
+
 def matching_labels(paths: list[str]) -> list[str]:
-    """Return the labels every path in *paths* justifies; [] when *paths* is empty."""
+    """Return the labels to apply to a PR changing *paths*; [] when *paths* is empty.
+
+    Restricting the intersection to UNANIMOUS_LABELS and the union to
+    EXHAUSTIVE_LABELS is what keeps the two rule shapes from contaminating
+    each other.
+    """
     if not paths:
         return []
-    return sorted(frozenset.intersection(*(labels_for_path(p) for p in paths)))
+    per_path = [labels_for_path(p) for p in paths]
+    unanimous = frozenset.intersection(*per_path) & UNANIMOUS_LABELS
+    existential = frozenset().union(*per_path) & EXHAUSTIVE_LABELS
+    return sorted(unanimous | existential)
+
+
+def labels_to_remove(paths: list[str]) -> list[str]:
+    """Return the EXHAUSTIVE_LABELS no path in *paths* justifies; [] when *paths* is empty.
+
+    This answers "which labels does the diff forbid", not "which labels does
+    the PR carry"; filtering down to the ones actually present is the
+    caller's job (see remove_unjustified_labels).
+    """
+    if not paths:
+        return []
+    justified = frozenset().union(*(labels_for_path(p) for p in paths))
+    return sorted(EXHAUSTIVE_LABELS - justified)
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +181,77 @@ def fetch_changed_files(repo: str, pr_number: int, token: str) -> list[str] | No
             return paths
         page += 1
     return None
+
+
+def fetch_current_labels(repo: str, pr_number: int, token: str) -> list[str]:
+    """Return the label names the pull request currently carries.
+
+    Raises ``RuntimeError`` if the response is not the expected object, and
+    the usual urllib errors on request failure.
+    """
+    pr = emxl.gh_api(f"repos/{repo}/issues/{pr_number}", token=token)
+    if not isinstance(pr, dict):
+        raise RuntimeError(f"unexpected response fetching #{pr_number}: {pr!r}")
+    return [lbl["name"] for lbl in pr.get("labels", [])]
+
+
+# ---------------------------------------------------------------------------
+# Label writes
+# ---------------------------------------------------------------------------
+
+
+def add_labels(repo: str, pr_number: int, labels: list[str], token: str) -> bool:
+    """Apply *labels* to the pull request. Returns True on success."""
+    try:
+        label_by_title.gh_api(
+            f"repos/{repo}/issues/{pr_number}/labels",
+            token=token,
+            method="POST",
+            body={"labels": labels},
+        )
+        print(f"Applied labels {labels} to #{pr_number}.")
+    except urllib.error.HTTPError as exc:
+        print(f"Error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
+        return False
+    except urllib.error.URLError as exc:
+        print(f"Network error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
+        return False
+    return True
+
+
+def remove_unjustified_labels(repo: str, pr_number: int, labels: list[str], token: str) -> bool:
+    """Remove whichever of *labels* the pull request actually carries.
+
+    The PR's current labels are fetched first so a DELETE is only issued for
+    a label that is really there. Most pull requests neither touch an
+    EXHAUSTIVE_LABELS path nor carry the label (121 of the 220 in issue
+    #785's dry run), and firing a DELETE for each would 404 and print a
+    spurious "already removed?" line on every run.
+
+    Removal itself is enforce_mutually_exclusive_labels.remove_labels(): the
+    identical operation with the identical contract (delete each, treat a 404
+    as already-gone), already URL-encoding the label name and already
+    carrying that module's transient-error retry.
+
+    Returns True on success, including when the PR carries none of *labels*.
+    """
+    try:
+        current = fetch_current_labels(repo, pr_number, token)
+    except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
+        print(f"Error fetching current labels for #{pr_number}: {exc}", file=sys.stderr)
+        return False
+
+    unjustified = {label.lower() for label in labels}
+    # Delete using the name string GitHub returned, not the one from the rule.
+    carried = [name for name in current if name.lower() in unjustified]
+    if not carried:
+        return True
+
+    print(
+        f"Removing labels {carried} from #{pr_number}: no changed file justifies them "
+        "(see EXHAUSTIVE_LABELS in scripts/ci/labels/label_by_files.py)."
+    )
+    return emxl.remove_labels(pr_number, carried, repo, token)
 
 
 # ---------------------------------------------------------------------------
@@ -162,27 +296,22 @@ def main() -> int:
         )
         return 0
 
-    labels = matching_labels(paths)
-    if not labels:
+    # An empty changed-file list is missing evidence, not evidence of
+    # absence: both helpers return [] for it, so neither an add nor a removal
+    # is derived from one.
+    to_add = matching_labels(paths)
+    to_remove = labels_to_remove(paths)
+
+    if not to_add and not to_remove:
         print(f"No label rules matched the changed files on #{pr_number}--nothing to do.")
         return 0
 
-    try:
-        label_by_title.gh_api(
-            f"repos/{repo}/issues/{pr_number}/labels",
-            token=token,
-            method="POST",
-            body={"labels": labels},
-        )
-        print(f"Applied labels {labels} to #{pr_number}.")
-    except urllib.error.HTTPError as exc:
-        print(f"Error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-    except urllib.error.URLError as exc:
-        print(f"Network error applying labels {labels} to #{pr_number}: {exc}", file=sys.stderr)
-        return 1
-
-    return 0
+    exit_code = 0
+    if to_add and not add_labels(repo, pr_number, to_add, token):
+        exit_code = 1
+    if to_remove and not remove_unjustified_labels(repo, pr_number, to_remove, token):
+        exit_code = 1
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/ci/labels/label_by_files.py
+++ b/scripts/ci/labels/label_by_files.py
@@ -48,7 +48,18 @@ import label_by_title
 
 TEST_DIR_SEGMENTS = frozenset({"test", "androidTest", "sharedTest"})
 TEST_SCRIPT_BASENAME = re.compile(r"test_.+\.(py|sh)\Z")
-CI_PATH_PREFIXES = (".github/workflows/",)
+
+# scripts/ci/ holds the repository's CI automation itself, so it maps to "ci"
+# alongside the workflow YAML that invokes it. This repo's most common CI
+# change is "a script under scripts/ci/ plus its test_* sibling": without the
+# mapping the script is unclassified, which empties the intersection and the
+# PR gets nothing; with it the script scores {ci} and its test scores
+# {ci, automated tests}, so unanimity fires on {ci}.
+#
+# scripts/lint/ and scripts/ci_monitor/ are deliberately excluded: lint.sh is
+# a local pre-commit tool as much as a CI step, and ci_monitor is the
+# Orchestrator's own tool rather than repo CI.
+CI_PATH_PREFIXES = (".github/workflows/", "scripts/ci/")
 
 
 def labels_for_path(path: str) -> frozenset[str]:

--- a/scripts/ci/labels/label_by_files.py
+++ b/scripts/ci/labels/label_by_files.py
@@ -258,7 +258,7 @@ def remove_unjustified_labels(repo: str, pr_number: int, labels: list[str], toke
         f"Removing labels {carried} from #{pr_number}: no changed file justifies them "
         "(see EXHAUSTIVE_LABELS in scripts/ci/labels/label_by_files.py)."
     )
-    return emxl.remove_labels(pr_number, carried, repo, token)
+    return emxl.remove_labels(pr_number, carried, repo, token, reason="unjustified")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/labels/label_by_title.py
+++ b/scripts/ci/labels/label_by_title.py
@@ -6,6 +6,11 @@ addition to the normal ``\\b`` boundary, so e.g. ``ci_monitor`` matches the
 ``ci`` rule. See LABEL_PATTERNS below for the exact rules--not duplicated
 here, to avoid this docstring drifting out of sync with the code.
 
+On a pull request, FILE_DETERMINED_LABELS are suppressed: those are owned by
+scripts/ci/labels/label_by_files.py, which decides them from the PR's own
+changed files. Issues have no changed-file list, so nothing is suppressed
+there.
+
 Labels are only ever added, never removed.
 
 Usage:
@@ -21,6 +26,11 @@ Required environment variables:
     GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
     ISSUE_NUMBER        Number of the issue or pull request
     ISSUE_TITLE         Title of the issue or pull request
+
+Optional environment variables:
+    IS_PULL_REQUEST     "true" when the target is a pull request rather than
+                        an issue, which suppresses FILE_DETERMINED_LABELS.
+                        Anything else (including unset) is treated as False.
 """
 
 import json
@@ -86,9 +96,31 @@ LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
 }
 
 
-def matching_labels(title: str) -> list[str]:
-    """Return the labels whose rule matches *title*."""
-    return [label for label, pattern in LABEL_PATTERNS.items() if pattern.search(title)]
+# Labels that scripts/ci/labels/label_by_files.py determines from a pull
+# request's changed files under an if-and-only-if rule. On a pull request the
+# file signal owns them outright, so the title rule must not also write them:
+# the repository owner's precedence decision on issue #775 is that the file
+# list wins on PRs. Issues carry no changed-file list, so the title rule stays
+# the only signal there and nothing is suppressed.
+#
+# Precedence is made structural rather than a race. label-by-title.yml runs on
+# `pull_request: [opened, edited]` while label-by-files.yml runs on
+# `[opened, synchronize]`, so on `opened` both jobs run concurrently and
+# whichever lands last would otherwise decide, and a title edit alone would
+# re-add a label the file signal had removed.
+FILE_DETERMINED_LABELS: frozenset[str] = frozenset({"agents"})
+
+
+def matching_labels(title: str, is_pull_request: bool = False) -> list[str]:
+    """Return the labels whose rule matches *title*.
+
+    On a pull request (*is_pull_request*), FILE_DETERMINED_LABELS are left to
+    scripts/ci/labels/label_by_files.py and never applied from the title.
+    """
+    labels = [label for label, pattern in LABEL_PATTERNS.items() if pattern.search(title)]
+    if is_pull_request:
+        return [label for label in labels if label not in FILE_DETERMINED_LABELS]
+    return labels
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +177,12 @@ def main() -> int:
         print(f"Error: ISSUE_NUMBER is not a valid integer: {issue_number_str!r}", file=sys.stderr)
         return 1
 
-    labels = matching_labels(title)
+    # Defaulting to False makes an omission fail open: a caller that forgets
+    # the variable labels a pull request from its title as before, and the
+    # file signal removes any FILE_DETERMINED_LABELS label on the next push.
+    is_pull_request = os.environ.get("IS_PULL_REQUEST", "").strip().lower() == "true"
+
+    labels = matching_labels(title, is_pull_request=is_pull_request)
     if not labels:
         print(f"No label rules matched title {title!r} on #{issue_number}--nothing to do.")
         return 0

--- a/scripts/ci/labels/label_by_title.py
+++ b/scripts/ci/labels/label_by_title.py
@@ -108,6 +108,17 @@ LABEL_PATTERNS: dict[str, re.Pattern[str]] = {
 # `[opened, synchronize]`, so on `opened` both jobs run concurrently and
 # whichever lands last would otherwise decide, and a title edit alone would
 # re-add a label the file signal had removed.
+#
+# This is the single canonical definition. scripts/ci/labels/label_by_files.py
+# (as EXHAUSTIVE_LABELS) and scripts/ci/labels/propagate_issue_labels.py (as
+# its own FILE_DETERMINED_LABELS) both reference this frozenset object
+# directly rather than each writing their own literal, since label_by_files
+# already imports this module and propagate_issue_labels can too without a
+# cycle. Three independently written literals happening to agree is exactly
+# the kind of silent drift a structural precedence claim cannot rest on: with
+# a shared reference, the three can no longer diverge in value at all, and
+# each module's own test suite pins that it is still using this object (not a
+# copy of it).
 FILE_DETERMINED_LABELS: frozenset[str] = frozenset({"agents"})
 
 

--- a/scripts/ci/labels/propagate_issue_labels.py
+++ b/scripts/ci/labels/propagate_issue_labels.py
@@ -25,7 +25,11 @@ agents/dev_orchestration.md deliberately lets an issue and its PR diverge on
 these mid-cycle (for example, `orchestrating` is removed from the PR alone,
 not the issue, to clear the "No blocking labels" merge gate while
 orchestration is still active), so blindly copying them from issue to PR
-fights that state machine instead of just adding a convenience label. See
+fights that state machine instead of just adding a convenience label.
+
+Labels a pull request's own changed files determine under an if-and-only-if
+rule (FILE_DETERMINED_LABELS, e.g. `agents`) are likewise never propagated:
+what a linked issue is about is not evidence about the PR's diff. See
 labels_to_propagate() for the exact rule.
 
 The pull_request trigger for this module's main() (see
@@ -44,7 +48,8 @@ Exit code:
     0  the PR has no closing issue references, its closing issues carry no
        labels, every eligible label was applied successfully, or every
        candidate was skipped due to a mutual-exclusion conflict or excluded
-       as orchestration-cycle state (neither is itself a failure).
+       as orchestration-cycle state or file-determined (none of these is
+       itself a failure).
     1  required configuration is missing/invalid, or fetching or applying
        labels failed.
 
@@ -185,6 +190,19 @@ PROCESS_STATE_LABELS: frozenset[str] = frozenset(
     }
 )
 
+# Labels a PR's own changed files determine under an if-and-only-if rule (see
+# scripts/ci/labels/label_by_files.py). What a linked issue is *about* is not
+# evidence about the PR's diff, so copying one of these across would
+# contradict the PR's own files. It would also fight the file signal on
+# timing: propagation runs on `opened` and on body edits, the file signal on
+# `opened` and `synchronize`, so a propagated label would sit on the PR until
+# the next push. Observed on 5 of the 21 PRs in issue #785's dry run that
+# carry `agents` without touching any agents path.
+#
+# Disjoint from PROCESS_STATE_LABELS by construction, so the two exclusion
+# reasons partition the excluded list cleanly for logging.
+FILE_DETERMINED_LABELS: frozenset[str] = frozenset({"agents"})
+
 
 def labels_to_propagate(
     current_pr_labels: list[str],
@@ -198,9 +216,11 @@ def labels_to_propagate(
                   enforce_mutually_exclusive_labels.py to remove a label
                   already staged on the PR (a real current PR label, or one
                   accepted earlier in this same call)
-        excluded  issue labels never considered at all because they are in
-                  PROCESS_STATE_LABELS--orchestration-cycle state the issue
-                  and its PR are allowed to carry differently by design
+        excluded  issue labels never considered at all: PROCESS_STATE_LABELS
+                  (orchestration-cycle state the issue and its PR are allowed
+                  to carry differently by design) and FILE_DETERMINED_LABELS
+                  (decided from the PR's own changed files, so the issue is
+                  not evidence about them)
 
     A label already present on the PR (case-insensitively) is dropped from
     every list--there is nothing to do for it. A label repeated across
@@ -226,7 +246,7 @@ def labels_to_propagate(
             continue
         seen_lower.add(lower)
 
-        if lower in PROCESS_STATE_LABELS:
+        if lower in PROCESS_STATE_LABELS or lower in FILE_DETERMINED_LABELS:
             excluded.append(label)
             continue
         if lower in already_lower:
@@ -288,11 +308,23 @@ def propagate_to_pr(owner: str, name: str, repo: str, pr_number: int, token: str
 
     to_add, skipped, excluded = labels_to_propagate(current_pr_labels, issue_labels)
 
-    if excluded:
+    # The two exclusions have different reasons, and the Actions log is the
+    # only debugging surface these scripts have, so they are reported apart.
+    process_state = [lbl for lbl in excluded if lbl.lower() in PROCESS_STATE_LABELS]
+    file_determined = [lbl for lbl in excluded if lbl.lower() in FILE_DETERMINED_LABELS]
+
+    if process_state:
         print(
-            f"Excluding orchestration-cycle labels {excluded} on PR #{pr_number}: the "
+            f"Excluding orchestration-cycle labels {process_state} on PR #{pr_number}: the "
             "issue and its PR are allowed to carry these differently while orchestration "
             "is active (see agents/dev_orchestration.md)."
+        )
+
+    if file_determined:
+        print(
+            f"Excluding file-determined labels {file_determined} on PR #{pr_number}: these "
+            "are decided from the PR's own changed files, so what the linked issue is about "
+            "is not evidence about them (see scripts/ci/labels/label_by_files.py)."
         )
 
     if skipped:

--- a/scripts/ci/labels/propagate_issue_labels.py
+++ b/scripts/ci/labels/propagate_issue_labels.py
@@ -66,6 +66,7 @@ import urllib.error
 import urllib.request
 
 import enforce_mutually_exclusive_labels as emxl
+import label_by_title
 
 # ---------------------------------------------------------------------------
 # GraphQL
@@ -199,9 +200,16 @@ PROCESS_STATE_LABELS: frozenset[str] = frozenset(
 # the next push. Observed on 5 of the 21 PRs in issue #785's dry run that
 # carry `agents` without touching any agents path.
 #
+# References label_by_title.FILE_DETERMINED_LABELS directly rather than
+# repeating its own literal, for the same reason label_by_files.py does: three
+# independently written copies of "agents" could silently drift apart, which
+# would break the "exactly one writer owns this label on a PR" precedence
+# claim without any test noticing. See the comment on
+# label_by_title.FILE_DETERMINED_LABELS for the full rationale.
+#
 # Disjoint from PROCESS_STATE_LABELS by construction, so the two exclusion
 # reasons partition the excluded list cleanly for logging.
-FILE_DETERMINED_LABELS: frozenset[str] = frozenset({"agents"})
+FILE_DETERMINED_LABELS: frozenset[str] = label_by_title.FILE_DETERMINED_LABELS
 
 
 def labels_to_propagate(

--- a/scripts/ci/labels/test_audit_labels_by_files.py
+++ b/scripts/ci/labels/test_audit_labels_by_files.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Unit tests for audit_labels_by_files.py."""
+
+import json
+import os
+import sys
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import audit_labels_by_files as alf  # noqa: E402
+
+
+def _pull(number: int, labels: list[str], merged: bool = True) -> dict:
+    return {
+        "number": number,
+        "labels": [{"name": lbl} for lbl in labels],
+        "merged_at": "2026-07-01T00:00:00Z" if merged else None,
+    }
+
+
+def _paths_from(mapping: dict[int, list[str] | None]):
+    """Build a fetch_paths callable backed by *mapping*."""
+    return lambda number: mapping[number]
+
+
+# ---------------------------------------------------------------------------
+# fetch_merged_pulls
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMergedPulls(unittest.TestCase):
+    def test_skips_closed_but_unmerged_pull_requests(self):
+        page = [_pull(3, []), _pull(2, [], merged=False), _pull(1, [])]
+        with patch.object(alf.label_by_title, "gh_api", side_effect=[page, []]):
+            result = alf.fetch_merged_pulls("owner/repo", "tok")
+        self.assertEqual([p["number"] for p in result], [3, 1])
+
+    def test_paginates_until_empty_page(self):
+        page1 = [_pull(i, []) for i in range(100, 0, -1)]
+        page2 = [_pull(0, [])]
+        with patch.object(alf.label_by_title, "gh_api", side_effect=[page1, page2, []]) as mock_api:
+            result = alf.fetch_merged_pulls("owner/repo", "tok")
+        self.assertEqual(len(result), 101)
+        self.assertEqual(mock_api.call_count, 3)
+
+    def test_limit_truncates_the_pull_request_list(self):
+        page = [_pull(i, []) for i in range(10, 0, -1)]
+        with patch.object(alf.label_by_title, "gh_api", side_effect=[page, []]) as mock_api:
+            result = alf.fetch_merged_pulls("owner/repo", "tok", limit=3)
+        self.assertEqual([p["number"] for p in result], [10, 9, 8])
+        # Stopping mid-page means the walk never asks for a second page.
+        self.assertEqual(mock_api.call_count, 1)
+
+    def test_requests_closed_pull_requests_newest_first(self):
+        with patch.object(alf.label_by_title, "gh_api", return_value=[]) as mock_api:
+            alf.fetch_merged_pulls("owner/repo", "tok")
+        path = mock_api.call_args[0][0]
+        self.assertIn("pulls?state=closed", path)
+        self.assertIn("direction=desc", path)
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport(unittest.TestCase):
+    def test_applied_and_missing_label_goes_to_add(self):
+        pulls = [_pull(1, [])]
+        report = alf.build_report(pulls, _paths_from({1: [".github/workflows/build.yml"]}))
+        self.assertEqual(report.add, {"ci": [1]})
+        self.assertEqual(report.to_add, {1: ["ci"]})
+        self.assertEqual(report.match, {})
+
+    def test_applied_and_present_label_goes_to_match(self):
+        pulls = [_pull(2, ["ci"])]
+        report = alf.build_report(pulls, _paths_from({2: [".github/workflows/build.yml"]}))
+        self.assertEqual(report.match, {"ci": [2]})
+        self.assertEqual(report.add, {})
+        self.assertEqual(report.to_add, {})
+
+    def test_forbidden_and_carried_label_goes_to_remove(self):
+        pulls = [_pull(3, ["agents"])]
+        report = alf.build_report(pulls, _paths_from({3: ["app/src/main/java/Foo.kt"]}))
+        self.assertEqual(report.remove, {"agents": [3]})
+        self.assertEqual(report.to_remove, {3: ["agents"]})
+
+    def test_forbidden_but_absent_label_is_not_reported(self):
+        pulls = [_pull(4, ["ci"])]
+        report = alf.build_report(pulls, _paths_from({4: ["app/src/main/java/Foo.kt"]}))
+        self.assertEqual(report.remove, {})
+        self.assertEqual(report.to_remove, {})
+
+    def test_unanimity_labels_are_never_proposed_for_removal(self):
+        # A product-only diff justifies no "ci", but "ci" is add-only: its
+        # path map is a heuristic, not a definition.
+        pulls = [_pull(5, ["ci", "automated tests"])]
+        report = alf.build_report(pulls, _paths_from({5: ["app/src/main/java/Foo.kt"]}))
+        self.assertEqual(report.remove, {})
+
+    def test_one_pull_request_can_both_gain_and_lose_a_label(self):
+        pulls = [_pull(6, ["agents"])]
+        report = alf.build_report(pulls, _paths_from({6: [".github/workflows/build.yml"]}))
+        self.assertEqual(report.to_add, {6: ["ci"]})
+        self.assertEqual(report.to_remove, {6: ["agents"]})
+
+    def test_removal_uses_the_spelling_github_returned(self):
+        pulls = [_pull(7, ["Agents"])]
+        report = alf.build_report(pulls, _paths_from({7: ["app/src/main/java/Foo.kt"]}))
+        self.assertEqual(report.to_remove, {7: ["Agents"]})
+
+    def test_truncated_file_list_is_skipped_and_counted(self):
+        pulls = [_pull(8, ["agents"]), _pull(9, [])]
+        report = alf.build_report(pulls, _paths_from({8: None, 9: [".github/workflows/build.yml"]}))
+        self.assertEqual(report.skipped, [8])
+        self.assertEqual(report.remove, {})
+        self.assertEqual(report.add, {"ci": [9]})
+
+    def test_numbers_accumulate_per_label(self):
+        pulls = [_pull(1, []), _pull(2, [])]
+        report = alf.build_report(
+            pulls,
+            _paths_from(
+                {1: [".github/workflows/build.yml"], 2: [".github/workflows/lint.yml"]},
+            ),
+        )
+        self.assertEqual(sorted(report.add["ci"]), [1, 2])
+
+
+# ---------------------------------------------------------------------------
+# apply_changes
+# ---------------------------------------------------------------------------
+
+
+class TestApplyChanges(unittest.TestCase):
+    def test_posts_adds_and_deletes_removals(self):
+        with patch.object(alf.label_by_title, "gh_api") as mock_add:
+            with patch.object(alf.emxl, "gh_api") as mock_remove:
+                result = alf.apply_changes({1: ["ci"]}, {2: ["agents"]}, "owner/repo", "tok")
+        self.assertTrue(result)
+        self.assertEqual(mock_add.call_args[0][0], "repos/owner/repo/issues/1/labels")
+        self.assertEqual(mock_add.call_args[1]["method"], "POST")
+        self.assertEqual(mock_remove.call_args[0][0], "repos/owner/repo/issues/2/labels/agents")
+        self.assertEqual(mock_remove.call_args[1]["method"], "DELETE")
+
+    def test_no_calls_when_nothing_to_do(self):
+        with patch.object(alf.label_by_title, "gh_api") as mock_add:
+            with patch.object(alf.emxl, "gh_api") as mock_remove:
+                result = alf.apply_changes({}, {}, "owner/repo", "tok")
+        self.assertTrue(result)
+        mock_add.assert_not_called()
+        mock_remove.assert_not_called()
+
+    def test_continues_past_a_failure_but_reports_it(self):
+        def fake_add(path, token, method="GET", body=None, **kwargs):
+            if "/1/" in path:
+                raise urllib.error.HTTPError(
+                    url=None, code=422, msg="Unprocessable", hdrs=None, fp=None
+                )
+
+        with patch.object(alf.label_by_title, "gh_api", side_effect=fake_add) as mock_add:
+            with patch.object(alf.emxl, "gh_api") as mock_remove:
+                result = alf.apply_changes(
+                    {1: ["ci"], 2: ["ci"]}, {3: ["agents"]}, "owner/repo", "tok"
+                )
+        self.assertFalse(result)
+        self.assertEqual(mock_add.call_count, 2)
+        mock_remove.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# format_report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport(unittest.TestCase):
+    def test_output_is_valid_json_with_all_three_categories(self):
+        report = alf.Report({"ci": [2, 1]}, {}, {"agents": [3]}, {}, {}, [])
+        parsed = json.loads(alf.format_report(report))
+        self.assertEqual(parsed, {"add": {"ci": [1, 2]}, "match": {}, "remove": {"agents": [3]}})
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._env_patch = patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "test-token", "GITHUB_REPOSITORY": "owner/repo"},
+        )
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_requires_a_mode_flag(self):
+        with self.assertRaises(SystemExit):
+            alf.main([])
+
+    def test_exit_1_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            self.assertEqual(alf.main(["-n"]), 1)
+
+    def test_exit_1_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            self.assertEqual(alf.main(["-n"]), 1)
+
+    def test_exit_1_when_limit_is_not_positive(self):
+        self.assertEqual(alf.main(["-n", "--limit", "0"]), 1)
+
+    def test_dry_run_writes_nothing(self):
+        with patch.object(alf, "fetch_merged_pulls", return_value=[_pull(1, ["agents"])]):
+            with patch.object(
+                alf.label_by_files, "fetch_changed_files", return_value=["app/src/main/Foo.kt"]
+            ):
+                with patch.object(alf, "apply_changes") as mock_apply:
+                    result = alf.main(["-n", "-q"])
+        self.assertEqual(result, 0)
+        mock_apply.assert_not_called()
+
+    def test_force_posts_and_deletes(self):
+        pulls = [_pull(1, []), _pull(2, ["agents"])]
+        paths = {1: [".github/workflows/build.yml"], 2: ["app/src/main/Foo.kt"]}
+        with patch.object(alf, "fetch_merged_pulls", return_value=pulls):
+            with patch.object(
+                alf.label_by_files,
+                "fetch_changed_files",
+                side_effect=lambda repo, number, token: paths[number],
+            ):
+                with patch.object(alf.label_by_title, "gh_api") as mock_add:
+                    with patch.object(alf.emxl, "gh_api") as mock_remove:
+                        result = alf.main(["-f", "-q"])
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_add.call_args[1]["body"], {"labels": ["ci"]})
+        self.assertEqual(mock_remove.call_args[0][0], "repos/owner/repo/issues/2/labels/agents")
+
+    def test_force_returns_1_when_a_write_fails(self):
+        with patch.object(alf, "fetch_merged_pulls", return_value=[_pull(1, [])]):
+            with patch.object(
+                alf.label_by_files,
+                "fetch_changed_files",
+                return_value=[".github/workflows/build.yml"],
+            ):
+                with patch.object(
+                    alf.label_by_title,
+                    "gh_api",
+                    side_effect=urllib.error.URLError("network error"),
+                ):
+                    result = alf.main(["-f", "-q"])
+        self.assertEqual(result, 1)
+
+    def test_per_pull_request_fetch_failure_is_skipped_not_fatal(self):
+        pulls = [_pull(1, ["agents"]), _pull(2, [])]
+
+        def fake_fetch(repo, number, token):
+            if number == 1:
+                raise urllib.error.HTTPError(
+                    url=None, code=404, msg="Not Found", hdrs=None, fp=None
+                )
+            return [".github/workflows/build.yml"]
+
+        with patch.object(alf, "fetch_merged_pulls", return_value=pulls):
+            with patch.object(alf.label_by_files, "fetch_changed_files", side_effect=fake_fetch):
+                with patch.object(alf, "apply_changes", return_value=True) as mock_apply:
+                    result = alf.main(["-f", "-q"])
+        self.assertEqual(result, 0)
+        # #1 yielded no verdict at all, so nothing is written for it.
+        to_add, to_remove = mock_apply.call_args[0][0], mock_apply.call_args[0][1]
+        self.assertEqual(to_add, {2: ["ci"]})
+        self.assertEqual(to_remove, {})
+
+    def test_exit_1_when_the_pull_request_list_cannot_be_fetched(self):
+        with patch.object(alf, "fetch_merged_pulls", side_effect=RuntimeError("boom")):
+            self.assertEqual(alf.main(["-n", "-q"]), 1)
+
+    def test_limit_is_passed_through_to_the_fetch(self):
+        with patch.object(alf, "fetch_merged_pulls", return_value=[]) as mock_fetch:
+            alf.main(["-n", "-q", "--limit", "5"])
+        self.assertEqual(mock_fetch.call_args[0][2], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/labels/test_audit_labels_by_files.py
+++ b/scripts/ci/labels/test_audit_labels_by_files.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """Unit tests for audit_labels_by_files.py."""
 
+import io
 import json
 import os
 import sys
 import unittest
 import urllib.error
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -144,6 +146,20 @@ class TestApplyChanges(unittest.TestCase):
         self.assertEqual(mock_add.call_args[1]["method"], "POST")
         self.assertEqual(mock_remove.call_args[0][0], "repos/owner/repo/issues/2/labels/agents")
         self.assertEqual(mock_remove.call_args[1]["method"], "DELETE")
+
+    def test_removal_log_line_says_unjustified_not_conflicting(self):
+        # Nothing conflicts here either: the removal reason is that no
+        # changed path justifies the label, so the log line must say so
+        # instead of defaulting to enforce_mutually_exclusive_labels's
+        # "conflicting" wording, which is the only line printed for this
+        # call site and would otherwise be the sole, wrong explanation on
+        # the Actions log.
+        with patch.object(alf.label_by_title, "gh_api"):
+            with patch.object(alf.emxl, "gh_api"):
+                out = io.StringIO()
+                with redirect_stdout(out):
+                    alf.apply_changes({}, {2: ["agents"]}, "owner/repo", "tok")
+        self.assertIn("Removed unjustified label 'agents' from #2.", out.getvalue())
 
     def test_no_calls_when_nothing_to_do(self):
         with patch.object(alf.label_by_title, "gh_api") as mock_add:

--- a/scripts/ci/labels/test_audit_labels_by_files.py
+++ b/scripts/ci/labels/test_audit_labels_by_files.py
@@ -27,6 +27,11 @@ def _paths_from(mapping: dict[int, list[str] | None]):
     return lambda number: mapping[number]
 
 
+def _pulls(n: int, start: int = 0) -> list[dict]:
+    """Build *n* merged, unlabeled pull request dicts with distinct numbers."""
+    return [_pull(start + i, []) for i in range(n)]
+
+
 # ---------------------------------------------------------------------------
 # fetch_merged_pulls
 # ---------------------------------------------------------------------------
@@ -39,12 +44,23 @@ class TestFetchMergedPulls(unittest.TestCase):
             result = alf.fetch_merged_pulls("owner/repo", "tok")
         self.assertEqual([p["number"] for p in result], [3, 1])
 
-    def test_paginates_until_empty_page(self):
-        page1 = [_pull(i, []) for i in range(100, 0, -1)]
-        page2 = [_pull(0, [])]
+    def test_stops_on_short_page(self):
+        # Matches label_by_files.fetch_changed_files's own early stop: a page
+        # shorter than PER_PAGE is the normal end of the list, so a second
+        # request is wasted.
+        page1 = _pulls(alf.PER_PAGE)
+        page2 = _pulls(1, start=alf.PER_PAGE)
+        with patch.object(alf.label_by_title, "gh_api", side_effect=[page1, page2]) as mock_api:
+            result = alf.fetch_merged_pulls("owner/repo", "tok")
+        self.assertEqual(len(result), alf.PER_PAGE + 1)
+        self.assertEqual(mock_api.call_count, 2)
+
+    def test_stops_on_empty_page_after_full_pages(self):
+        page1 = _pulls(alf.PER_PAGE)
+        page2 = _pulls(alf.PER_PAGE, start=alf.PER_PAGE)
         with patch.object(alf.label_by_title, "gh_api", side_effect=[page1, page2, []]) as mock_api:
             result = alf.fetch_merged_pulls("owner/repo", "tok")
-        self.assertEqual(len(result), 101)
+        self.assertEqual(len(result), alf.PER_PAGE * 2)
         self.assertEqual(mock_api.call_count, 3)
 
     def test_limit_truncates_the_pull_request_list(self):
@@ -55,11 +71,15 @@ class TestFetchMergedPulls(unittest.TestCase):
         # Stopping mid-page means the walk never asks for a second page.
         self.assertEqual(mock_api.call_count, 1)
 
-    def test_requests_closed_pull_requests_newest_first(self):
+    def test_requests_closed_pull_requests_by_updated_newest_first(self):
+        # sort=updated, not sort=created: the REST API has no sort=merged
+        # option, but merging updates a pull request, so updated_at
+        # approximates merge recency far better than created_at does.
         with patch.object(alf.label_by_title, "gh_api", return_value=[]) as mock_api:
             alf.fetch_merged_pulls("owner/repo", "tok")
         path = mock_api.call_args[0][0]
         self.assertIn("pulls?state=closed", path)
+        self.assertIn("sort=updated", path)
         self.assertIn("direction=desc", path)
 
 

--- a/scripts/ci/labels/test_backfill_labels_by_title.py
+++ b/scripts/ci/labels/test_backfill_labels_by_title.py
@@ -16,6 +16,13 @@ def _issue(number: int, title: str, labels: list[str]) -> dict:
     return {"number": number, "title": title, "labels": [{"name": lbl} for lbl in labels]}
 
 
+def _pull_request(number: int, title: str, labels: list[str]) -> dict:
+    """Build an /issues item for a pull request (marked by the pull_request key)."""
+    item = _issue(number, title, labels)
+    item["pull_request"] = {"url": f"https://api.github.com/repos/owner/repo/pulls/{number}"}
+    return item
+
+
 # ---------------------------------------------------------------------------
 # TRACKED_LABELS
 # ---------------------------------------------------------------------------
@@ -123,6 +130,35 @@ class TestBuildReport(unittest.TestCase):
         add, match, miss, to_apply = blt.build_report(items)
         self.assertIn("ci", to_apply[1])
         self.assertIn("agents", to_apply[1])
+
+    # -- file-determined labels on pull requests (issue #785) ---------------
+
+    def test_pull_request_never_gets_a_file_determined_label_proposed(self):
+        # -f would otherwise reapply exactly what the if-and-only-if rule in
+        # label_by_files.py forbids.
+        items = [_pull_request(1, "Tighten guidance for agents", [])]
+        add, match, miss, to_apply = blt.build_report(items)
+        self.assertNotIn("agents", add)
+        self.assertNotIn(1, to_apply)
+
+    def test_pull_request_carrying_a_file_determined_label_is_not_a_miss(self):
+        # Reporting it would put every `agents`-labeled PR in "miss" on every
+        # run: the permanent noise TRACKED_LABELS exists to avoid.
+        items = [_pull_request(2, "Bump the version number", ["agents"])]
+        add, match, miss, to_apply = blt.build_report(items)
+        self.assertEqual(miss, {})
+
+    def test_pull_request_still_reports_labels_the_title_rule_owns(self):
+        items = [_pull_request(3, "Bump the version number", ["ci", "agents"])]
+        add, match, miss, to_apply = blt.build_report(items)
+        self.assertEqual(miss["ci"], [3])
+        self.assertNotIn("agents", miss)
+
+    def test_issue_without_a_pull_request_key_is_unchanged(self):
+        items = [_issue(4, "Tighten guidance for agents", [])]
+        add, match, miss, to_apply = blt.build_report(items)
+        self.assertEqual(add["agents"], [4])
+        self.assertEqual(to_apply[4], ["agents"])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/labels/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/ci/labels/test_enforce_mutually_exclusive_labels.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """Unit tests for enforce_mutually_exclusive_labels.py."""
 
+import io
 import json
 import os
 import sys
 import unittest
 import urllib.error
+from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -500,6 +502,25 @@ class TestRemoveLabels(unittest.TestCase):
 
         self.assertTrue(any("verification%20needed" in p for p in call_paths))
         self.assertTrue(result)
+
+    def test_default_reason_says_conflicting(self):
+        with patch.object(emxl, "gh_api"):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                emxl.remove_labels(1, ["p2"], "owner/repo", "tok")
+        self.assertIn("Removed conflicting label 'p2' from #1.", out.getvalue())
+
+    def test_custom_reason_replaces_conflicting_in_the_log_line(self):
+        # scripts/ci/labels/label_by_files.py and
+        # scripts/ci/labels/audit_labels_by_files.py reuse this function for a
+        # removal where nothing conflicts, so they pass reason="unjustified"
+        # to keep the log line honest.
+        with patch.object(emxl, "gh_api"):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                emxl.remove_labels(1, ["agents"], "owner/repo", "tok", reason="unjustified")
+        self.assertIn("Removed unjustified label 'agents' from #1.", out.getvalue())
+        self.assertNotIn("conflicting", out.getvalue())
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -28,12 +28,34 @@ class TestLabelsForPath(unittest.TestCase):
 
     def test_test_script_basename_gives_automated_tests(self):
         self.assertEqual(
-            lbf.labels_for_path("scripts/ci/labels/test_label_by_files.py"),
+            lbf.labels_for_path("scripts/lint/test_check_md040.py"),
             frozenset({"automated tests"}),
         )
 
     def test_workflow_yaml_gives_ci(self):
         self.assertEqual(lbf.labels_for_path(".github/workflows/build.yml"), frozenset({"ci"}))
+
+    def test_ci_script_gives_ci(self):
+        for path in (
+            "scripts/ci/labels/label_by_title.py",
+            "scripts/ci/test-support/dismiss_anr.sh",
+        ):
+            self.assertEqual(lbf.labels_for_path(path), frozenset({"ci"}), msg=path)
+
+    def test_ci_test_script_gives_both_ci_and_automated_tests(self):
+        # Both rules fire on one path: the basename is a test script and the
+        # path is CI automation.
+        self.assertEqual(
+            lbf.labels_for_path("scripts/ci/labels/test_label_by_title.py"),
+            frozenset({"automated tests", "ci"}),
+        )
+
+    def test_lint_and_ci_monitor_scripts_are_not_ci(self):
+        # Pins the deliberate exclusions from CI_PATH_PREFIXES: lint.sh is a
+        # local pre-commit tool as much as a CI step, and ci_monitor is the
+        # Orchestrator's tool rather than repo CI.
+        for path in ("scripts/lint/lint.sh", "scripts/ci_monitor/ci_monitor.py"):
+            self.assertEqual(lbf.labels_for_path(path), frozenset(), msg=path)
 
     def test_unclassified_paths_give_empty_set(self):
         for path in (
@@ -116,6 +138,18 @@ class TestMatchingLabels(unittest.TestCase):
         # #665: a pure .github/workflows/*.yml version bump. The other miss
         # issue #775 cited.
         paths = [".github/workflows/strip-session-bylines.yml"]
+        self.assertEqual(lbf.matching_labels(paths), ["ci"])
+
+    def test_pr_782_regression_fixture(self):
+        # #782: the "a script under scripts/ci/ plus its test_* sibling"
+        # shape that motivates mapping scripts/ci/ to "ci". Without that
+        # mapping label_by_files.py itself is unclassified, which empties the
+        # intersection and the PR gets no label at all.
+        paths = [
+            ".github/workflows/label-by-files.yml",
+            "scripts/ci/labels/label_by_files.py",
+            "scripts/ci/labels/test_label_by_files.py",
+        ]
         self.assertEqual(lbf.matching_labels(paths), ["ci"])
 
 

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -108,6 +108,25 @@ class TestLabelsForPath(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# EXHAUSTIVE_LABELS / FILE_DETERMINED_LABELS identity
+# ---------------------------------------------------------------------------
+
+
+class TestExhaustiveLabelsIdentity(unittest.TestCase):
+    def test_exhaustive_labels_is_the_same_object_as_file_determined_labels(self):
+        # label_by_title.FILE_DETERMINED_LABELS is the single canonical
+        # definition (label_by_title.py suppresses these from PR titles,
+        # propagate_issue_labels.py excludes them from propagation, and this
+        # module both adds and removes them from a PR's own changed files).
+        # An `is` check, not just `==`, is the point: it fails the moment
+        # someone reintroduces a separately written literal that happens to
+        # equal today's value, which is exactly the silent-drift risk a
+        # structural "exactly one writer owns this label" claim cannot rest
+        # on three independently maintained copies to avoid.
+        self.assertIs(lbf.EXHAUSTIVE_LABELS, lbf.label_by_title.FILE_DETERMINED_LABELS)
+
+
+# ---------------------------------------------------------------------------
 # matching_labels tests
 # ---------------------------------------------------------------------------
 

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Unit tests for label_by_files.py."""
 
+import io
 import os
 import sys
 import unittest
 import urllib.error
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -411,6 +413,20 @@ class TestMain(unittest.TestCase):
         self.assertEqual(result, 0)
         mock_api.assert_not_called()
         self.mock_emxl_api.assert_not_called()
+
+    def test_removal_log_line_says_unjustified_not_conflicting(self):
+        # enforce_mutually_exclusive_labels.remove_labels defaults its log
+        # line to "conflicting", which would be false here: nothing conflicts,
+        # the diff simply justifies nothing. reason="unjustified" keeps the
+        # log line honest instead of contradicting the "no changed file
+        # justifies them" line printed immediately before it.
+        self.mock_emxl_api.return_value = {"labels": [{"name": "agents"}]}
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api"):
+                out = io.StringIO()
+                with redirect_stdout(out):
+                    lbf.main()
+        self.assertIn("Removed unjustified label 'agents'", out.getvalue())
 
     def test_no_verdict_when_file_list_is_empty(self):
         # Removing a label on the strength of an empty file list is exactly

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -61,7 +61,6 @@ class TestLabelsForPath(unittest.TestCase):
         for path in (
             "app/src/main/java/com/gb4pc/Foo.kt",
             "README.md",
-            "agents/pr_participation.md",
             ".github/release.yml",
             ".github/allowed-test-failures.txt",
         ):
@@ -71,6 +70,41 @@ class TestLabelsForPath(unittest.TestCase):
         # segments[:-1] restricts the directory-segment check to
         # directories, so a *file* named "test" doesn't trigger the rule.
         self.assertEqual(lbf.labels_for_path("app/src/main/test"), frozenset())
+
+    def test_agents_path_set_gives_agents(self):
+        # The repository owner's four globs from issue #775:
+        # **/AGENTS.md, **/CLAUDE.md, **/agents/**/*, .claude/**/*.
+        for path in (
+            "AGENTS.md",
+            "CLAUDE.md",
+            "agents/code_edit.md",
+            "agents/pr_participation.md",
+            "scripts/agents/update_gh_labels.sh",
+            ".claude/rules/prose-style.md",
+            ".claude/settings.json",
+            "scripts/ci_monitor/CLAUDE.md",
+        ):
+            self.assertEqual(lbf.labels_for_path(path), frozenset({"agents"}), msg=path)
+
+    def test_agents_test_script_gives_agents_and_automated_tests(self):
+        self.assertEqual(
+            lbf.labels_for_path("scripts/agents/test_update_gh_labels.sh"),
+            frozenset({"agents", "automated tests"}),
+        )
+
+    def test_workflow_claude_md_gives_agents_and_ci(self):
+        # Decision 4 from the repository owner's comment on issue #775.
+        self.assertEqual(
+            lbf.labels_for_path(".github/workflows/CLAUDE.md"),
+            frozenset({"agents", "ci"}),
+        )
+
+    def test_agents_matching_is_case_sensitive_and_directory_only(self):
+        # A *file* named "agents" is not the directory the glob names, and
+        # a lowercase docs/agents.md is a different document, not a stale
+        # spelling of AGENTS.md.
+        for path in ("app/src/main/agents", "docs/agents.md"):
+            self.assertEqual(lbf.labels_for_path(path), frozenset(), msg=path)
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +186,87 @@ class TestMatchingLabels(unittest.TestCase):
         ]
         self.assertEqual(lbf.matching_labels(paths), ["ci"])
 
+    # -- the existential (if-and-only-if) half ------------------------------
+
+    def test_one_agents_path_among_unrelated_files_still_gives_agents(self):
+        # "regardless of what else the PR changes": unanimity would fail
+        # here, but `agents` is existential.
+        self.assertEqual(
+            lbf.matching_labels(["agents/code_edit.md", "app/src/main/java/Foo.kt"]),
+            ["agents"],
+        )
+
+    def test_agents_path_does_not_drag_a_unanimous_label_along(self):
+        # The workflow YAML justifies "ci" but agents/x.md does not, so
+        # unanimity still fails for "ci" while "agents" fires on its own.
+        self.assertEqual(
+            lbf.matching_labels(["agents/x.md", ".github/workflows/build.yml"]),
+            ["agents"],
+        )
+
+    def test_one_path_can_produce_both_shapes(self):
+        self.assertEqual(lbf.matching_labels([".github/workflows/CLAUDE.md"]), ["agents", "ci"])
+
+    def test_pr_779_regression_fixture(self):
+        # #779: a reorg that moved scripts around, touching .claude/ files
+        # and a dozen workflow YAMLs. The existential half applies `agents`
+        # even though most changed paths justify only `ci`.
+        paths = [
+            ".claude/environment.md",
+            ".claude/hooks/session-start.sh",
+            ".github/workflows/CLAUDE.md",
+            ".github/workflows/build.yml",
+            ".github/workflows/lint.yml",
+        ]
+        self.assertIn("agents", lbf.matching_labels(paths))
+
+
+# ---------------------------------------------------------------------------
+# labels_to_remove tests
+# ---------------------------------------------------------------------------
+
+
+class TestLabelsToRemove(unittest.TestCase):
+    def test_empty_list_removes_nothing(self):
+        # An empty changed-file list is missing evidence, not evidence of
+        # absence.
+        self.assertEqual(lbf.labels_to_remove([]), [])
+
+    def test_product_only_list_removes_agents(self):
+        self.assertEqual(lbf.labels_to_remove(["app/src/main/java/com/gb4pc/Foo.kt"]), ["agents"])
+
+    def test_any_agents_path_keeps_agents(self):
+        self.assertEqual(
+            lbf.labels_to_remove(["app/src/main/java/Foo.kt", ".claude/settings.json"]),
+            [],
+        )
+
+    def test_all_test_list_removes_agents(self):
+        # The label is justified nowhere here. Whether the PR actually
+        # carries it is the caller's concern, not this function's.
+        self.assertEqual(
+            lbf.labels_to_remove(["app/src/test/java/com/gb4pc/FooTest.kt"]),
+            ["agents"],
+        )
+
+    def test_unanimous_labels_are_never_removed(self):
+        # A product-only diff justifies neither "ci" nor "automated tests",
+        # but their path maps are heuristics rather than definitions, so
+        # absence of evidence must not become a removal.
+        self.assertNotIn("ci", lbf.labels_to_remove(["app/src/main/java/Foo.kt"]))
+        self.assertNotIn("automated tests", lbf.labels_to_remove(["app/src/main/java/Foo.kt"]))
+
+    def test_pr_753_regression_fixture(self):
+        # #753: a ci_monitor change carrying `agents` that touches no path in
+        # the owner's agents set, so the label goes and nothing is added.
+        paths = [
+            "scripts/ci_monitor/README.md",
+            "scripts/ci_monitor/ci_monitor.py",
+            "scripts/test_ci_monitor.py",
+        ]
+        self.assertEqual(lbf.labels_to_remove(paths), ["agents"])
+        self.assertEqual(lbf.matching_labels(paths), [])
+
 
 # ---------------------------------------------------------------------------
 # fetch_changed_files tests
@@ -199,6 +314,13 @@ class TestFetchChangedFiles(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+def _delete_paths(mock_api) -> list[str]:
+    """Return the API paths *mock_api* was asked to DELETE."""
+    return [
+        call.args[0] for call in mock_api.call_args_list if call.kwargs.get("method") == "DELETE"
+    ]
+
+
 class TestMain(unittest.TestCase):
     def setUp(self):
         self._env_patch = patch.dict(
@@ -210,8 +332,15 @@ class TestMain(unittest.TestCase):
             },
         )
         self._env_patch.start()
+        # The removal path reads the PR's current labels, then deletes,
+        # through enforce_mutually_exclusive_labels.gh_api. Default it to a
+        # PR carrying no labels so no test reaches the network; the tests
+        # that care about a carried label override it.
+        self._emxl_patch = patch.object(lbf.emxl, "gh_api", return_value={"labels": []})
+        self.mock_emxl_api = self._emxl_patch.start()
 
     def tearDown(self):
+        self._emxl_patch.stop()
         self._env_patch.stop()
 
     def test_exit_1_when_token_missing(self):
@@ -234,19 +363,95 @@ class TestMain(unittest.TestCase):
             result = lbf.main()
         self.assertEqual(result, 1)
 
-    def test_no_api_call_when_no_files_match(self):
+    def test_no_post_and_no_delete_when_no_files_match_and_label_absent(self):
         with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
             with patch.object(lbf.label_by_title, "gh_api") as mock_api:
                 result = lbf.main()
         self.assertEqual(result, 0)
         mock_api.assert_not_called()
+        # The rule forbids `agents` here, but the PR does not carry it, so
+        # firing a DELETE would only 404.
+        self.assertEqual(_delete_paths(self.mock_emxl_api), [])
 
-    def test_no_api_call_when_file_list_possibly_truncated(self):
+    def test_deletes_a_carried_label_no_changed_file_justifies(self):
+        self.mock_emxl_api.return_value = {"labels": [{"name": "agents"}, {"name": "p1"}]}
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+        self.assertEqual(
+            _delete_paths(self.mock_emxl_api),
+            ["repos/owner/repo/issues/42/labels/agents"],
+        )
+
+    def test_no_verdict_when_file_list_possibly_truncated(self):
         with patch.object(lbf, "fetch_changed_files", return_value=None):
             with patch.object(lbf.label_by_title, "gh_api") as mock_api:
                 result = lbf.main()
         self.assertEqual(result, 0)
         mock_api.assert_not_called()
+        self.mock_emxl_api.assert_not_called()
+
+    def test_no_verdict_when_file_list_is_empty(self):
+        # Removing a label on the strength of an empty file list is exactly
+        # the case where the evidence does not exist.
+        with patch.object(lbf, "fetch_changed_files", return_value=[]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+        self.mock_emxl_api.assert_not_called()
+
+    def test_exit_1_when_removal_fails_with_a_non_404(self):
+        def fake_api(path, token, method="GET", body=None, **kwargs):
+            if method == "DELETE":
+                raise urllib.error.HTTPError(
+                    url=None, code=500, msg="Server Error", hdrs=None, fp=None
+                )
+            return {"labels": [{"name": "agents"}]}
+
+        self.mock_emxl_api.side_effect = fake_api
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api"):
+                result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_0_when_removal_404s(self):
+        # A 404 means the label was already gone (e.g. a race with a human
+        # removing it), which is the desired end state, not a failure.
+        def fake_api(path, token, method="GET", body=None, **kwargs):
+            if method == "DELETE":
+                raise urllib.error.HTTPError(
+                    url=None, code=404, msg="Not Found", hdrs=None, fp=None
+                )
+            return {"labels": [{"name": "agents"}]}
+
+        self.mock_emxl_api.side_effect = fake_api
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api"):
+                result = lbf.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_1_when_the_current_label_fetch_fails(self):
+        self.mock_emxl_api.side_effect = urllib.error.URLError("network error")
+        with patch.object(lbf, "fetch_changed_files", return_value=["app/src/main/java/Foo.kt"]):
+            with patch.object(lbf.label_by_title, "gh_api"):
+                result = lbf.main()
+        self.assertEqual(result, 1)
+
+    def test_posts_and_deletes_are_both_attempted_in_one_run(self):
+        # A PR whose diff justifies `ci` but forbids `agents`, carrying both.
+        self.mock_emxl_api.return_value = {"labels": [{"name": "agents"}]}
+        with patch.object(lbf, "fetch_changed_files", return_value=[".github/workflows/build.yml"]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_api.call_args[1]["body"], {"labels": ["ci"]})
+        self.assertEqual(
+            _delete_paths(self.mock_emxl_api),
+            ["repos/owner/repo/issues/42/labels/agents"],
+        )
 
     def test_posts_matching_label(self):
         with patch.object(lbf, "fetch_changed_files", return_value=[".github/workflows/build.yml"]):

--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -414,6 +414,18 @@ class TestMain(unittest.TestCase):
         mock_api.assert_not_called()
         self.mock_emxl_api.assert_not_called()
 
+    def test_no_current_label_fetch_when_diff_justifies_agents(self):
+        # labels_to_remove is [] when a changed path justifies "agents", so
+        # remove_unjustified_labels--and its GET of the PR's current
+        # labels--never runs at all. This is the path deciding whether an
+        # agents-touching PR pays an extra GET on every synchronize.
+        with patch.object(lbf, "fetch_changed_files", return_value=["agents/code_edit.md"]):
+            with patch.object(lbf.label_by_title, "gh_api") as mock_api:
+                result = lbf.main()
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_api.call_args[1]["body"], {"labels": ["agents"]})
+        self.mock_emxl_api.assert_not_called()
+
     def test_removal_log_line_says_unjustified_not_conflicting(self):
         # enforce_mutually_exclusive_labels.remove_labels defaults its log
         # line to "conflicting", which would be false here: nothing conflicts,

--- a/scripts/ci/labels/test_label_by_title.py
+++ b/scripts/ci/labels/test_label_by_title.py
@@ -280,6 +280,24 @@ class TestMatchingLabelsCombined(unittest.TestCase):
         self.assertEqual(lpt.matching_labels("Set overlay default position to y=75%"), [])
 
 
+class TestFileDeterminedLabelSuppression(unittest.TestCase):
+    def test_issue_path_is_the_default_and_still_gets_agents(self):
+        self.assertIn("agents", lpt.matching_labels("Add PR verification agent instructions"))
+
+    def test_pull_request_path_suppresses_agents(self):
+        self.assertNotIn(
+            "agents",
+            lpt.matching_labels("Add PR verification agent instructions", is_pull_request=True),
+        )
+
+    def test_pull_request_path_keeps_every_other_matching_label(self):
+        title = "Add CiWatcher agent and fix Reviewer CI-polling loop"
+        self.assertEqual(lpt.matching_labels(title, is_pull_request=True), ["ci"])
+
+    def test_agents_is_the_only_file_determined_label(self):
+        self.assertEqual(lpt.FILE_DETERMINED_LABELS, frozenset({"agents"}))
+
+
 # ---------------------------------------------------------------------------
 # main() tests
 # ---------------------------------------------------------------------------
@@ -348,6 +366,67 @@ class TestMain(unittest.TestCase):
         body = mock_api.call_args[1]["body"]
         self.assertIn("ci", body["labels"])
         self.assertIn("agents", body["labels"])
+
+    def test_is_pull_request_true_omits_agents_from_the_post(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ISSUE_TITLE": "Add CiWatcher agent and fix Reviewer CI-polling loop",
+                "IS_PULL_REQUEST": "true",
+            },
+        ):
+            with patch.object(lpt, "gh_api") as mock_api:
+                result = lpt.main()
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_api.call_args[1]["body"], {"labels": ["ci"]})
+
+    def test_is_pull_request_is_case_and_whitespace_tolerant(self):
+        # GitHub Actions renders the boolean expression as "true"/"false",
+        # but a hand-run invocation may not be so tidy.
+        for value in ("TRUE", " true "):
+            with self.subTest(value=value):
+                with patch.dict(
+                    os.environ,
+                    {
+                        "ISSUE_TITLE": "Add CiWatcher agent and fix Reviewer CI-polling loop",
+                        "IS_PULL_REQUEST": value,
+                    },
+                ):
+                    with patch.object(lpt, "gh_api") as mock_api:
+                        lpt.main()
+                self.assertEqual(mock_api.call_args[1]["body"], {"labels": ["ci"]})
+
+    def test_omitted_or_false_is_pull_request_behaves_as_before(self):
+        # Fail open: a caller that forgets the variable labels a PR from its
+        # title exactly as it did before, and the file signal removes the
+        # label on the next push.
+        for env in ({}, {"IS_PULL_REQUEST": ""}, {"IS_PULL_REQUEST": "false"}):
+            with self.subTest(env=env):
+                with patch.dict(
+                    os.environ,
+                    {
+                        "ISSUE_TITLE": "Add CiWatcher agent and fix Reviewer CI-polling loop",
+                        **env,
+                    },
+                ):
+                    with patch.object(lpt, "gh_api") as mock_api:
+                        lpt.main()
+                body = mock_api.call_args[1]["body"]
+                self.assertIn("agents", body["labels"])
+                self.assertIn("ci", body["labels"])
+
+    def test_no_post_when_agents_was_the_only_match_on_a_pull_request(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ISSUE_TITLE": "Tighten guidance for agents",
+                "IS_PULL_REQUEST": "true",
+            },
+        ):
+            with patch.object(lpt, "gh_api") as mock_api:
+                result = lpt.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
 
     def test_exit_1_on_http_error(self):
         error = urllib.error.HTTPError(url=None, code=422, msg="Unprocessable", hdrs=None, fp=None)

--- a/scripts/ci/labels/test_propagate_issue_labels.py
+++ b/scripts/ci/labels/test_propagate_issue_labels.py
@@ -178,8 +178,11 @@ class TestLabelsToPropagate(unittest.TestCase):
         self.assertEqual(excluded, [])
 
     def test_labels_outside_any_exclusive_group_never_conflict(self):
-        to_add, skipped, excluded = pil.labels_to_propagate(["automated tests"], ["ci", "agents"])
-        self.assertEqual(to_add, ["ci", "agents"])
+        # "agents" was one of the examples here until issue #785 made it
+        # file-determined and therefore never propagated at all; "bug" keeps
+        # this case about mutual exclusion alone.
+        to_add, skipped, excluded = pil.labels_to_propagate(["automated tests"], ["ci", "bug"])
+        self.assertEqual(to_add, ["ci", "bug"])
         self.assertEqual(skipped, [])
         self.assertEqual(excluded, [])
 
@@ -222,6 +225,31 @@ class TestLabelsToPropagate(unittest.TestCase):
     def test_process_state_label_deduplicated_across_issues(self):
         to_add, skipped, excluded = pil.labels_to_propagate([], ["orchestrating", "orchestrating"])
         self.assertEqual(excluded, ["orchestrating"])
+
+    # -- FILE_DETERMINED_LABELS exclusion (issue #785) -----------------------
+
+    def test_excludes_agents_from_propagation(self):
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["agents", "p1"])
+        self.assertEqual(to_add, ["p1"])
+        self.assertEqual(skipped, [])
+        self.assertEqual(excluded, ["agents"])
+
+    def test_excludes_agents_even_when_the_pr_already_carries_it(self):
+        # Ordered ahead of the already-present check, matching how
+        # PROCESS_STATE_LABELS is handled today.
+        to_add, skipped, excluded = pil.labels_to_propagate(["agents"], ["agents"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(excluded, ["agents"])
+
+    def test_file_determined_exclusion_is_case_insensitive(self):
+        to_add, skipped, excluded = pil.labels_to_propagate([], ["Agents"])
+        self.assertEqual(to_add, [])
+        self.assertEqual(excluded, ["Agents"])
+
+    def test_file_determined_and_process_state_sets_are_disjoint(self):
+        # propagate_to_pr partitions `excluded` by these two sets for
+        # logging, which is only total if nothing belongs to both.
+        self.assertEqual(pil.FILE_DETERMINED_LABELS & pil.PROCESS_STATE_LABELS, frozenset())
 
     def test_process_state_exclusion_does_not_consume_a_skip_slot(self):
         # A process-state label and a genuinely conflicting label in the same
@@ -360,6 +388,19 @@ class TestPropagateToPr(unittest.TestCase):
                 pil.emxl, "gh_api", return_value={"labels": [{"name": "ci"}]}
             ) as mock_api:
                 result = pil.propagate_to_pr("owner", "repo", "owner/repo", 713, "tok")
+
+        self.assertTrue(result)
+        post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0].kwargs["body"], {"labels": ["p1"]})
+
+    def test_does_not_propagate_agents_from_a_linked_issue(self):
+        # Issue #775 itself carries `agents`; a PR fixing it by touching only
+        # scripts/ci/labels/ must not inherit the label, on open or on any
+        # later body edit.
+        with patch.object(pil, "fetch_closing_issue_labels", return_value=["agents", "p1"]):
+            with patch.object(pil.emxl, "gh_api", return_value={"labels": []}) as mock_api:
+                result = pil.propagate_to_pr("owner", "repo", "owner/repo", 42, "tok")
 
         self.assertTrue(result)
         post_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"]

--- a/scripts/ci/labels/test_propagate_issue_labels.py
+++ b/scripts/ci/labels/test_propagate_issue_labels.py
@@ -251,6 +251,16 @@ class TestLabelsToPropagate(unittest.TestCase):
         # logging, which is only total if nothing belongs to both.
         self.assertEqual(pil.FILE_DETERMINED_LABELS & pil.PROCESS_STATE_LABELS, frozenset())
 
+    def test_file_determined_labels_is_the_same_object_as_label_by_titles(self):
+        # label_by_title.FILE_DETERMINED_LABELS is the single canonical
+        # definition; this module references it directly instead of writing
+        # its own literal. An `is` check, not just `==`, is the point: it
+        # fails the moment someone reintroduces a separately written literal
+        # that happens to equal today's value, which is exactly the kind of
+        # silent drift that would break the "exactly one writer owns this
+        # label on a PR" precedence claim without any test noticing.
+        self.assertIs(pil.FILE_DETERMINED_LABELS, pil.label_by_title.FILE_DETERMINED_LABELS)
+
     def test_process_state_exclusion_does_not_consume_a_skip_slot(self):
         # A process-state label and a genuinely conflicting label in the same
         # run are reported in their own distinct lists, not conflated.


### PR DESCRIPTION
Fixes #785.

Implements the plan in #785 as written, which is the repository owner's decision on #775 treated as a requirement: on a pull request `agents` applies if and only if the diff touches one of `**/AGENTS.md`, `**/CLAUDE.md`, `**/agents/**/*`, `.claude/**/*`; where the two signals disagree the file list wins; issues have no changed-file list, so nothing about issue labeling changes.

The issue proposes three PRs. They are delivered here as separate commits on the one branch this work was assigned, in the same order, so each concern is still reviewable on its own.

## What changed, and why it works

**1. `scripts/ci/` maps to `ci`** (`a59d153`).
One entry in `CI_PATH_PREFIXES`. This repo's most common CI change is "a script under `scripts/ci/` plus its `test_*` sibling"; without the mapping the script is unclassified, which empties the unanimity intersection and the PR gets nothing. `scripts/lint/` and `scripts/ci_monitor/` stay out, per the issue's reasoning.

**2. The if-and-only-if rule and PR precedence** (`dd1730a`), atomic because landing the file rule without the two suppressions would make the label flap.

`label_by_files.py` gains the `agents` path group and splits its two rule shapes. `UNANIMOUS_LABELS` (`ci`, `automated tests`) keep the add-only unanimity rule, because their path maps are heuristics and "not every path justifies it" is an absence of evidence: a symmetric removal rule would have stripped `ci` from 63 and `automated tests` from 28 of the 220 PRs in the issue's dry run. `EXHAUSTIVE_LABELS` (`agents`) get the existential add plus a removal, sound only because that path map is the label's complete definition. Restricting the intersection to one set and the union to the other is what keeps the shapes from contaminating each other, so #782's existing tests stand unchanged.

Precedence is structural rather than a race: on a PR exactly one writer owns `agents`. `label_by_title.py` suppresses `FILE_DETERMINED_LABELS` when `IS_PULL_REQUEST` is true, and `propagate_issue_labels.py` never copies them from a linked issue. Both are needed: the title job runs on `opened`/`edited` and the file job on `opened`/`synchronize`, so on open they race, and a later title or body edit would otherwise re-add what the file signal removed. The env var defaults to false so a caller that forgets it fails open.

As of this round, `label_by_files.EXHAUSTIVE_LABELS`, `label_by_title.FILE_DETERMINED_LABELS`, and `propagate_issue_labels.FILE_DETERMINED_LABELS` are one frozenset object, not three independently written literals: `label_by_title.FILE_DETERMINED_LABELS` is the single canonical definition, and the other two reference it directly. See "Changes since the last review round" below.

Three properties are enforced in code rather than left implicit: an empty or possibly-truncated file list yields no verdict at all, neither add nor removal; a `DELETE` only fires for a label the PR actually carries (otherwise 121 of the 220 sampled PRs would 404 on every run); and removal reuses `enforce_mutually_exclusive_labels.remove_labels`, which already URL-encodes the name and carries that module's transient-error retry.

`backfill_labels_by_title.py` stops proposing and stops reporting file-determined labels on PRs, so `-f` cannot reapply what the rule forbids and `miss` does not fill with permanent noise.

**3. `audit_labels_by_files.py`** (`0e4f42d` refactor, `6912ebf` script).
`label-by-files.yml` only sees PRs that are open while it runs, so history is never revisited, and #781's Verification section assumed a repeatable dry run that was never committed. One script does both jobs: replay the rules over each merged PR's real changed-file list, report `add` / `match` / `remove`, and apply only with `-f`. The formatter extraction is committed separately as a pure refactor.

## Answers to the issue's open questions

Nobody commented on #785, so the questions are resolved the way the issue says to resolve them:

1. **`scripts/ci_monitor/`**: implemented as the owner wrote it, per "The plan implements it as written unless you say otherwise." ci_monitor PRs stop carrying `agents` unless they touch `scripts/ci_monitor/CLAUDE.md`, which does match. Reversing this is one entry in `AGENTS_PATH_PREFIXES`.
2. **Run the backfill once?**: not run. Running `-f` is listed as a non-goal of the code change; this PR builds the capability and leaves the decision open.
3. **Is step 3 worth it at all?**: built, since it is in the plan and the plan is the spec. It is also the cheapest thing to drop if you disagree, being two self-contained commits.

## Loosened test requirements

- Modified `test_labels_outside_any_exclusive_group_never_conflict` in `test_propagate_issue_labels.py` to use `bug` instead of `agents` as its example of a label outside any exclusive group, because `agents` is now excluded from propagation outright and no longer reaches the mutual-exclusion path that test is about.
- Re-pointed `test_test_script_basename_gives_automated_tests` in `test_label_by_files.py` at `scripts/lint/test_check_md040.py`, because `scripts/ci/labels/test_label_by_files.py` now legitimately matches both rules. The both-rules case is covered by the new `test_ci_test_script_gives_both_ci_and_automated_tests`.
- `agents/pr_participation.md` moved out of `test_unclassified_paths_give_empty_set` into the new `test_agents_path_set_gives_agents`, as #785 requires.

## Changes since the last review round

Four commits address the review, in this order:

1. Tied `label_by_files.EXHAUSTIVE_LABELS`, `label_by_title.FILE_DETERMINED_LABELS`, and `propagate_issue_labels.FILE_DETERMINED_LABELS` together by reference instead of three separately written literals, with an `is`-identity test in each dependent module (the blocking review comment).
2. Gave the two non-conflict removal call sites (`label_by_files.remove_unjustified_labels`, `audit_labels_by_files.apply_changes`) a truthful `reason="unjustified"` instead of `enforce_mutually_exclusive_labels.remove_labels`'s default "conflicting" wording (nit 1).
3. Made `audit_labels_by_files`'s `--limit` sort by `updated` instead of `created` (so it approximates most-recently-*merged* rather than most-recently-*opened*, the documented intent) and stop pagination on a short page instead of only an empty one, matching `label_by_files.fetch_changed_files`'s own early stop (nits 2 and 3).
4. Added a coverage test pinning that `label_by_files.main()` skips the current-label GET entirely when the diff justifies `agents` (nit 5).

Nit 4 (the commit-message omission in `dd1730a`) is addressed in a reply comment rather than by rewriting that commit's message; see the reply for why.

## Verification

Run locally, all green: `python3 -m unittest discover -s scripts/ci/labels -p "test_*.py"` (365 tests), the other four Python test directories CI discovers, `python3 scripts/test_ci_monitor.py` (375 checks), and `scripts/lint/lint.sh --check --all`. No CI wiring was needed: `build.yml` discovers `test_*.py` by directory and `lint.yml` covers the workflow YAML edits.

Three checks still need the workflows live on `main` and a later PR to observe, so per #785 they belong in follow-on tracking issues shaped like #783 rather than in this PR:

- [ ] A PR touching an agents path alongside unrelated files: confirm `label-by-files` applies `agents` anyway.
- [ ] A PR that carries `agents` at open time and touches no agents path: confirm the `DELETE` fires and the "No blocking labels" check re-runs green on the resulting `unlabeled` event.
- [ ] A PR with `Fixes #N` where issue N carries `agents` and the PR touches no agents path: confirm the propagation job logs the exclusion and the PR never receives the label.

The fourth check needs no follow-on issue: a PR whose title matches the `agents` rule but whose files touch no agents path. This PR is itself an instance of it (its title matches the `agents` title regex, and its diff touches no agents path), and its own CI already demonstrated the result live at open time: the `label-by-title` job ran with `IS_PULL_REQUEST: true` against this title and logged "No label rules matched title ... nothing to do", while `label-by-files` applied only `['ci']`.
