### PR TITLE
Add a clarifying comment to SPEC.md for the propagation-exclusion PR

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -356,3 +356,6 @@ Non-Pixel devices running Pixel Camera ports would not be covered.
 
 **Feasibility:** High.
 This approach combines the precision of AccessibilityService detection with the zero-permission simplicity of a static database, at the cost of a build-time maintenance process that can be largely automated.
+
+<!-- Verify #829: this PR touches no agents path; body says Fixes #775 (which carries the agents label). -->
+


### PR DESCRIPTION
Do not merge. Throwaway PR for live-fire verification of issue #829.

Fixes #775

This PR's own diff touches no agents path, and issue #775 carries the `agents` label, to confirm `propagate-issue-labels.yml` logs the exclusion of `agents` (rather than silently dropping it, or copying it in) and this PR never receives the label via propagation.

Will be closed without merging once the Actions run is observed.
