### PR TITLE
Reclassify a spent per-package ignore entry as stale, not mismatched

### DIFF
--- a/scripts/ci/audit_requirements.py
+++ b/scripts/ci/audit_requirements.py
@@ -460,12 +460,28 @@ def evaluate(
     a version, so splitting one advisory into a per-version entry would be noise.
     Both findings are still listed individually in the report; what is shared is
     the justification, not the visibility.
+
+    One advisory ID can also cover two different packages pinned in the same
+    lock, each with its own ``(lock, package, id)`` entry.  When one of those
+    findings stops being reported, that entry's own match disappears while the
+    ID is still reported against the *other* package.  That other package
+    already has its own entry accounting for it, so the vanished entry is
+    spent, not misfiled: it is reported as stale rather than as naming the
+    wrong package.  An entry is only reported as naming the wrong package when
+    the ID is reported against a package that has no entry of its own to
+    explain it.
     """
     by_package: dict[tuple[str, str, str], list[Finding]] = {}
     by_id: dict[tuple[str, str], list[Finding]] = {}
     for f in findings:
         by_package.setdefault((f.lock, f.package, f.vuln_id), []).append(f)
         by_id.setdefault((f.lock, f.vuln_id), []).append(f)
+
+    # Every (lock, package, id) an ignore entry claims, regardless of whether
+    # it currently matches a finding. Computed once over the whole list so the
+    # stale/mismatched split below does not depend on the order entries are
+    # processed in.
+    entry_keys = {(e.lock, e.package, e.vuln_id) for e in ignores}
 
     honored: list[tuple[IgnoreEntry, Finding]] = []
     stale: list[IgnoreEntry] = []
@@ -478,13 +494,15 @@ def evaluate(
             accounted.update(matches)
             continue
         others = by_id.get((entry.lock, entry.vuln_id), [])
-        if others:
-            # Reported, but against a package this entry does not name, so the
-            # entry is wrong rather than merely tolerant. These are accounted
-            # for so they are not *also* listed as having no entry at all,
-            # which would tell the reader to add one that already exists.
-            mismatched.extend((entry, f) for f in others)
-            accounted.update(others)
+        unclaimed = [f for f in others if (f.lock, f.package, f.vuln_id) not in entry_keys]
+        if unclaimed:
+            # Reported, but against a package that has no entry of its own
+            # either, so this entry is naming the wrong package rather than
+            # merely being spent. Accounted for so it is not *also* listed as
+            # having no entry at all, which would tell the reader to add one
+            # that already exists.
+            mismatched.extend((entry, f) for f in unclaimed)
+            accounted.update(unclaimed)
             continue
         stale.append(entry)
 

--- a/scripts/ci/test_audit_requirements.py
+++ b/scripts/ci/test_audit_requirements.py
@@ -398,6 +398,34 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual([f.package for _, f in report.honored], ["somepkg"])
         self.assertEqual([f.package for f in report.unignored], ["otherpkg"])
 
+    def test_spent_entry_is_stale_not_mismatched_when_a_sibling_entry_covers_the_other_package(
+        self,
+    ):
+        # Issue #815: one advisory ID legitimately covers two packages in one
+        # lock, each with its own entry. When one of the two findings stops
+        # being reported, that entry's own match disappears while the ID is
+        # still reported against the other package. That package is already
+        # accounted for by its own entry, so the vanished entry is spent
+        # (stale), not naming the wrong package (mismatched).
+        entries = [entry(package="somepkg"), entry(package="otherpkg")]
+        findings = [finding(package="somepkg")]  # otherpkg's finding disappeared
+        report = ar.evaluate([("lock.txt", 3, 1)], findings, entries)
+        self.assertTrue(report.failed)
+        self.assertEqual([f.package for _, f in report.honored], ["somepkg"])
+        self.assertEqual(report.mismatched, [])
+        self.assertEqual([e.package for e in report.stale], ["otherpkg"])
+
+    def test_spent_entry_verdict_does_not_depend_on_entry_order(self):
+        # Same scenario as above with the entries reversed: the vanished
+        # entry is processed before the one that is still honored. The
+        # verdict must not depend on which entry happens to run first.
+        entries = [entry(package="otherpkg"), entry(package="somepkg")]
+        findings = [finding(package="somepkg")]
+        report = ar.evaluate([("lock.txt", 3, 1)], findings, entries)
+        self.assertEqual([f.package for _, f in report.honored], ["somepkg"])
+        self.assertEqual(report.mismatched, [])
+        self.assertEqual([e.package for e in report.stale], ["otherpkg"])
+
 
 class TestFormatReport(unittest.TestCase):
     def test_stale_entry_report_names_the_removal_condition(self):
@@ -494,6 +522,29 @@ class TestMain(IgnoreFileTestCase):
         self.assertEqual(code, 0)
         self.assertIn("unreachable via risky", out)
         self.assertIn("unreachable via alsorisky", out)
+
+    def test_one_of_two_packages_sharing_an_advisory_going_spent_is_reported_stale(self):
+        # Companion to the fully-ignored case above (issue #815). When
+        # alsorisky's finding stops being reported, its entry is spent, not
+        # misfiled: risky already has its own entry accounting for it.
+        (self.tmpdir / "scripts" / "ci" / "requirements-tool.txt").write_text(
+            "risky==1.23.3 \\\n    --hash=sha256:def\nalsorisky==2.0 \\\n    --hash=sha256:abc\n",
+            encoding="utf-8",
+        )
+        shared = "GHSA-shared-0000-0000"
+        body = "".join(
+            f'[[ignore."scripts/ci/requirements-tool.txt"]]\n'
+            f'id = "{shared}"\n'
+            f'package = "{pkg}"\n'
+            f'reason = "unreachable via {pkg}"\n'
+            f'remove_when = "upstream drops {pkg}"\n'
+            for pkg in ("risky", "alsorisky")
+        )
+        code, out = self.run_main(body, {"risky": [vuln(shared)]})
+        self.assertEqual(code, 1)
+        self.assertIn("Stale ignore entries", out)
+        self.assertIn("alsorisky", out)
+        self.assertNotIn("naming the wrong package", out)
 
     def test_narrowing_to_one_lock_does_not_misread_the_other_locks_entries(self):
         # Naming a lock is the documented interface, and it used to exit 2 with


### PR DESCRIPTION
Fixes #815.

`scripts/ci/audit_requirements.py` lets one advisory ID cover two packages pinned in the same lock, each with its own `(lock, package, id)` ignore entry. When one of those two findings stops being reported while the ID is still reported against the other package, `evaluate()` classified the non-matching entry as `mismatched`:

```text
Ignore entries naming the wrong package:
  [L] X is recorded against 'b' but is reported against 'a'
Correct the `package` field in i.toml, or file the entry under the advisory ID that actually covers the package it names.
```

That entry is not wrong; it is spent (its finding no longer exists), and the advice points the wrong way: correcting `package` to `a` would collide with the entry already filed for `a`.

`evaluate()` now only reports an entry as naming the wrong package when the ID is reported against a package that has no ignore entry of its own to explain it. When every other package still reported under that ID is already accounted for by its own dedicated entry, the entry whose own match disappeared is reported as stale instead, which is the existing "delete this from the ignore file" verdict.

The stale/mismatched split is computed from the full set of ignore entries up front, so the verdict does not depend on the order the entries happen to be listed in.

## Tests

- `TestEvaluate.test_spent_entry_is_stale_not_mismatched_when_a_sibling_entry_covers_the_other_package` and its order-reversed companion cover the unit-level classification.
- `TestMain.test_one_of_two_packages_sharing_an_advisory_going_spent_is_reported_stale` covers it end to end through `main()`.
- The existing `test_entry_naming_the_wrong_package_fails` and `test_an_entry_for_one_package_does_not_cover_another_with_the_same_id` still pass unchanged, confirming genuine wrong-package and unignored-finding cases are unaffected.
