### PR TITLE
Add --force-reinstall to CI's pip installs, matching the session hook

### DIFF
--- a/.claude/environment.md
+++ b/.claude/environment.md
@@ -194,8 +194,11 @@ Regenerate the lock with the `uv pip compile` command recorded in that `.in` fil
 
 Both sides install it: CI in `.github/workflows/build.yml`, and the `SessionStart` hook in step 4 (issue #806).
 The session install is what makes the whole test suite runnable in a session; without it, four of the Python test modules and `scripts/ci/test-support/test_summarize_preflight_integration.sh` fail with `No module named 'defusedxml'` whatever the change under test is.
-The hook returns immediately unless `CLAUDE_CODE_REMOTE=true`, so a checkout on your own machine is not covered by it: install the lock there yourself with `pip install --require-hashes -r scripts/requirements.txt`, the command CI runs.
+The hook returns immediately unless `CLAUDE_CODE_REMOTE=true`, so a checkout on your own machine is not covered by it: install the lock there yourself with `pip install --force-reinstall --require-hashes -r scripts/requirements.txt`, the command CI runs.
 The install also makes the versions this repository declares the ones a session runs: `requests` and `PyYAML` happen to resolve from the base image, so a change there would extend the same failure to them with no other signal.
+`--force-reinstall` is what guarantees that: without it, pip leaves a package alone when the runner image already ships the pinned version, and CI would silently run the image's copy instead of the artifact the lock names (issue #810).
+CI and the hook now match on both `--require-hashes` and `--force-reinstall`; only `--user` differs, because CI has no per-session home to isolate into and installs straight into the runner's own site (`build.yml`'s `shell-tests` job installs the lint lock into a dedicated venv instead, where `--user` is not even valid; `lint.yml` relies on `sysconfig`'s own scripts path, which a `--user` install would not populate).
+`scripts/test_install_pinned_requirements.sh` case (i) checks every CI install line still carries `--force-reinstall`.
 
 Steps 3b and 4 both install through `scripts/install-pinned-requirements.sh`, which records the SHA-256 of the lock it installed under `~/.local/share/gb4pc/`.
 A re-run against an unchanged lock is therefore a no-op, an edited lock reinstalls, and a failed install writes no marker and is retried.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,12 @@ jobs:
         # the split job must install them itself. --require-hashes refuses any
         # artifact whose SHA-256 is not in the generated lock scripts/requirements.txt
         # (issue #723; see scripts/requirements.in for the top-level pins).
+        # --force-reinstall matches scripts/install-pinned-requirements.sh, the
+        # session-start hook's installer: without it, a runner image that already
+        # ships a package at exactly the pinned version keeps its own copy instead
+        # of the artifact the lock names (issue #810).
         if: needs.check-diff.outputs.needs_full_build == 'true'
-        run: pip install --require-hashes -r scripts/requirements.txt
+        run: pip install --force-reinstall --require-hashes -r scripts/requirements.txt
 
       - name: Install lint tools for shell tests
         # scripts/lint/test_lint_hook.sh drives scripts/lint/lint.sh and the pre-commit git
@@ -72,11 +76,13 @@ jobs:
         # into a venv so scripts/lint/lint.sh resolves them by explicit path via
         # LINT_BIN_DIR (persisted to the next step through $GITHUB_ENV). ktlint (a
         # Maven Central JAR needing a JDK) is not installed here; the test skips
-        # only its Kotlin case when ktlint is absent.
+        # only its Kotlin case when ktlint is absent. --force-reinstall matches the
+        # session-start hook's installer (issue #810); --user is not applicable
+        # here because the venv's own pip refuses --user installs outright.
         if: needs.check-diff.outputs.needs_full_build == 'true'
         run: |
           python3 -m venv "$RUNNER_TEMP/lintvenv"
-          "$RUNNER_TEMP/lintvenv/bin/pip" install --quiet --require-hashes -r scripts/lint/requirements-lint.txt
+          "$RUNNER_TEMP/lintvenv/bin/pip" install --quiet --force-reinstall --require-hashes -r scripts/lint/requirements-lint.txt
           echo "LINT_BIN_DIR=$RUNNER_TEMP/lintvenv/bin" >> "$GITHUB_ENV"
 
       - name: Run shell script unit tests
@@ -136,8 +142,9 @@ jobs:
         if: needs.check-diff.outputs.needs_full_build == 'true'
         # --require-hashes refuses any artifact whose SHA-256 is not in the
         # generated lock scripts/requirements.txt (issue #723; see
-        # scripts/requirements.in for the top-level pins).
-        run: pip install --require-hashes -r scripts/requirements.txt
+        # scripts/requirements.in for the top-level pins). --force-reinstall
+        # matches the session-start hook's installer (issue #810).
+        run: pip install --force-reinstall --require-hashes -r scripts/requirements.txt
 
       - name: Run Python script unit tests
         if: needs.check-diff.outputs.needs_full_build == 'true'
@@ -1365,8 +1372,9 @@ jobs:
       - name: Install Python script dependencies
         # --require-hashes refuses any artifact whose SHA-256 is not in the
         # generated lock scripts/requirements.txt (issue #723; see
-        # scripts/requirements.in for the top-level pins).
-        run: pip install --require-hashes -r scripts/requirements.txt
+        # scripts/requirements.in for the top-level pins). --force-reinstall
+        # matches the session-start hook's installer (issue #810).
+        run: pip install --force-reinstall --require-hashes -r scripts/requirements.txt
 
       - name: File issues for failed tests
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,14 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Python lint tools
+        # --force-reinstall matches scripts/install-pinned-requirements.sh, the
+        # session-start hook's installer: without it, a runner image that already
+        # ships a package at exactly the pinned version keeps its own copy instead
+        # of the artifact the lock names (issue #810). --user is not used here:
+        # LINT_BIN_DIR below is sysconfig's own scripts path, which a --user
+        # install would not populate.
         run: |
-          pip install --require-hashes -r scripts/lint/requirements-lint.txt
+          pip install --force-reinstall --require-hashes -r scripts/lint/requirements-lint.txt
           echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
       - name: Ruff check
         run: scripts/lint/lint.sh --check --only python --all
@@ -47,8 +53,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Python lint tools
+        # --force-reinstall matches the session-start hook's installer (issue
+        # #810); see the python-ruff job above for the full rationale.
         run: |
-          pip install --require-hashes -r scripts/lint/requirements-lint.txt
+          pip install --force-reinstall --require-hashes -r scripts/lint/requirements-lint.txt
           echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
       - name: mdformat check
         # Also runs scripts/lint/check_md040.py (issue #689): MD040 (a fenced code
@@ -63,8 +71,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Python lint tools
+        # --force-reinstall matches the session-start hook's installer (issue
+        # #810); see the python-ruff job above for the full rationale.
         run: |
-          pip install --require-hashes -r scripts/lint/requirements-lint.txt
+          pip install --force-reinstall --require-hashes -r scripts/lint/requirements-lint.txt
           echo "LINT_BIN_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_ENV"
       - name: Hygiene checks
         run: scripts/lint/lint.sh --check --only hygiene --all

--- a/scripts/install-pinned-requirements.sh
+++ b/scripts/install-pinned-requirements.sh
@@ -23,6 +23,13 @@
 # it, a package the base image happens to ship at the pinned version is left in
 # place and the session runs bytes the repository never declared.
 #
+# CI does not call this script for its own installs (its pip is not always on
+# PATH, e.g. the shell-tests job's venv, and it has no marker to gate). Its
+# inline pip install lines pass --force-reinstall independently instead, and
+# scripts/test_install_pinned_requirements.sh case (i) checks every one of them
+# does, so CI cannot drift back to running whatever a runner image happens to
+# ship (issue #810).
+#
 # The install is gated on the SHA-256 of the lock: a marker file records the hash
 # that was last installed, so a re-run against an unchanged lock skips the work
 # while any edit to the pinned versions reinstalls. The marker is named after the

--- a/scripts/test_install_pinned_requirements.sh
+++ b/scripts/test_install_pinned_requirements.sh
@@ -15,18 +15,19 @@
 #
 # HOW THE WIRING CASES FIND A LOCK
 #
-# Cases (g) and (h) grep for a spelling rather than parsing bash or YAML, so an
-# install written another way drops out of the comparison silently: (h) would
-# then still pass, because its non-empty guard only proves that some lock
+# Cases (g), (h), and (i) grep for a spelling rather than parsing bash or YAML, so
+# an install written another way drops out of the comparison silently: (h) and (i)
+# would then still pass, because their non-empty guards only prove that some lock
 # matched, not that yours did. If you add an install, match these spellings, or
 # extend the patterns here:
 #
 #   .claude/hooks/session-start.sh   "$REPO_ROOT/scripts/<path>.txt", unquoted
 #                                    path, no variable standing in for it
-#   .github/workflows/build.yml      -r scripts/<path>.txt (not --requirement,
-#                                    not a quoted or variable path)
+#   .github/workflows/build.yml,     -r scripts/<path>.txt (not --requirement,
+#   .github/workflows/lint.yml       not a quoted or variable path); (i) also
+#                                    requires --force-reinstall on that same line
 #
-# Comments are stripped from both files first, so prose naming a lock is not
+# Comments are stripped from all three files first, so prose naming a lock is not
 # counted as an install.
 #
 # Always exits 0 on success, non-zero on failure.
@@ -257,6 +258,47 @@ if [[ -z "$UNPROVISIONED" ]]; then
     pass "the session-start hook installs every lock build.yml installs"
 else
     fail "build.yml installs locks the session-start hook does not:$UNPROVISIONED"
+fi
+
+# ── (i) CI installs the locks the same way the hook does ─────────────────────
+#
+# Issue #810: (h) above confirms both sides install the same *locks*, but not
+# that they install them the same *way*. Every call site already agreed on
+# --require-hashes, so the integrity property held either way, but only the
+# hook's installer (this script) passed --force-reinstall. Without it, pip
+# leaves a package alone when something already satisfies the pinned
+# requirement, so a runner image that ships a package at exactly the locked
+# version keeps the runner's own copy instead of the artifact the lock names,
+# while a session force-reinstalls it--both sides pass --require-hashes, but
+# only one of them is provably running the bytes the lock declares.
+#
+# --user is deliberately NOT compared here: it stays session-only. build.yml's
+# shell-tests job installs the lint lock into a dedicated venv, where pip
+# refuses a --user install outright, and lint.yml's three jobs derive
+# LINT_BIN_DIR from sysconfig's own scripts path, which a --user install does
+# not populate. Both are legitimate divergences from the hook, which has no
+# venv of its own and installs into the session user's site instead.
+echo ""
+echo "=== (i) every CI lock install forces the pinned version, like the hook does ==="
+CI_INSTALL_LINES="$( { sed 's/#.*$//' "$REPO_ROOT/.github/workflows/build.yml"; \
+                       sed 's/#.*$//' "$REPO_ROOT/.github/workflows/lint.yml"; } \
+    | grep -- '-r scripts/[A-Za-z0-9_./-]*\.txt' )"
+if [[ -n "$CI_INSTALL_LINES" ]]; then
+    pass "found $(echo "$CI_INSTALL_LINES" | grep -c .) CI lock-install line(s) to check"
+else
+    fail "no CI lock-install line found in build.yml or lint.yml (did the install steps move?)"
+fi
+
+UNFORCED=""
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" == *"--force-reinstall"* ]] || UNFORCED="$UNFORCED
+    $line"
+done <<< "$CI_INSTALL_LINES"
+if [[ -z "$UNFORCED" ]]; then
+    pass "every CI lock install passes --force-reinstall"
+else
+    fail "CI installs a lock without --force-reinstall:$UNFORCED"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
🤖 Author

Fixes #810.

`--require-hashes` already held on every install site, so the integrity property #699 exists for was intact everywhere. The gap was `--force-reinstall`: only `scripts/install-pinned-requirements.sh` (the session-start hook's shared installer) passed it. Without it, pip leaves a package alone when something already satisfies the pinned requirement, so a runner image that happens to ship a package at exactly the locked version keeps the runner's own copy instead of the artifact the lock names, while a session force-reinstalls it. Both sides pass `--require-hashes`, but only one of them was provably running the bytes the lock declares.

## What changed

**`.github/workflows/build.yml` and `.github/workflows/lint.yml`.**
Added `--force-reinstall` to every CI `pip install` line that installs a lock the session-start hook also provisions: the two `scripts/requirements.txt` installs in `build-and-test` and `shell-tests`, the one in `file-issues` (an extra call site the issue didn't enumerate but is the same asymmetry), the venv install of `scripts/lint/requirements-lint.txt` in `shell-tests`, and the three `scripts/lint/requirements-lint.txt` installs in `lint.yml`'s three jobs. Seven sites total.

I picked the issue's second candidate shape (add the flag to the CI steps and leave them inline) over routing through `install-pinned-requirements.sh`: the shell-tests venv's pip is not on `PATH` (the issue already flagged this), and more importantly the script always passes `--user`, which pip refuses outright inside a venv and which would silently break `lint.yml`'s `sysconfig`-based `LINT_BIN_DIR` detection (a `--user` install populates a different scripts directory than `sysconfig.get_path("scripts")` reports). Keeping the flag inline avoids reconciling those two `--user` semantics inside the shared script.

**`--user` stays a legitimate divergence, recorded rather than forced to match.**
CI has no per-session home to isolate into: it installs straight into the runner's own site, or (for the lint lock, in two different ways) into a venv or via `setup-python`'s own interpreter. Forcing `--user` onto those would either error (the venv) or break lint discovery (`lint.yml`). This is documented next to the new test case, in `install-pinned-requirements.sh`, and in `.claude/environment.md`.

**`scripts/test_install_pinned_requirements.sh` case (i) (new).**
Checks that every CI line installing a `scripts/*.txt` lock also carries `--force-reinstall`, so this cannot drift back silently. It greps `build.yml` and `lint.yml` with the same lock-spelling convention case (h) already established, reusing that documented fragility rather than adding a new one. Verified it fails against the unpatched workflow files (all 7 sites flagged) and passes once the flag is present everywhere case (h) expects a lock to be installed.

**`.claude/environment.md` and `scripts/install-pinned-requirements.sh`.**
The doc line asserting the session-install command is "the command CI runs" was byte-identical before this PR (the previous reviewer round on #807 verified that literally); updated it to the new command so it stays true. Added a short paragraph recording the `--force-reinstall` parity and the `--user` divergence, and a cross-reference in the installer script noting CI enforces the same flag independently, via case (i), rather than by calling this script.

## Out of scope

`.github/workflows/watch-toolchain-bump.yml` also installs `scripts/requirements.txt` (with neither flag), but it is a scheduled workflow, not one of the test-running workflows case (h) already scopes itself to ("the workflow that runs the test suites a session is expected to reproduce"), so it is left alone for the same reason `semgrep.yml` and `dependency-audit.yml` are.

## Test coverage

`scripts/test_install_pinned_requirements.sh`: 22 of 22 cases pass, including the new case (i). Confirmed case (i) is a real regression guard by stashing just the workflow changes and re-running: it fails, correctly listing all 7 unpatched install lines, then passes again once they're restored.

## Verification

All 14 shell test suites under `scripts/**/test_*.sh` pass. `./scripts/lint/lint.sh --check` is clean on every changed file. `python3 -c "import yaml; ..."` confirms both edited workflow files still parse. No Kotlin, Gradle, or app source is touched, so the Android build is unaffected and was not run.