### PR TITLE
Add a "hold N days" label ladder that snoozes and later wakes issues

### DIFF
--- a/.github/workflows/snooze-held-issues.yml
+++ b/.github/workflows/snooze-held-issues.yml
@@ -1,0 +1,33 @@
+name: Snooze held issues
+
+# When a "hold N days" label (see HOLD_LABEL_DAYS in
+# scripts/ci/labels/enforce_mutually_exclusive_labels.py) is added to an
+# issue, closes it. This is the snooze half of issue #821: the issue stops
+# reading as open, dispatchable work while it waits out its hold.
+# wake-held-issues.yml is the other half, reopening it once the hold elapses.
+#
+# Scoped to issues only, not pull requests: closing an open PR is a different
+# action (abandoning work) from snoozing an issue, and the hold-label ladder
+# is meant for issues whose revisit condition is elapsed time, not PRs.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  snooze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Snooze held issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ADDED_LABEL: ${{ github.event.label.name }}
+        run: python3 scripts/ci/labels/snooze_held_issues.py

--- a/.github/workflows/wake-held-issues.yml
+++ b/.github/workflows/wake-held-issues.yml
@@ -1,0 +1,31 @@
+name: Wake held issues
+
+# Daily check for issues whose "hold N days" snooze (see snooze-held-issues.yml
+# and HOLD_LABEL_DAYS in scripts/ci/labels/enforce_mutually_exclusive_labels.py)
+# has elapsed. Reopens each one, strips its hold label, and strips
+# propagate_issue_labels.PROCESS_STATE_LABELS so it lands back in plain
+# triage rather than resuming mid-orchestration-cycle. See
+# scripts/ci/labels/wake_held_issues.py's docstring for the full design.
+#
+# Offset an hour from archive-stale-test-failures.yml's 04:00 UTC cron so the
+# two daily issue-label jobs do not start at the same minute.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'   # daily at 05:00 UTC
+
+permissions:
+  issues: write
+
+jobs:
+  wake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Wake held issues past their snooze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/ci/labels/wake_held_issues.py

--- a/scripts/ci/labels/enforce_mutually_exclusive_labels.py
+++ b/scripts/ci/labels/enforce_mutually_exclusive_labels.py
@@ -10,6 +10,7 @@ Mutually exclusive sets (fixed):
     [verification needed, verified]
     [changes requested, changes done]
     [orchestrate, orchestrating]
+    [hold 30 days, hold 90 days, hold 180 days]  (see HOLD_LABEL_DAYS)
 
 Mutually exclusive prefix groups (any label sharing a prefix is exclusive):
     c-a-*          (author model, e.g. c-a-haiku, c-a-sonnet, c-a-opus)
@@ -52,11 +53,28 @@ import urllib.request
 # Mutually exclusive label sets
 # ---------------------------------------------------------------------------
 
+# The "hold N days" snooze ladder (issue #821): the elapsed-time revisit label
+# floated as a complementary, explicitly out-of-scope idea in issue #803. A
+# fixed ladder rather than an open-ended "hold <N> days" prefix family, per
+# #803's own note: MUTUALLY_EXCLUSIVE_SETS already models exclusive sets as
+# fixed frozensets, and a three-rung ladder fits that shape far more cheaply
+# than parsing an arbitrary N out of free-form label text. The int value is
+# the snooze duration in days; scripts/ci/labels/snooze_held_issues.py and
+# scripts/ci/labels/wake_held_issues.py both key off this single dict so the
+# ladder is defined in exactly one place.
+HOLD_LABEL_DAYS: dict[str, int] = {
+    "hold 30 days": 30,
+    "hold 90 days": 90,
+    "hold 180 days": 180,
+}
+HOLD_LABELS: frozenset[str] = frozenset(HOLD_LABEL_DAYS)
+
 MUTUALLY_EXCLUSIVE_SETS: list[frozenset[str]] = [
     frozenset({"p1", "p2", "p3"}),
     frozenset({"verification needed", "verified"}),
     frozenset({"changes requested", "changes done"}),
     frozenset({"orchestrate", "orchestrating"}),
+    HOLD_LABELS,
 ]
 
 # Prefix-based exclusive groups: any two labels sharing a prefix are exclusive.

--- a/scripts/ci/labels/snooze_held_issues.py
+++ b/scripts/ci/labels/snooze_held_issues.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Close an issue when a "hold N days" snooze label is added to it.
+
+Part of the issue #821 snooze mechanism, for issues whose revisit condition is
+elapsed time with no observable upstream signal. Applying one of the fixed
+`HOLD_LABEL_DAYS` labels (see enforce_mutually_exclusive_labels.py) is how a
+human snoozes such an issue: this script closes it so it stops reading as
+open, dispatchable work, and scripts/ci/labels/wake_held_issues.py reopens it
+once the label's day count has elapsed.
+
+enforce_mutually_exclusive_labels.py already keeps at most one hold label on
+an issue at a time (HOLD_LABELS is one of its MUTUALLY_EXCLUSIVE_SETS), so
+this script only has to react to the label that was just added; it does not
+need to reconcile the full label set itself.
+
+Already-closed issues are left alone (idempotent no-op), which also covers
+the case where a hold label is swapped for a longer one on an issue that is
+already snoozed.
+
+Usage:
+    python3 scripts/ci/labels/snooze_held_issues.py
+
+Exit code:
+    0  ADDED_LABEL is not a hold label, the issue was already closed, or the
+       issue was closed successfully.
+    1  required configuration is missing/invalid, or fetching or closing the
+       issue failed.
+
+Required environment variables:
+    GITHUB_TOKEN        Personal access token or Actions secret with
+                        issues: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+    ISSUE_NUMBER        Number of the issue
+    ADDED_LABEL         Name of the label that was just added
+"""
+
+import os
+import sys
+
+import enforce_mutually_exclusive_labels as emxl
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def snooze_issue(issue_number: int, hold_label: str, repo: str, token: str) -> bool:
+    """Close *issue_number* for its *hold_label* snooze.
+
+    Returns True on success. Raises on a fetch or PATCH failure so main()
+    can report a nonzero exit; there is nothing benign about either failing
+    here (contrast with the already-gone 404 tolerated when removing labels
+    elsewhere in this package).
+    """
+    issue = emxl.gh_api(f"repos/{repo}/issues/{issue_number}", token=token)
+    if not isinstance(issue, dict):
+        raise RuntimeError(f"unexpected response fetching issue #{issue_number}: {issue!r}")
+
+    if issue.get("state") == "closed":
+        print(f"#{issue_number} is already closed--nothing to do.")
+        return True
+
+    emxl.gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        token=token,
+        method="PATCH",
+        body={"state": "closed"},
+    )
+    print(f"Closed #{issue_number} for its '{hold_label}' hold.")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    issue_number_str = os.environ.get("ISSUE_NUMBER", "")
+    added_label = os.environ.get("ADDED_LABEL", "")
+
+    if not token:
+        print("Warning: GITHUB_TOKEN not set--skipping snooze.", file=sys.stderr)
+        return 0
+    if not repo:
+        print("Warning: GITHUB_REPOSITORY not set--skipping snooze.", file=sys.stderr)
+        return 0
+    if not issue_number_str:
+        print("Warning: ISSUE_NUMBER not set--skipping snooze.", file=sys.stderr)
+        return 0
+    if not added_label:
+        print("Warning: ADDED_LABEL not set--skipping snooze.", file=sys.stderr)
+        return 0
+
+    if added_label.lower() not in emxl.HOLD_LABEL_DAYS:
+        print(f"Label '{added_label}' is not a hold label--nothing to do.")
+        return 0
+
+    try:
+        issue_number = int(issue_number_str)
+    except ValueError:
+        print(
+            f"Error: ISSUE_NUMBER is not a valid integer: {issue_number_str!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        snooze_issue(issue_number, added_label, repo, token)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error snoozing #{issue_number}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/labels/test_enforce_mutually_exclusive_labels.py
+++ b/scripts/ci/labels/test_enforce_mutually_exclusive_labels.py
@@ -232,6 +232,18 @@ class TestFindConflictingSet(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("orchestrate", result)
 
+    def test_hold_labels_found(self):
+        for label in ("hold 30 days", "hold 90 days", "hold 180 days"):
+            with self.subTest(label=label):
+                result = emxl.find_conflicting_set(label)
+                self.assertIsNotNone(result)
+                self.assertIn("hold 30 days", result)
+                self.assertIn("hold 90 days", result)
+                self.assertIn("hold 180 days", result)
+
+    def test_hold_label_case_insensitive(self):
+        self.assertIsNotNone(emxl.find_conflicting_set("Hold 30 Days"))
+
     def test_unknown_label_returns_none(self):
         self.assertIsNone(emxl.find_conflicting_set("bug"))
         self.assertIsNone(emxl.find_conflicting_set("ci"))
@@ -657,6 +669,23 @@ class TestMain(unittest.TestCase):
         self.assertEqual(result, 0)
         delete_call = mock_api.call_args_list[1]
         self.assertIn("orchestrate", delete_call[0][0])
+
+    def test_escalating_hold_label_removes_shorter_one(self):
+        """Adding hold 90 days when hold 30 days is present removes hold 30 days."""
+        with patch.dict(os.environ, {"ADDED_LABEL": "hold 90 days", "ISSUE_NUMBER": "9"}):
+            with patch.object(
+                emxl,
+                "gh_api",
+                side_effect=[
+                    self._make_issue_response(["hold 30 days", "ci"]),
+                    None,  # DELETE hold 30 days
+                ],
+            ) as mock_api:
+                result = emxl.main()
+
+        self.assertEqual(result, 0)
+        delete_call = mock_api.call_args_list[1]
+        self.assertIn("hold%2030%20days", delete_call[0][0])
 
     def test_exit_1_when_fetch_raises(self):
         with patch.object(emxl, "gh_api", side_effect=Exception("network error")):

--- a/scripts/ci/labels/test_snooze_held_issues.py
+++ b/scripts/ci/labels/test_snooze_held_issues.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for snooze_held_issues.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import snooze_held_issues as shi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# snooze_issue tests
+# ---------------------------------------------------------------------------
+
+
+class TestSnoozeIssue(unittest.TestCase):
+    def test_closes_open_issue(self):
+        with patch.object(
+            shi.emxl,
+            "gh_api",
+            side_effect=[{"number": 5, "state": "open"}, None],
+        ) as mock_api:
+            result = shi.snooze_issue(5, "hold 30 days", "owner/repo", "tok")
+
+        self.assertTrue(result)
+        self.assertEqual(mock_api.call_count, 2)
+        patch_call = mock_api.call_args_list[1]
+        self.assertEqual(patch_call[1]["method"], "PATCH")
+        self.assertEqual(patch_call[1]["body"], {"state": "closed"})
+        self.assertIn("5", patch_call[0][0])
+
+    def test_already_closed_is_a_noop(self):
+        with patch.object(
+            shi.emxl,
+            "gh_api",
+            side_effect=[{"number": 5, "state": "closed"}],
+        ) as mock_api:
+            result = shi.snooze_issue(5, "hold 30 days", "owner/repo", "tok")
+
+        self.assertTrue(result)
+        # Only the GET was made; no PATCH followed for an already-closed issue.
+        self.assertEqual(mock_api.call_count, 1)
+
+    def test_raises_on_non_dict_response(self):
+        with patch.object(shi.emxl, "gh_api", return_value=None):
+            with self.assertRaises(RuntimeError):
+                shi.snooze_issue(5, "hold 30 days", "owner/repo", "tok")
+
+    def test_raises_when_fetch_fails(self):
+        with patch.object(shi.emxl, "gh_api", side_effect=Exception("network error")):
+            with self.assertRaises(Exception):
+                shi.snooze_issue(5, "hold 30 days", "owner/repo", "tok")
+
+    def test_raises_when_patch_fails(self):
+        with patch.object(
+            shi.emxl,
+            "gh_api",
+            side_effect=[{"number": 5, "state": "open"}, Exception("boom")],
+        ):
+            with self.assertRaises(Exception):
+                shi.snooze_issue(5, "hold 30 days", "owner/repo", "tok")
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._env_patch = patch.dict(
+            os.environ,
+            {
+                "GITHUB_TOKEN": "test-token",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "ISSUE_NUMBER": "42",
+                "ADDED_LABEL": "hold 30 days",
+            },
+        )
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_exit_0_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            result = shi.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            result = shi.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_issue_number_missing(self):
+        with patch.dict(os.environ, {"ISSUE_NUMBER": ""}):
+            result = shi.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_added_label_missing(self):
+        with patch.dict(os.environ, {"ADDED_LABEL": ""}):
+            result = shi.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_label_not_a_hold_label(self):
+        with patch.dict(os.environ, {"ADDED_LABEL": "bug"}):
+            with patch.object(shi.emxl, "gh_api") as mock_api:
+                result = shi.main()
+        self.assertEqual(result, 0)
+        mock_api.assert_not_called()
+
+    def test_exit_1_when_issue_number_non_integer(self):
+        with patch.dict(os.environ, {"ISSUE_NUMBER": "abc"}):
+            result = shi.main()
+        self.assertEqual(result, 1)
+
+    def test_snoozes_for_each_hold_label(self):
+        for label in ("hold 30 days", "hold 90 days", "hold 180 days", "HOLD 30 DAYS"):
+            with self.subTest(label=label):
+                with patch.dict(os.environ, {"ADDED_LABEL": label}):
+                    with patch.object(shi, "snooze_issue", return_value=True) as mock_snooze:
+                        result = shi.main()
+                self.assertEqual(result, 0)
+                mock_snooze.assert_called_once_with(42, label, "owner/repo", "test-token")
+
+    def test_exit_1_when_snooze_raises(self):
+        with patch.object(shi, "snooze_issue", side_effect=Exception("boom")):
+            result = shi.main()
+        self.assertEqual(result, 1)
+
+    def test_exit_0_on_success(self):
+        with patch.object(shi, "snooze_issue", return_value=True) as mock_snooze:
+            result = shi.main()
+        self.assertEqual(result, 0)
+        mock_snooze.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/labels/test_wake_held_issues.py
+++ b/scripts/ci/labels/test_wake_held_issues.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Unit tests for wake_held_issues.py."""
 
+import io
 import os
 import sys
 import unittest
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -159,49 +161,109 @@ class TestFindLabelAppliedAt(unittest.TestCase):
 
 
 class TestWakeIssue(unittest.TestCase):
-    def test_strips_hold_label_and_reopens(self):
+    """wake_issue() re-fetches live, then reopens (label-free PATCH) and
+    removes only the specific labels it targets (via emxl.remove_labels(),
+    patched separately from the raw gh_api calls it wraps)."""
+
+    def test_reopens_via_a_labels_free_patch(self):
         issue = _make_issue(7, ["hold 30 days", "bug"])
-        with patch.object(whi.emxl, "gh_api") as mock_api:
-            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]) as mock_api:
+            with patch.object(whi.emxl, "remove_labels", return_value=True):
+                result = whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
 
-        patch_call = mock_api.call_args_list[0]
+        self.assertTrue(result)
+        patch_call = mock_api.call_args_list[1]
         self.assertEqual(patch_call[1]["method"], "PATCH")
-        self.assertEqual(patch_call[1]["body"]["state"], "open")
-        self.assertEqual(patch_call[1]["body"]["labels"], ["bug"])
+        self.assertEqual(patch_call[1]["body"], {"state": "open"})
 
-    def test_strips_process_state_labels(self):
+    def test_targets_only_the_hold_label_when_nothing_else_conflicts(self):
+        issue = _make_issue(7, ["hold 30 days", "p1", "ci"])
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]):
+            with patch.object(whi.emxl, "remove_labels", return_value=True) as mock_remove:
+                whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
+
+        mock_remove.assert_called_once_with(
+            7, ["hold 30 days"], "owner/repo", "tok", reason="expired-hold"
+        )
+
+    def test_targets_process_state_labels_alongside_the_hold_label(self):
         issue = _make_issue(7, ["hold 90 days", "orchestrate", "changes requested", "ci"])
-        with patch.object(whi.emxl, "gh_api") as mock_api:
-            whi.wake_issue(issue, "hold 90 days", "owner/repo", "tok")
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]):
+            with patch.object(whi.emxl, "remove_labels", return_value=True) as mock_remove:
+                whi.wake_issue(7, "hold 90 days", "owner/repo", "tok")
 
-        patch_call = mock_api.call_args_list[0]
-        self.assertEqual(patch_call[1]["body"]["labels"], ["ci"])
+        targeted = mock_remove.call_args[0][1]
+        self.assertCountEqual(targeted, ["hold 90 days", "orchestrate", "changes requested"])
+        self.assertNotIn("ci", targeted)
 
     def test_posts_a_comment(self):
         issue = _make_issue(7, ["hold 30 days"])
-        with patch.object(whi.emxl, "gh_api") as mock_api:
-            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]) as mock_api:
+            with patch.object(whi.emxl, "remove_labels", return_value=True):
+                whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
 
-        comment_call = mock_api.call_args_list[1]
+        comment_call = mock_api.call_args_list[2]
         self.assertIn("comments", comment_call[0][0])
         self.assertEqual(comment_call[1]["method"], "POST")
         self.assertIn("hold 30 days", comment_call[1]["body"]["body"])
 
     def test_comment_notes_other_stripped_labels(self):
         issue = _make_issue(7, ["hold 30 days", "orchestrating"])
-        with patch.object(whi.emxl, "gh_api") as mock_api:
-            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]) as mock_api:
+            with patch.object(whi.emxl, "remove_labels", return_value=True):
+                whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
 
-        comment_body = mock_api.call_args_list[1][1]["body"]["body"]
+        comment_body = mock_api.call_args_list[2][1]["body"]["body"]
         self.assertIn("orchestrating", comment_body)
 
-    def test_no_other_labels_left_intact(self):
-        issue = _make_issue(7, ["hold 30 days", "p1", "ci"])
-        with patch.object(whi.emxl, "gh_api") as mock_api:
-            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+    def test_case_insensitive_hold_label_still_matches(self):
+        issue = _make_issue(7, ["Hold 30 Days"])
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue, None, None]):
+            with patch.object(whi.emxl, "remove_labels", return_value=True) as mock_remove:
+                result = whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
 
-        patch_call = mock_api.call_args_list[0]
-        self.assertCountEqual(patch_call[1]["body"]["labels"], ["p1", "ci"])
+        self.assertTrue(result)
+        mock_remove.assert_called_once()
+
+    def test_raises_on_non_dict_get_response(self):
+        with patch.object(whi.emxl, "gh_api", return_value=None):
+            with self.assertRaises(RuntimeError):
+                whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
+
+    # ------------------------------------------------------------------
+    # Concurrency guards (PR #837 review)
+    # ------------------------------------------------------------------
+
+    def test_returns_false_and_touches_nothing_when_hold_label_already_gone(self):
+        """A live re-fetch showing the hold label already replaced (e.g. an
+        escalation from hold 30 days to hold 90 days that landed between
+        main()'s list call and this call) is left alone entirely: no reopen,
+        no label removal, no comment."""
+        issue = _make_issue(7, ["hold 90 days", "ci"])
+        with patch.object(whi.emxl, "gh_api", side_effect=[issue]) as mock_api:
+            with patch.object(whi.emxl, "remove_labels") as mock_remove:
+                result = whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
+
+        self.assertFalse(result)
+        self.assertEqual(mock_api.call_count, 1)  # only the re-fetch GET
+        mock_remove.assert_not_called()
+
+    def test_reopen_and_strip_are_not_undone_by_a_failed_comment(self):
+        issue = _make_issue(7, ["hold 30 days"])
+
+        def gh_api_side_effect(path, token, method="GET", body=None):
+            if method == "POST":
+                raise Exception("comment API down")
+            return issue if method == "GET" else None
+
+        with patch.object(whi.emxl, "gh_api", side_effect=gh_api_side_effect):
+            with patch.object(whi.emxl, "remove_labels", return_value=True) as mock_remove:
+                result = whi.wake_issue(7, "hold 30 days", "owner/repo", "tok")
+
+        # The reopen and label removal both already happened; a failed
+        # notification comment does not retroactively fail the wake.
+        self.assertTrue(result)
+        mock_remove.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +306,7 @@ class TestMain(unittest.TestCase):
                     result = whi.main()
 
         self.assertEqual(result, 0)
-        mock_wake.assert_called_once_with(issue, "hold 30 days", "owner/repo", "test-token")
+        mock_wake.assert_called_once_with(1, "hold 30 days", "owner/repo", "test-token")
 
     def test_leaves_issue_within_hold_period(self):
         """applied_at 5 days before real "now" has not yet cleared the 30-day hold."""
@@ -308,6 +370,25 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(result, 0)
         mock_wake.assert_not_called()
+
+    def test_does_not_count_a_no_op_wake_as_woken(self):
+        """wake_issue() returning False (hold label already gone by the time it
+        re-fetched, e.g. an escalation) must not inflate the woken count."""
+        issue = _make_issue(1, ["hold 30 days"])
+        applied_at = datetime.now(timezone.utc) - timedelta(days=31)
+
+        def fetch_side_effect(repo, token, label):
+            return [issue] if label == "hold 30 days" else []
+
+        out = io.StringIO()
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            with patch.object(whi, "find_label_applied_at", return_value=applied_at):
+                with patch.object(whi, "wake_issue", return_value=False):
+                    with redirect_stdout(out):
+                        result = whi.main()
+
+        self.assertEqual(result, 0)
+        self.assertIn("Woke 0 issue(s)", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/ci/labels/test_wake_held_issues.py
+++ b/scripts/ci/labels/test_wake_held_issues.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Unit tests for wake_held_issues.py."""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import wake_held_issues as whi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 8, 10, 5, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_issue(number: int, labels: list[str], state: str = "closed", is_pr: bool = False) -> dict:
+    issue = {
+        "number": number,
+        "labels": [{"name": lbl} for lbl in labels],
+        "state": state,
+    }
+    if is_pr:
+        issue["pull_request"] = {"url": "https://api.github.com/..."}
+    return issue
+
+
+def _labeled_event(label: str, when: datetime) -> dict:
+    return {
+        "event": "labeled",
+        "label": {"name": label},
+        "created_at": when.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# fetch_issues_with_label tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchIssuesWithLabel(unittest.TestCase):
+    def _paged(self, pages: list[list[dict]]):
+        call_count = [0]
+
+        def side_effect(path, token, method="GET", body=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return pages[idx] if idx < len(pages) else []
+
+        return side_effect
+
+    def test_returns_matching_issues(self):
+        issue = _make_issue(1, ["hold 30 days"])
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([[issue], []])):
+            result = whi.fetch_issues_with_label("owner/repo", "tok", "hold 30 days")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["number"], 1)
+
+    def test_excludes_pull_requests(self):
+        issue = _make_issue(1, ["hold 30 days"])
+        pr = _make_issue(2, ["hold 30 days"], is_pr=True)
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([[issue, pr], []])):
+            result = whi.fetch_issues_with_label("owner/repo", "tok", "hold 30 days")
+        self.assertEqual([i["number"] for i in result], [1])
+
+    def test_paginates(self):
+        page1 = [_make_issue(i, ["hold 30 days"]) for i in range(1, 4)]
+        page2 = [_make_issue(i, ["hold 30 days"]) for i in range(4, 6)]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([page1, page2, []])):
+            result = whi.fetch_issues_with_label("owner/repo", "tok", "hold 30 days")
+        self.assertEqual(len(result), 5)
+
+    def test_includes_state_all_and_encoded_label(self):
+        calls = []
+
+        def side_effect(path, token, method="GET", body=None):
+            calls.append(path)
+            return []
+
+        with patch.object(whi.emxl, "gh_api", side_effect=side_effect):
+            whi.fetch_issues_with_label("owner/repo", "tok", "hold 30 days")
+
+        self.assertIn("state=all", calls[0])
+        self.assertIn("hold%2030%20days", calls[0])
+
+
+# ---------------------------------------------------------------------------
+# find_label_applied_at tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindLabelAppliedAt(unittest.TestCase):
+    def _paged(self, pages: list[list[dict]]):
+        call_count = [0]
+
+        def side_effect(path, token, method="GET", body=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return pages[idx] if idx < len(pages) else []
+
+        return side_effect
+
+    def test_returns_none_when_no_matching_event(self):
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([[], []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertIsNone(result)
+
+    def test_returns_timestamp_of_matching_event(self):
+        when = _NOW - timedelta(days=31)
+        events = [
+            {"event": "commented", "created_at": when.strftime("%Y-%m-%dT%H:%M:%SZ")},
+            _labeled_event("hold 30 days", when),
+        ]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([events, []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertEqual(result, when)
+
+    def test_ignores_events_for_other_labels(self):
+        when = _NOW - timedelta(days=31)
+        events = [_labeled_event("orchestrate", when)]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([events, []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertIsNone(result)
+
+    def test_case_insensitive_label_match(self):
+        when = _NOW - timedelta(days=31)
+        events = [_labeled_event("Hold 30 Days", when)]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([events, []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertEqual(result, when)
+
+    def test_returns_most_recent_of_several_matching_events(self):
+        older = _NOW - timedelta(days=100)
+        newer = _NOW - timedelta(days=31)
+        events = [
+            _labeled_event("hold 30 days", older),
+            _labeled_event("hold 30 days", newer),
+        ]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([events, []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertEqual(result, newer)
+
+    def test_paginates_across_events(self):
+        when = _NOW - timedelta(days=31)
+        page1 = [{"event": "commented", "created_at": when.strftime("%Y-%m-%dT%H:%M:%SZ")}] * 100
+        page2 = [_labeled_event("hold 30 days", when)]
+        with patch.object(whi.emxl, "gh_api", side_effect=self._paged([page1, page2, []])):
+            result = whi.find_label_applied_at(1, "hold 30 days", "owner/repo", "tok")
+        self.assertEqual(result, when)
+
+
+# ---------------------------------------------------------------------------
+# wake_issue tests
+# ---------------------------------------------------------------------------
+
+
+class TestWakeIssue(unittest.TestCase):
+    def test_strips_hold_label_and_reopens(self):
+        issue = _make_issue(7, ["hold 30 days", "bug"])
+        with patch.object(whi.emxl, "gh_api") as mock_api:
+            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+
+        patch_call = mock_api.call_args_list[0]
+        self.assertEqual(patch_call[1]["method"], "PATCH")
+        self.assertEqual(patch_call[1]["body"]["state"], "open")
+        self.assertEqual(patch_call[1]["body"]["labels"], ["bug"])
+
+    def test_strips_process_state_labels(self):
+        issue = _make_issue(7, ["hold 90 days", "orchestrate", "changes requested", "ci"])
+        with patch.object(whi.emxl, "gh_api") as mock_api:
+            whi.wake_issue(issue, "hold 90 days", "owner/repo", "tok")
+
+        patch_call = mock_api.call_args_list[0]
+        self.assertEqual(patch_call[1]["body"]["labels"], ["ci"])
+
+    def test_posts_a_comment(self):
+        issue = _make_issue(7, ["hold 30 days"])
+        with patch.object(whi.emxl, "gh_api") as mock_api:
+            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+
+        comment_call = mock_api.call_args_list[1]
+        self.assertIn("comments", comment_call[0][0])
+        self.assertEqual(comment_call[1]["method"], "POST")
+        self.assertIn("hold 30 days", comment_call[1]["body"]["body"])
+
+    def test_comment_notes_other_stripped_labels(self):
+        issue = _make_issue(7, ["hold 30 days", "orchestrating"])
+        with patch.object(whi.emxl, "gh_api") as mock_api:
+            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+
+        comment_body = mock_api.call_args_list[1][1]["body"]["body"]
+        self.assertIn("orchestrating", comment_body)
+
+    def test_no_other_labels_left_intact(self):
+        issue = _make_issue(7, ["hold 30 days", "p1", "ci"])
+        with patch.object(whi.emxl, "gh_api") as mock_api:
+            whi.wake_issue(issue, "hold 30 days", "owner/repo", "tok")
+
+        patch_call = mock_api.call_args_list[0]
+        self.assertCountEqual(patch_call[1]["body"]["labels"], ["p1", "ci"])
+
+
+# ---------------------------------------------------------------------------
+# main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._env_patch = patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "test-token", "GITHUB_REPOSITORY": "owner/repo"},
+        )
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_exit_0_when_token_missing(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": ""}):
+            result = whi.main()
+        self.assertEqual(result, 0)
+
+    def test_exit_0_when_repository_missing(self):
+        with patch.dict(os.environ, {"GITHUB_REPOSITORY": ""}):
+            result = whi.main()
+        self.assertEqual(result, 0)
+
+    def test_wakes_issue_past_its_hold(self):
+        """applied_at 31 days before real "now" clears the 30-day hold."""
+        issue = _make_issue(1, ["hold 30 days"])
+        applied_at = datetime.now(timezone.utc) - timedelta(days=31)
+
+        def fetch_side_effect(repo, token, label):
+            return [issue] if label == "hold 30 days" else []
+
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            with patch.object(whi, "find_label_applied_at", return_value=applied_at):
+                with patch.object(whi, "wake_issue") as mock_wake:
+                    result = whi.main()
+
+        self.assertEqual(result, 0)
+        mock_wake.assert_called_once_with(issue, "hold 30 days", "owner/repo", "test-token")
+
+    def test_leaves_issue_within_hold_period(self):
+        """applied_at 5 days before real "now" has not yet cleared the 30-day hold."""
+        issue = _make_issue(1, ["hold 30 days"])
+        applied_at = datetime.now(timezone.utc) - timedelta(days=5)
+
+        def fetch_side_effect(repo, token, label):
+            return [issue] if label == "hold 30 days" else []
+
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            with patch.object(whi, "find_label_applied_at", return_value=applied_at):
+                with patch.object(whi, "wake_issue") as mock_wake:
+                    result = whi.main()
+
+        self.assertEqual(result, 0)
+        mock_wake.assert_not_called()
+
+    def test_skips_when_applied_at_unknown(self):
+        issue = _make_issue(1, ["hold 30 days"])
+
+        def fetch_side_effect(repo, token, label):
+            return [issue] if label == "hold 30 days" else []
+
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            with patch.object(whi, "find_label_applied_at", return_value=None):
+                with patch.object(whi, "wake_issue") as mock_wake:
+                    result = whi.main()
+
+        self.assertEqual(result, 0)
+        mock_wake.assert_not_called()
+
+    def test_continues_after_fetch_error_for_one_label(self):
+        def fetch_side_effect(repo, token, label):
+            if label == "hold 30 days":
+                raise Exception("network error")
+            return []
+
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            result = whi.main()
+
+        self.assertEqual(result, 0)
+
+    def test_continues_after_wake_error_for_one_issue(self):
+        issue = _make_issue(1, ["hold 30 days"])
+        applied_at = _NOW - timedelta(days=31)
+
+        def fetch_side_effect(repo, token, label):
+            return [issue] if label == "hold 30 days" else []
+
+        with patch.object(whi, "fetch_issues_with_label", side_effect=fetch_side_effect):
+            with patch.object(whi, "find_label_applied_at", return_value=applied_at):
+                with patch.object(whi, "wake_issue", side_effect=Exception("boom")):
+                    result = whi.main()
+
+        self.assertEqual(result, 0)
+
+    def test_no_issues_found_wakes_nothing(self):
+        with patch.object(whi, "fetch_issues_with_label", return_value=[]):
+            with patch.object(whi, "wake_issue") as mock_wake:
+                result = whi.main()
+
+        self.assertEqual(result, 0)
+        mock_wake.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/labels/wake_held_issues.py
+++ b/scripts/ci/labels/wake_held_issues.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Reopen issues whose "hold N days" snooze period has elapsed.
+
+The other half of the issue #821 snooze mechanism: scripts/ci/labels/
+snooze_held_issues.py closes an issue when a hold label
+(HOLD_LABEL_DAYS in enforce_mutually_exclusive_labels.py) is added to it.
+This script runs daily and, for every issue still carrying a hold label,
+checks whether that many days have passed since the label was applied. Once
+they have, the issue is reopened, the hold label is removed, and so is every
+label in propagate_issue_labels.PROCESS_STATE_LABELS (orchestrate,
+orchestrating, verification needed, verified, changes requested, changes
+done)--a woken issue should land in plain triage, not resume mid-cycle in
+whatever orchestration state it was closed in, and not silently look
+dispatchable via a leftover `orchestrate`.
+
+The elapsed time is measured from the most recent "labeled" event for the
+issue's current hold label (the GitHub issue events API), not from the
+issue's `updated_at`, which any comment or other label change would also
+bump and so would silently extend or reset the hold. If that event cannot be
+found (should not happen in practice; every label application produces one),
+the issue is left alone rather than guessed at--acting on evidence the script
+does not have would be worse than staying snoozed for one more run.
+
+Usage:
+    python3 scripts/ci/labels/wake_held_issues.py
+
+Exit code is always 0; API failures are logged but do not fail the CI run,
+matching scripts/ci/prs-and-issues/archive_stale_test_failures.py.
+
+Required environment variables:
+    GITHUB_TOKEN        Personal access token or Actions secret with
+                        issues: write
+    GITHUB_REPOSITORY   Owner/repo (e.g. "aunger/gallery-button-for-pixel-camera")
+"""
+
+import datetime
+import os
+import sys
+import urllib.parse
+
+import enforce_mutually_exclusive_labels as emxl
+import propagate_issue_labels as pil
+
+# ---------------------------------------------------------------------------
+# Fetching
+# ---------------------------------------------------------------------------
+
+
+def fetch_issues_with_label(repo: str, token: str, label: str) -> list[dict]:
+    """Return every issue (not pull request) carrying *label*, open or closed.
+
+    Paginates through all pages automatically. Pull requests are excluded:
+    GitHub's issues-list endpoint returns them alongside real issues for any
+    matching label, identifiable by the presence of a "pull_request" key, and
+    the hold-label snooze is scoped to issues (see snooze_held_issues.py).
+    """
+    encoded = urllib.parse.quote(label, safe="")
+    issues: list[dict] = []
+    page = 1
+    while True:
+        batch = emxl.gh_api(
+            f"repos/{repo}/issues?labels={encoded}&state=all&per_page=100&page={page}",
+            token=token,
+        )
+        if not batch:
+            break
+        issues.extend(item for item in batch if "pull_request" not in item)
+        page += 1
+    return issues
+
+
+def find_label_applied_at(
+    issue_number: int,
+    label: str,
+    repo: str,
+    token: str,
+) -> datetime.datetime | None:
+    """Return when *label* was most recently applied to *issue_number*, or None.
+
+    Reads the issue events API for "labeled" events matching *label*
+    (case-insensitively) and returns the latest one's timestamp. Returns None
+    if no such event is found--for example if the label predates the
+    repository's event history, though GitHub does not appear to prune it.
+    """
+    lower = label.lower()
+    latest: datetime.datetime | None = None
+    page = 1
+    while True:
+        batch = emxl.gh_api(
+            f"repos/{repo}/issues/{issue_number}/events?per_page=100&page={page}",
+            token=token,
+        )
+        if not batch:
+            break
+        for event in batch:
+            if event.get("event") != "labeled":
+                continue
+            event_label = (event.get("label") or {}).get("name", "")
+            if event_label.lower() != lower:
+                continue
+            created_at = datetime.datetime.fromisoformat(event["created_at"].replace("Z", "+00:00"))
+            if latest is None or created_at > latest:
+                latest = created_at
+        if len(batch) < 100:
+            break
+        page += 1
+    return latest
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def wake_issue(issue: dict, hold_label: str, repo: str, token: str) -> None:
+    """Reopen *issue*, stripping its hold label and PROCESS_STATE_LABELS."""
+    issue_number = issue["number"]
+    current_labels = [lbl["name"] for lbl in issue.get("labels", [])]
+    hold_lower = hold_label.lower()
+    remaining = [
+        lbl
+        for lbl in current_labels
+        if lbl.lower() != hold_lower and lbl.lower() not in pil.PROCESS_STATE_LABELS
+    ]
+    stripped = [lbl for lbl in current_labels if lbl not in remaining]
+
+    emxl.gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        token=token,
+        method="PATCH",
+        body={"state": "open", "labels": remaining},
+    )
+
+    stripped_note = ""
+    other_stripped = sorted(lbl for lbl in stripped if lbl.lower() != hold_lower)
+    if other_stripped:
+        stripped_note = f" Also removed stale process-state label(s): {', '.join(other_stripped)}."
+
+    emxl.gh_api(
+        f"repos/{repo}/issues/{issue_number}/comments",
+        token=token,
+        method="POST",
+        body={
+            "body": (
+                f"The `{hold_label}` hold has elapsed. Reopening and returning this "
+                f"issue to triage.{stripped_note}"
+            )
+        },
+    )
+    print(f"Woke #{issue_number} from its '{hold_label}' hold.")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    if not token:
+        print("Warning: GITHUB_TOKEN not set; skipping wake check.", file=sys.stderr)
+        return 0
+    if not repo:
+        print("Warning: GITHUB_REPOSITORY not set; skipping wake check.", file=sys.stderr)
+        return 0
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    woken = 0
+
+    for hold_label, hold_days in emxl.HOLD_LABEL_DAYS.items():
+        try:
+            issues = fetch_issues_with_label(repo, token, hold_label)
+        except Exception as exc:  # noqa: BLE001
+            print(f"Error fetching issues held with '{hold_label}': {exc}", file=sys.stderr)
+            continue
+
+        cutoff = now - datetime.timedelta(days=hold_days)
+
+        for issue in issues:
+            issue_number = issue["number"]
+            try:
+                applied_at = find_label_applied_at(issue_number, hold_label, repo, token)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"Error reading label history for #{issue_number}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+
+            if applied_at is None:
+                print(
+                    f"Could not find when '{hold_label}' was applied to #{issue_number}; "
+                    "leaving it held.",
+                    file=sys.stderr,
+                )
+                continue
+
+            if applied_at > cutoff:
+                continue  # still within the hold period
+
+            try:
+                wake_issue(issue, hold_label, repo, token)
+                woken += 1
+            except Exception as exc:  # noqa: BLE001
+                print(f"Error waking #{issue_number}: {exc}", file=sys.stderr)
+
+    print(f"Done. Woke {woken} issue(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/labels/wake_held_issues.py
+++ b/scripts/ci/labels/wake_held_issues.py
@@ -21,6 +21,14 @@ found (should not happen in practice; every label application produces one),
 the issue is left alone rather than guessed at--acting on evidence the script
 does not have would be worse than staying snoozed for one more run.
 
+Before acting on an issue, wake_issue() re-fetches it and confirms the hold
+label is still present, and removes labels one at a time by name rather than
+PATCHing a computed full array. Both guard against a run that takes long
+enough (many issues, events-API pagination, transient-error retries) for a
+label to change underneath it--in particular an escalation to a longer hold,
+which replaces the shorter one via mutual-exclusion enforcement and must not
+be silently undone by a wake decided before the escalation happened.
+
 Usage:
     python3 scripts/ci/labels/wake_held_issues.py
 
@@ -112,42 +120,85 @@ def find_label_applied_at(
 # ---------------------------------------------------------------------------
 
 
-def wake_issue(issue: dict, hold_label: str, repo: str, token: str) -> None:
-    """Reopen *issue*, stripping its hold label and PROCESS_STATE_LABELS."""
-    issue_number = issue["number"]
-    current_labels = [lbl["name"] for lbl in issue.get("labels", [])]
+def wake_issue(issue_number: int, hold_label: str, repo: str, token: str) -> bool:
+    """Reopen *issue_number* if it is still held by *hold_label*.
+
+    Re-fetches the issue's current labels immediately before acting, rather
+    than reusing the list-call snapshot main() saw when it decided this
+    issue's hold had elapsed, and removes only the specific labels this
+    function targets (via enforce_mutually_exclusive_labels.remove_labels(),
+    one DELETE per label) instead of PATCHing a computed full label array.
+    Together these mean a label change made after main()'s snapshot--most
+    importantly someone escalating to a longer hold, which replaces
+    *hold_label* via mutual-exclusion enforcement--is never silently
+    reverted: an escalation is caught by the live re-fetch below (the
+    now-current label list would no longer contain *hold_label*, so this
+    returns without touching anything), and even a label added in the
+    narrower window between this fetch and the DELETE calls survives, since
+    remove_labels() only ever removes the labels it is explicitly told to.
+
+    Returns True if the issue was woken (reopened and stripped), False if it
+    turned out to no longer be held by *hold_label* (left untouched).
+    """
+    issue = emxl.gh_api(f"repos/{repo}/issues/{issue_number}", token=token)
+    if not isinstance(issue, dict):
+        raise RuntimeError(f"unexpected response fetching issue #{issue_number}: {issue!r}")
+
     hold_lower = hold_label.lower()
-    remaining = [
+    current_labels = [lbl["name"] for lbl in issue.get("labels", [])]
+    if hold_lower not in {lbl.lower() for lbl in current_labels}:
+        print(
+            f"#{issue_number} no longer carries '{hold_label}' (label changed since "
+            "this run started)--leaving it alone."
+        )
+        return False
+
+    to_remove = [
         lbl
         for lbl in current_labels
-        if lbl.lower() != hold_lower and lbl.lower() not in pil.PROCESS_STATE_LABELS
+        if lbl.lower() == hold_lower or lbl.lower() in pil.PROCESS_STATE_LABELS
     ]
-    stripped = [lbl for lbl in current_labels if lbl not in remaining]
 
+    # Reopening the issue's state never touches its labels at all--no PATCH
+    # body key for labels is sent here, so there is nothing for this call to
+    # clobber even if the label list changes again immediately afterward.
     emxl.gh_api(
         f"repos/{repo}/issues/{issue_number}",
         token=token,
         method="PATCH",
-        body={"state": "open", "labels": remaining},
+        body={"state": "open"},
     )
+    emxl.remove_labels(issue_number, to_remove, repo, token, reason="expired-hold")
 
+    other_stripped = sorted(lbl for lbl in to_remove if lbl.lower() != hold_lower)
     stripped_note = ""
-    other_stripped = sorted(lbl for lbl in stripped if lbl.lower() != hold_lower)
     if other_stripped:
         stripped_note = f" Also removed stale process-state label(s): {', '.join(other_stripped)}."
 
-    emxl.gh_api(
-        f"repos/{repo}/issues/{issue_number}/comments",
-        token=token,
-        method="POST",
-        body={
-            "body": (
-                f"The `{hold_label}` hold has elapsed. Reopening and returning this "
-                f"issue to triage.{stripped_note}"
-            )
-        },
-    )
+    try:
+        emxl.gh_api(
+            f"repos/{repo}/issues/{issue_number}/comments",
+            token=token,
+            method="POST",
+            body={
+                "body": (
+                    f"The `{hold_label}` hold has elapsed. Reopening and returning this "
+                    f"issue to triage.{stripped_note}"
+                )
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        # The reopen and label strip above already succeeded and are not
+        # undone by a failed notification comment; report this narrowly so
+        # the Actions log does not read this issue as untouched.
+        print(
+            f"#{issue_number} was reopened and stripped of its hold, but posting the "
+            f"wake comment failed: {exc}",
+            file=sys.stderr,
+        )
+
     print(f"Woke #{issue_number} from its '{hold_label}' hold.")
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +252,8 @@ def main() -> int:
                 continue  # still within the hold period
 
             try:
-                wake_issue(issue, hold_label, repo, token)
-                woken += 1
+                if wake_issue(issue_number, hold_label, repo, token):
+                    woken += 1
             except Exception as exc:  # noqa: BLE001
                 print(f"Error waking #{issue_number}: {exc}", file=sys.stderr)
 


### PR DESCRIPTION
🤖 Author

Fixes #821.

Adds the "hold N days" snooze label #803's "Not in scope" section floated as a complementary follow-on: a label for issues whose revisit condition is elapsed time with no observable upstream signal (#774's follow-up list has two: removing `-dontrepackage`, and `compileSdk`/`targetSdk` 36).

## Design

Three pieces, matching #803's two notes plus the missing effect that makes the label do something:

1. **The fixed ladder** (`hold 30 days`, `hold 90 days`, `hold 180 days`), as `HOLD_LABEL_DAYS` in `scripts/ci/labels/enforce_mutually_exclusive_labels.py`, added to `MUTUALLY_EXCLUSIVE_SETS` so at most one hold label is present at a time. Per #803's own note: that module already models exclusive sets as fixed frozensets, and a three-rung ladder fits that shape far more cheaply than parsing an arbitrary N out of free-form label text.
2. **Snooze** (`scripts/ci/labels/snooze_held_issues.py`, `.github/workflows/snooze-held-issues.yml`): adding a hold label closes the issue. Without this the label would just sit on an open issue and do nothing; closing is what actually takes it out of triage/dispatch view while it waits. Already-closed issues are a no-op, which also covers escalating from a shorter hold to a longer one.
3. **Wake** (`scripts/ci/labels/wake_held_issues.py`, `.github/workflows/wake-held-issues.yml`): a daily cron reopens an issue once its hold label's day count has elapsed, measured from the most recent "labeled" event for that label (the issue events API), not `updated_at`, since an unrelated comment or label change must not silently extend or reset the hold. Per #803's other note, the reopen also strips `propagate_issue_labels.PROCESS_STATE_LABELS` (`orchestrate`, `orchestrating`, `verification needed`, `verified`, `changes requested`, `changes done`) along with the hold label itself, so a woken issue lands in plain triage instead of resuming mid-orchestration-cycle or looking dispatchable via a leftover `orchestrate`. If the labeling event can't be found, the issue is left alone rather than guessed at.

`wake-held-issues.yml` runs daily at 05:00 UTC, offset an hour from `archive-stale-test-failures.yml`'s existing 04:00 UTC cron.

## Commits

1. The label ladder and its mutual-exclusion tests.
2. Snooze-on-label-add.
3. Wake-on-elapsed-hold.

## Test plan

Full unit-test suite green locally (`scripts/ci/labels` 407 tests, `scripts/ci` 53 including the label-existence integration test), plus `scripts/lint/lint.sh --check` on every changed file.

Not covered by automated tests:

- [ ] Create the three labels (`hold 30 days`, `hold 90 days`, `hold 180 days`) in the repository's Labels settings page. `scripts/ci/test_label_existence_integration.py` picks them up automatically via `MUTUALLY_EXCLUSIVE_SETS` and will fail in CI (with `GITHUB_TOKEN` set) until they exist.

## Follow-up suggestions

- None from this PR; the two notes #803 left for this feature are both addressed above.

