### PR TITLE
Note why label-by-files.yml checks out the repository first

### DIFF
--- a/.github/workflows/label-by-files.yml
+++ b/.github/workflows/label-by-files.yml
@@ -22,6 +22,8 @@ jobs:
   label-by-files:
     runs-on: ubuntu-latest
     steps:
+      # Checked out so label_by_files.py runs from this commit's own copy of
+      # the path rules, not a stale one baked into the runner image.
       - name: Check out repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Do not merge. This is a throwaway PR opened to satisfy issue #783: it exists only to give the `label-by-files` job a real pull request whose changed files are entirely under `.github/workflows/`, with a title deliberately worded so `label_by_title.py`'s regexes match none of its rules (no standalone "ci", "workflow", "automat...", "github action...", "e2e...", "merge" + gate/block/pr, "preflight", "codeql", "agent...", "verif...", "author", "reviewer...", "orchestrat...", "test...", or "unit").

The only change is a two-line comment added to `.github/workflows/label-by-files.yml` itself, so the diff is a single file under `.github/workflows/` and nothing else.

Once the Actions run confirms (or fails to confirm) that the `label-by-files` job applies the `ci` label with no title-based trigger in play, I will record the result on #783 and close this PR without merging.
