### PR TITLE
Add a disjointness guard between UNANIMOUS_LABELS and EXHAUSTIVE_LABELS

### DIFF
--- a/scripts/ci/labels/test_label_by_files.py
+++ b/scripts/ci/labels/test_label_by_files.py
@@ -241,6 +241,18 @@ class TestMatchingLabels(unittest.TestCase):
         ]
         self.assertIn("agents", lbf.matching_labels(paths))
 
+    def test_unanimous_and_exhaustive_labels_are_disjoint(self):
+        # matching_labels()'s docstring claims that restricting the
+        # intersection to UNANIMOUS_LABELS and the union to EXHAUSTIVE_LABELS
+        # is what keeps the two rule shapes from contaminating each
+        # other--true only while the two sets stay disjoint. If a label ever
+        # landed in both, the existential add would silently subsume the
+        # unanimity add for it and the unanimity restriction would become
+        # dead code for that label, with no test noticing (issue #830).
+        # Mirrors propagate_issue_labels.py's
+        # test_file_determined_and_process_state_sets_are_disjoint.
+        self.assertEqual(lbf.UNANIMOUS_LABELS & lbf.EXHAUSTIVE_LABELS, frozenset())
+
 
 # ---------------------------------------------------------------------------
 # labels_to_remove tests


### PR DESCRIPTION
🤖 Author

Fixes #830.

## What it does

`matching_labels()` in `scripts/ci/labels/label_by_files.py` restricts the intersection of a PR's changed-file labels to `UNANIMOUS_LABELS` and the union to `EXHAUSTIVE_LABELS`, and its docstring claims this "keeps the two rule shapes from contaminating each other." That claim is only true while the two sets stay disjoint: if a label ever landed in both, the existential (if-and-only-if) add would silently subsume the unanimity add for it, and the unanimity restriction would become dead code for that label, with no test noticing.

This adds `test_unanimous_and_exhaustive_labels_are_disjoint` to `scripts/ci/labels/test_label_by_files.py`, pinning `UNANIMOUS_LABELS & EXHAUSTIVE_LABELS == frozenset()`. It mirrors the existing `test_file_determined_and_process_state_sets_are_disjoint` in `scripts/ci/labels/test_propagate_issue_labels.py`, which guards the analogous invariant between `propagate_issue_labels.py`'s own two label sets.

## Why a test rather than a runtime assertion

`propagate_issue_labels.py`'s existing precedent for this exact kind of guard is a test, not a module-level `assert`, so this follows the same pattern rather than introducing a new one. Both sets are fixed at import time (`UNANIMOUS_LABELS` is a literal, `EXHAUSTIVE_LABELS` is `label_by_title.FILE_DETERMINED_LABELS`), so a test that runs on every CI invocation catches drift just as reliably as a runtime assertion would, without adding an assertion that fires on every production label-classification run for a condition that is actually a static, test-time-checkable property of the source.

## Test plan

`python3 -m unittest discover -p "test_*.py"` in `scripts/ci/labels/` passes all 413 tests (56 in `test_label_by_files.py`, including the new one). `ruff check` and `ruff format --check` are clean on the changed file.
