### PR TITLE
Add .github/dependabot.yml for app-runtime CVE coverage over app/build.gradle.kts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,13 @@
 # graph (gradle/verification-metadata.xml, 585 artifacts) and recommended
 # against it: none of the 20 flagged artifacts at the time were declared app
 # dependencies, all 20 arrived transitively through Gradle/AGP build tooling
-# that never ships in the APK, and that toolchain already has its own,
-# narrower watch (scripts/ci/prs-and-issues/watch_toolchain_bump.py, added by
-# PR #812) plus the manual bump procedure in gradle/README.md. #803's
-# conclusion: "If app-runtime CVE coverage is wanted, that is Dependabot over
-# app/build.gradle.kts, a separate piece of work from this one."
+# that never ships in the APK, and that toolchain gets its own, narrower
+# coverage separately: PR #812 adds a report-only watch
+# (scripts/ci/prs-and-issues/watch_toolchain_bump.py) over exactly those
+# toolchain coordinates, on top of the manual bump procedure in
+# gradle/README.md. #803's conclusion: "If app-runtime CVE coverage is
+# wanted, that is Dependabot over app/build.gradle.kts, a separate piece of
+# work from this one."
 #
 # directory is "/app", not "/", so this does not touch the root
 # build.gradle.kts toolchain pins (the Gradle/AGP/KGP versions), which

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# App-runtime CVE coverage for the dependencies declared directly in
+# app/build.gradle.kts (issue #819, a follow-on suggestion from PR #812's
+# "Follow-up suggestions" section).
+#
+# #803 looked at general CVE scanning over the whole resolved dependency
+# graph (gradle/verification-metadata.xml, 585 artifacts) and recommended
+# against it: none of the 20 flagged artifacts at the time were declared app
+# dependencies, all 20 arrived transitively through Gradle/AGP build tooling
+# that never ships in the APK, and that toolchain already has its own,
+# narrower watch (scripts/ci/prs-and-issues/watch_toolchain_bump.py, added by
+# PR #812) plus the manual bump procedure in gradle/README.md. #803's
+# conclusion: "If app-runtime CVE coverage is wanted, that is Dependabot over
+# app/build.gradle.kts, a separate piece of work from this one."
+#
+# directory is "/app", not "/", so this does not touch the root
+# build.gradle.kts toolchain pins (the Gradle/AGP/KGP versions), which
+# gradle/README.md documents as deliberately un-automated: any bump there
+# also needs a KGP-compatibility-row check, a CodeQL Kotlin ceiling check,
+# and a gradle/verification-metadata.xml regeneration, none of which
+# Dependabot performs.
+#
+# That last point still applies within app/: every dependency version bump
+# changes which artifacts Gradle resolves, so gradle/verification-metadata.xml
+# needs the same manual regeneration (scripts/regenerate-gradle-verification.sh)
+# on top of any Dependabot pull request here before its CI can pass. Dependabot
+# cannot do that step itself; a human pushes the regenerated file onto the
+# Dependabot branch, the same as any other dependency bump in this repo.
+#
+# Weekly on Monday, offset an hour past dependency-audit.yml's 09:00 UTC
+# Monday cron (which is itself offset from semgrep.yml's 08:00), so the three
+# don't land in the same CI-minute window.
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "UTC"


### PR DESCRIPTION
🤖 Author

Fixes #819.

Adds `.github/dependabot.yml`, configuring Dependabot version updates for the `gradle` ecosystem over `directory: "/app"`. This is the "app-runtime CVE coverage" #803 recommended as a separate piece of work from PR #812's toolchain watcher, and #812's "Follow-up suggestions" carried forward into this issue.

## Why `/app`, not `/`

`app/build.gradle.kts` is where the app's actual runtime dependencies live (androidx, Compose, Material Components, `subsampling-scale-image-view`), the ones #803's OSV scan found zero advisories against at the time. The root `build.gradle.kts` instead holds the Gradle/AGP/KGP toolchain pins, which `gradle/README.md` documents as deliberately un-automated: any bump there needs a KGP-compatibility-row check, a CodeQL Kotlin ceiling check, and a `gradle/verification-metadata.xml` regeneration, in that order, none of which Dependabot performs. PR #812 adds a narrower, report-only watch over that toolchain (`scripts/ci/prs-and-issues/watch_toolchain_bump.py`), which never bumps on its own. Pointing Dependabot at `/` would have it open PRs against that same toolchain, duplicating and fighting that watcher's deliberately-manual design. Scoping to `/app` keeps this addition inside the boundary #803 actually drew.

## Cadence

Weekly on Monday at 10:00 UTC, an hour past `dependency-audit.yml`'s 09:00 UTC Monday cron (itself offset from `semgrep.yml`'s 08:00), so the three don't land in the same CI-minute window.

## A caveat worth flagging for review

Every dependency version bump changes which artifacts Gradle resolves, so `gradle/verification-metadata.xml` needs the same manual regeneration (`scripts/regenerate-gradle-verification.sh`) that any other dependency bump in this repo requires, on top of each Dependabot PR, before its CI can pass. Dependabot cannot do that step itself. This isn't a defect in the config; it's the existing verification-metadata design (issue #714) applying uniformly, and I've left it as a manual step rather than building automation for it here, to keep this PR to the one thing #819 asked for.

## Test plan

Nothing here is exercised by the existing automated suite (there's no code, only a Dependabot config file), so the checks below are manual/out-of-repo:

- [ ] Confirm Dependabot is enabled for this repository in Settings > Code security (this file configures version updates, but does not itself flip that toggle for an org/repo where Dependabot might be off).
- [ ] After merge, wait for (or manually trigger, if GitHub exposes that) the first scheduled run, and confirm it opens at least one version-update PR against `app/build.gradle.kts` if a newer version of any declared dependency exists.
- [ ] On the first such PR, confirm the expected `gradle/verification-metadata.xml` CI failure occurs, then regenerate and push it by hand, confirming the rest of CI then passes.

## Follow-up suggestions

- Automating the `gradle/verification-metadata.xml` regeneration for Dependabot's own PRs (for example, a workflow that detects a Dependabot-authored PR, runs `scripts/regenerate-gradle-verification.sh`, and pushes the diff back onto its branch) so a Dependabot PR can go green without that manual step. Left out here to keep this PR scoped to what #819 asked for.
- Enabling "Dependabot security updates" specifically (a separate repo-settings toggle from version updates) if it isn't already on, per #803's "checking whether alerts are on in repo settings, which is not visible from the tree."