### PR TITLE
Add a clarifying comment to two documentation files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -356,3 +356,6 @@ Non-Pixel devices running Pixel Camera ports would not be covered.
 
 **Feasibility:** High.
 This approach combines the precision of AccessibilityService detection with the zero-permission simplicity of a static database, at the cost of a build-time maintenance process that can be largely automated.
+
+<!-- Verify #827: unrelated file included alongside an agents-path change in agents/task_complexity.md. -->
+

--- a/agents/task_complexity.md
+++ b/agents/task_complexity.md
@@ -99,3 +99,6 @@ Author: 3 / 2 / 3 / 3 / 3 / 3; Reviewer: 3 / 2 / 3 / 3 / 2 / 2
 Full system design with competing approaches; undocumented API behavior; 5-file implementation plan.
 Investigation and ambiguity both drop for review.
 Author: 3 / 3 / 3 / 3 / 3 / 3; Reviewer: 3 / 2 / 3 / 3 / 3 / 2
+
+<!-- Verify #827: label-by-files should apply "agents" to this PR (this path plus an unrelated SPEC.md edit). -->
+


### PR DESCRIPTION
Do not merge. Throwaway PR for live-fire verification of issue #827.

This PR's diff touches `agents/task_complexity.md` (an agents path) alongside `SPEC.md` (unrelated), to confirm `label-by-files.yml` applies the `agents` label anyway (the existential/any-path-justifies-it half of the if-and-only-if rule).

Will be closed without merging once the Actions run is observed.
