### PR TITLE
Guard collect_state's advisories dict against coordinate@version key collisions

### DIFF
--- a/scripts/ci/prs-and-issues/test_watch_toolchain_bump.py
+++ b/scripts/ci/prs-and-issues/test_watch_toolchain_bump.py
@@ -486,6 +486,22 @@ class TestCollectState(unittest.TestCase):
         self.assertEqual(mock_osv.call_count, 0)
         self.assertEqual(state["toolchain_advisories"], {})
 
+    def test_colliding_coordinate_version_key_is_guarded(self):
+        """#838: a future pin whose coordinate coincides with another pin's coordinate at the
+        same version must not silently overwrite that pin's advisory record."""
+        colliding = {
+            "gradle": ["org.gradle:gradle-core"],
+            "agp": ["org.gradle:gradle-core"],
+        }
+        with patch.object(wtb, "COORDINATES_BY_PIN", colliding):
+            with patch.object(
+                wtb, "read_pinned_versions", return_value={"gradle": "9.5.1", "agp": "9.5.1"}
+            ):
+                with patch.object(wtb, "fetch_text", side_effect=self._fake_fetch()):
+                    with patch.object(wtb, "query_osv", return_value=[]):
+                        with self.assertRaises(AssertionError):
+                            wtb.collect_state(self.root)
+
 
 # ---------------------------------------------------------------------------
 # State round-trip through comments

--- a/scripts/ci/prs-and-issues/watch_toolchain_bump.py
+++ b/scripts/ci/prs-and-issues/watch_toolchain_bump.py
@@ -510,7 +510,16 @@ def collect_state(repo_root: Path) -> dict:
         if not version:
             continue
         for coordinate in coordinates:
-            advisories[f"{coordinate}@{version}"] = _collect(errors, query_osv, coordinate, version)
+            key = f"{coordinate}@{version}"
+            # Nothing collides today: every coordinate in COORDINATES_BY_PIN is unique across all
+            # pins (#838). This guards the assumption instead of letting a future pin silently
+            # overwrite another pin's advisory record under the same coordinate@version key.
+            assert key not in advisories, (
+                f"duplicate coordinate@version key {key!r} in toolchain_advisories: two entries "
+                "in COORDINATES_BY_PIN resolved to the same key, so one would silently overwrite "
+                "the other's advisory result"
+            )
+            advisories[key] = _collect(errors, query_osv, coordinate, version)
 
     return {
         "pinned": pinned,


### PR DESCRIPTION
Fixes #838.

## Context

PR #836 widened `COORDINATES_BY_PIN` so a single pin (the KGP pin) can contribute more than one OSV coordinate (`org.jetbrains.kotlin:kotlin-gradle-plugin` and `org.jetbrains.kotlin:kotlin-stdlib`). `collect_state` in `scripts/ci/prs-and-issues/watch_toolchain_bump.py` keys the shared `advisories` dict by `f"{coordinate}@{version}"` across all pins. Nothing collides today (every coordinate is unique across all three pins), but the loop did not defend against it: a future pin whose coordinate happens to coincide with another pin's coordinate at the same version would silently overwrite one advisory record with the other.

## Change

Add an assertion at the point the `coordinate@version` key is built in `collect_state`, so a future collision fails loudly instead of silently dropping an advisory record. This matches the file's existing "fail-loud posture" (see its module docstring).

Added `test_colliding_coordinate_version_key_is_guarded`, which patches `COORDINATES_BY_PIN` and `read_pinned_versions` so two pins resolve to the same coordinate at the same version, and asserts `collect_state` raises.

## Test plan

- [x] `python3 -m pytest scripts/ci/prs-and-issues/test_watch_toolchain_bump.py` (97 passed)
- [x] `ruff check` / `ruff format --check` on both changed files

