### PR TITLE
Auto-regenerate gradle/verification-metadata.xml for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -5,10 +5,17 @@ name: Push regenerated verification metadata (Dependabot)
 # this is split into two workflow files.
 #
 # This workflow never checks out or runs code from the PR: it only downloads
-# the file the other workflow already generated and treats it as inert data
-# to copy into place. Workflow files must live on the base branch to run at
-# all, so what actually executes here is always this reviewed file on main,
-# never anything from a Dependabot branch.
+# the file the other workflow already generated and writes it back through
+# the GitHub Contents API, treating it as inert data. An earlier revision
+# used `actions/checkout` on the Dependabot branch, under the one credential
+# in this whole design that can write, so it could still materialize the
+# untrusted branch's full tree (and any build-time code a bumped dependency
+# ships) under a privileged token; CodeQL flagged that ("Checkout of
+# untrusted code in a privileged context"), and it was right to. Reading and
+# writing exactly one named file through the API instead means the branch's
+# tree is never checked out here at all. Workflow files must live on the
+# base branch to run at all, so what actually executes here is always this
+# reviewed file on main, never anything from a Dependabot branch.
 #
 # The push authenticates with a personal access token
 # (secrets.DEPENDABOT_VERIFICATION_PAT), not the default GITHUB_TOKEN. A
@@ -46,9 +53,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Downloaded outside $GITHUB_WORKSPACE: the checkout step below runs
-      # `git clean -ffdx` after checkout, which would otherwise delete this
-      # untracked download.
       - name: Download the regenerated file, if one was produced
         uses: actions/download-artifact@v7
         with:
@@ -80,21 +84,22 @@ jobs:
             exit 1
           fi
 
-      - name: Check out the Dependabot branch
-        if: steps.gate.outputs.has_artifact == 'true'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-          token: ${{ secrets.DEPENDABOT_VERIFICATION_PAT }}
-
-      - name: Apply and push the regenerated file
+      - name: Push the regenerated file through the Contents API
         if: steps.gate.outputs.has_artifact == 'true'
         env:
+          PAT: ${{ secrets.DEPENDABOT_VERIFICATION_PAT }}
+          REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
           ARTIFACT_DIR: ${{ runner.temp }}/dependabot-verification-metadata
+          FILE_PATH: gradle/verification-metadata.xml
         run: |
           set -euo pipefail
+
+          AUTH_HEADER="Authorization: Bearer $PAT"
+          ACCEPT_HEADER="Accept: application/vnd.github+json"
+          VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
+          API="https://api.github.com/repos/$REPO"
 
           # The file was regenerated against workflow_run.head_sha. If the
           # branch's current tip is a different commit, something pushed to
@@ -102,21 +107,35 @@ jobs:
           # round of this same automation); abandon this round rather than
           # overwrite work the stale artifact knows nothing about. Whatever
           # moved the branch triggers a fresh pair of runs on its own.
-          CURRENT_SHA="$(git rev-parse HEAD)"
+          CURRENT_SHA="$(curl -sf -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+            "$API/git/ref/heads/$HEAD_BRANCH" | jq -r '.object.sha')"
           if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
             echo "::warning::$HEAD_BRANCH moved (was $EXPECTED_SHA, now $CURRENT_SHA) since the file was generated; skipping this stale regeneration."
             exit 0
           fi
 
-          cp "$ARTIFACT_DIR/verification-metadata.xml" gradle/verification-metadata.xml
+          # Read the file's current blob sha and content at that same tip.
+          # Reading it through the API, rather than a checkout, is what
+          # keeps this job from ever materializing the rest of the
+          # (untrusted) branch under the PAT.
+          EXISTING="$(curl -sf -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+            "$API/contents/$FILE_PATH?ref=$EXPECTED_SHA")"
+          EXISTING_SHA="$(echo "$EXISTING" | jq -r '.sha')"
 
-          if git diff --quiet -- gradle/verification-metadata.xml; then
-            echo "Working tree already matches the regenerated file; nothing to commit."
+          if echo "$EXISTING" | jq -r '.content' | base64 -d | cmp -s - "$ARTIFACT_DIR/verification-metadata.xml"; then
+            echo "$FILE_PATH already matches the regenerated file; nothing to commit."
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add gradle/verification-metadata.xml
-          git commit -m "Regenerate gradle/verification-metadata.xml for this Dependabot bump"
-          git push origin "HEAD:refs/heads/$HEAD_BRANCH"
+          CONTENT_B64="$(base64 -w0 "$ARTIFACT_DIR/verification-metadata.xml")"
+          BODY="$(jq -n \
+            --arg message "Regenerate gradle/verification-metadata.xml for this Dependabot bump" \
+            --arg content "$CONTENT_B64" \
+            --arg sha "$EXISTING_SHA" \
+            --arg branch "$HEAD_BRANCH" \
+            '{message: $message, content: $content, sha: $sha, branch: $branch,
+              committer: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com"},
+              author: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com"}}')"
+
+          curl -sf -X PUT -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+            -d "$BODY" "$API/contents/$FILE_PATH" >/dev/null

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -62,6 +62,7 @@ jobs:
       actions: read
     steps:
       - name: Download the regenerated file, if one was produced
+        id: download
         uses: actions/download-artifact@v7
         with:
           name: dependabot-verification-metadata
@@ -69,6 +70,31 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           path: ${{ runner.temp }}/dependabot-verification-metadata
         continue-on-error: true
+
+      - name: Confirm a failed download really means "no artifact produced"
+        # continue-on-error above means a real failure (a transient API
+        # error, or this job's own permissions regressing again) would
+        # otherwise fall through to "Decide whether there is anything to
+        # push" and get silently reported as a clean no-op, exactly the
+        # failure mode this whole step exists to avoid. Ask the Actions API
+        # directly whether an artifact actually exists for this run: if it
+        # does, the download step's failure was a real problem, not an
+        # empty result, so fail loudly instead of staying silent.
+        if: steps.download.outcome != 'success'
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          COUNT="$(curl -sf -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/artifacts?name=dependabot-verification-metadata" \
+            | jq -r '.total_count')"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::A dependabot-verification-metadata artifact exists for run $RUN_ID, but downloading it failed for some other reason (see the failed 'Download the regenerated file' step's own log above). Failing loudly instead of silently reporting nothing to push."
+            exit 1
+          fi
+          echo "No dependabot-verification-metadata artifact exists for run $RUN_ID (the generate workflow found no dependency-graph change, or its author gate did not pass); nothing to push."
 
       - name: Decide whether there is anything to push
         id: gate

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -52,6 +52,14 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      # download-artifact below pulls from the *generate* workflow's run
+      # (run-id: github.event.workflow_run.id), a different run than this
+      # job's own. actions/download-artifact's docs require an actions:read
+      # token for that cross-run case; a job-level permissions block fully
+      # replaces the workflow-level one for that job rather than merging
+      # with it, so this must be listed explicitly even though the
+      # workflow-level block above does not have it.
+      actions: read
     steps:
       - name: Download the regenerated file, if one was produced
         uses: actions/download-artifact@v7

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -1,0 +1,122 @@
+name: Push regenerated verification metadata (Dependabot)
+
+# Second half of the automation from dependabot-verification-metadata-regen.yml;
+# read that file's header first for the full rationale (issue #842) and why
+# this is split into two workflow files.
+#
+# This workflow never checks out or runs code from the PR: it only downloads
+# the file the other workflow already generated and treats it as inert data
+# to copy into place. Workflow files must live on the base branch to run at
+# all, so what actually executes here is always this reviewed file on main,
+# never anything from a Dependabot branch.
+#
+# The push authenticates with a personal access token
+# (secrets.DEPENDABOT_VERIFICATION_PAT), not the default GITHUB_TOKEN. A
+# GITHUB_TOKEN-authored push never triggers a new workflow run--that is
+# GitHub's own anti-recursion rule for the GITHUB_TOKEN, and it applies here
+# too, not just to the plain `push` event--which would leave the PR's other
+# checks (build.yml, lint.yml, ...) stuck against the pre-regeneration commit
+# forever. That is exactly the manual step issue #842 wants gone: someone
+# would still have to nudge CI by hand. A PAT-authenticated push is
+# indistinguishable from an ordinary human push, so it re-triggers every
+# `pull_request`-triggered workflow normally, with no extra bookkeeping here
+# and nothing that goes stale as new required checks are added later.
+#
+# One-time setup: create a fine-grained personal access token scoped to just
+# this repository with "Contents: Read and write" permission and nothing
+# else, and add it as a repository secret named DEPENDABOT_VERIFICATION_PAT.
+# Until that secret exists, this workflow fails loudly (see "Confirm the push
+# token is configured" below) rather than silently falling back to a token
+# that cannot do the job; regenerate gradle/verification-metadata.xml for
+# Dependabot PRs by hand in the meantime, per gradle/README.md.
+
+on:
+  workflow_run:
+    workflows: ["Regenerate verification metadata for Dependabot PRs"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      # Downloaded outside $GITHUB_WORKSPACE: the checkout step below runs
+      # `git clean -ffdx` after checkout, which would otherwise delete this
+      # untracked download.
+      - name: Download the regenerated file, if one was produced
+        uses: actions/download-artifact@v7
+        with:
+          name: dependabot-verification-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/dependabot-verification-metadata
+        continue-on-error: true
+
+      - name: Decide whether there is anything to push
+        id: gate
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/dependabot-verification-metadata
+        run: |
+          if [ -f "$ARTIFACT_DIR/verification-metadata.xml" ]; then
+            echo "has_artifact=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No regenerated file was uploaded (no dependency-graph change, or the generate workflow's author gate did not pass); nothing to push."
+            echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Confirm the push token is configured
+        if: steps.gate.outputs.has_artifact == 'true'
+        env:
+          PAT: ${{ secrets.DEPENDABOT_VERIFICATION_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::DEPENDABOT_VERIFICATION_PAT is not set. See this workflow's header comment to create it. Until then, regenerate gradle/verification-metadata.xml for Dependabot PRs by hand, per gradle/README.md."
+            exit 1
+          fi
+
+      - name: Check out the Dependabot branch
+        if: steps.gate.outputs.has_artifact == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          token: ${{ secrets.DEPENDABOT_VERIFICATION_PAT }}
+
+      - name: Apply and push the regenerated file
+        if: steps.gate.outputs.has_artifact == 'true'
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          ARTIFACT_DIR: ${{ runner.temp }}/dependabot-verification-metadata
+        run: |
+          set -euo pipefail
+
+          # The file was regenerated against workflow_run.head_sha. If the
+          # branch's current tip is a different commit, something pushed to
+          # it since generation started (a Dependabot rebase, or a second
+          # round of this same automation); abandon this round rather than
+          # overwrite work the stale artifact knows nothing about. Whatever
+          # moved the branch triggers a fresh pair of runs on its own.
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::warning::$HEAD_BRANCH moved (was $EXPECTED_SHA, now $CURRENT_SHA) since the file was generated; skipping this stale regeneration."
+            exit 0
+          fi
+
+          cp "$ARTIFACT_DIR/verification-metadata.xml" gradle/verification-metadata.xml
+
+          if git diff --quiet -- gradle/verification-metadata.xml; then
+            echo "Working tree already matches the regenerated file; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add gradle/verification-metadata.xml
+          git commit -m "Regenerate gradle/verification-metadata.xml for this Dependabot bump"
+          git push origin "HEAD:refs/heads/$HEAD_BRANCH"

--- a/.github/workflows/dependabot-verification-metadata-regen.yml
+++ b/.github/workflows/dependabot-verification-metadata-regen.yml
@@ -1,0 +1,99 @@
+name: Regenerate verification metadata for Dependabot PRs
+
+# Automates the manual step PR #834 flagged and issue #842 asked for: every
+# Dependabot PR that bumps a pin in app/build.gradle.kts moves the dependency
+# graph, so gradle/verification-metadata.xml needs the same regeneration
+# (scripts/regenerate-gradle-verification.sh) any other dependency bump in
+# this repo requires (issue #714), or build.yml's Gradle invocation fails
+# verification. Dependabot cannot run that script itself.
+#
+# This is one half of a two-workflow split; the other half,
+# dependabot-verification-metadata-push.yml, does the actual write. Splitting
+# them means the half with write access never runs code from the PR. This
+# workflow runs on the ordinary `pull_request` trigger, exactly what
+# build.yml already uses for every PR, so it gets the exact same treatment
+# GitHub already forces on Dependabot's own PRs: GITHUB_TOKEN is read-only
+# and no secrets are available (GitHub's own Dependabot-on-Actions security
+# default). It only ever builds and uploads a file for the other workflow to
+# pick up; it never writes to the repository, and permissions below never
+# grant it contents: write. See the push workflow's header for why the write
+# half needs a separate file and a personal access token, and
+# https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+# for the pattern (an untrusted build workflow hands off an artifact to a
+# privileged workflow_run workflow, which never checks out or executes PR
+# code) this split follows.
+#
+# Gated on github.event.pull_request.user.login (the PR's original author,
+# which no later push to the PR can change), not github.actor (who
+# triggered THIS particular event, which a "@dependabot recreate" comment can
+# set to dependabot[bot] on a PR that someone else actually opened and
+# controls). See
+# https://labs.boostsecurity.io/articles/weaponizing-dependabot-pwn-request-at-its-finest
+# for the confused-deputy attack this specifically defends against.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'app/build.gradle.kts'
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+        with:
+          packages: ''
+
+      - name: Pin the SDK components explicitly
+        # Matches regenerate-gradle-toolchain.yml: platform-tools is required
+        # because app/build.gradle.kts resolves adb via
+        # sdkComponents.sdkDirectory + platform-tools/adb.
+        run: sdkmanager --install "build-tools;36.0.0" "platforms;android-35" "platform-tools"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Regenerate gradle/verification-metadata.xml
+        # The committed wrapper is used (GRADLE_BIN defaults to ./gradlew),
+        # unlike the toolchain generator's standalone Gradle: Dependabot is
+        # scoped to app/build.gradle.kts (dependabot.yml, directory "/app"),
+        # never the root build.gradle.kts toolchain pins, so the committed
+        # wrapper is always new enough to run the bumped dependency graph.
+        run: bash scripts/regenerate-gradle-verification.sh
+
+      - name: Check whether regeneration changed anything
+        id: diff
+        run: |
+          if git diff --quiet -- gradle/verification-metadata.xml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No verification-metadata.xml change from this bump; nothing to hand off."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload the regenerated file
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependabot-verification-metadata
+          path: gradle/verification-metadata.xml
+          retention-days: 1

--- a/.github/workflows/dependabot-verification-metadata-regen.yml
+++ b/.github/workflows/dependabot-verification-metadata-regen.yml
@@ -45,7 +45,15 @@ jobs:
   regenerate:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # scripts/regenerate-gradle-verification.sh always sets a fresh mktemp
+    # GRADLE_USER_HOME (so no previously-cached artifact is silently omitted
+    # from the generated file), so this job's build+test invocation is just
+    # as uncached as regenerate-gradle-toolchain.yml's identical call to the
+    # same script. That sibling workflow documents a 20-45 minute cold run
+    # for it and budgets 90 minutes; match that here instead of assuming
+    # this job is faster. Never inherit GitHub's 360-minute default either
+    # (issue #611).
+    timeout-minutes: 90
     steps:
       - name: Check out the PR head
         uses: actions/checkout@v6

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -96,7 +96,7 @@ Any Kotlin, KGP, or Kotlin-compiler bump must check that ceiling **before** it i
 To check it:
 
 1. Read `cliVersion` from `src/defaults.json` in `github/codeql-action`, at the ref `codeql.yml` actually uses (currently `v4`).
-1. Read the Kotlin row of `docs/codeql/reusables/supported-versions-compilers.rst` in `github/codeql`, at tag `codeql-cli/v<cliVersion>`.
+2. Read the Kotlin row of `docs/codeql/reusables/supported-versions-compilers.rst` in `github/codeql`, at tag `codeql-cli/v<cliVersion>`.
 
 The upper bound uses a trailing-`x` wildcard for the patch digit, so `2.4.0x` means "any 2.4.0 patch", that is, everything below 2.4.10.
 Read `2.4.1x` the same way: up to but not including 2.4.20.
@@ -182,7 +182,7 @@ A JDK change has a wider blast radius and is not covered here.
    Do this **before** editing any version, not after a red CI run.
    The watcher's latest comment already carries the ceiling and the newest published KGP, but it does not read the compatibility row, so that part is still yours to do by hand.
 
-1. Edit the versions.
+2. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
    For a Gradle bump the surrounding pins are the ones named in the distribution-pin section above.
    Beyond those, a handful of version literals sit in prose and script headers that no guard reads: the docs URL and the toolchain requirement near the top of this file, the header of `scripts/regenerate-gradle-verification.sh`, and the AGP comment in `.claude/hooks/session-start.sh`.
@@ -198,18 +198,18 @@ A JDK change has a wider blast radius and is not covered here.
    > Every version of this inventory has turned out incomplete when checked against the tree.
    > Treat it as a starting point, search deliberately for the rest, and add what you find.
 
-1. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
+3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    Do not open the PR yet: `build.yml` runs on pull requests, so opening one now spends a full build on a commit that is still half-migrated by design.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
    It rebuilds `verification-metadata.xml` from scratch and then the wrapper matched set, an order chosen so the wrapper step runs under enforcement of the fresh pins, and uploads them as `gradle-toolchain-regenerated`.
    A **failed** run instead uploads `gradle-toolchain-partial-DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
-1. Review the downloaded artifact, then bring the files into the tree, amend them into the step 2 commit, and force-push.
+4. Review the downloaded artifact, then bring the files into the tree, amend them into the step 2 commit, and force-push.
    #774's Step 5 holds the review recipe, but it is written with 9.5.1 literals throughout, so substitute your own version and checksum rather than running its commands as printed.
    Unpack the tarball somewhere outside the working tree: it carries a review-only `metadata-components.txt` whose path inside the archive is the repository root, and which is not gitignored.
    Keep `gradlew` executable, and confirm `git diff` reports no mode change on it; the tarball format exists because `upload-artifact` strips permissions.
 
-1. Open the PR and let `build.yml` validate it end to end.
+5. Open the PR and let `build.yml` validate it end to end.
    `codeql.yml`'s `analyze-kotlin` job is what actually tests the ceiling computed in step 1, but on a pull request it runs only when the diff touches `.kt`, `.kts`, or `.java`, so a Gradle-only bump does not exercise it until the post-merge push to `main`.
    #774 Step 6 also asks for one enforcing run against live registries before merge; note that `build.yml`'s cache falls back through a `restore-keys` prefix, so clearing the branch's own entries is not sufficient on its own to force a cold resolve.
    On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
@@ -219,7 +219,7 @@ A JDK change has a wider blast radius and is not covered here.
    > A re-dispatch is deterministic, so it will reproduce the same pin set unless the task list in `scripts/regenerate-gradle-verification.sh` is what needs extending.
    > Diagnose which of the two you are facing before spending a 20-45 minute run on it.
 
-1. Finish what CI cannot check.
+6. Finish what CI cannot check.
    Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
 
 The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -32,8 +32,9 @@ There are two regeneration modes, and the difference is deliberate:
   That `rm` lives in the workflow rather than in the script for exactly the reason above, and `scripts/test_verification_metadata.sh` check (e) allowlists that one workflow filename for the pattern while failing any other workflow that deletes or moves the file.
 
 Any change that moves the dependency graph, an AGP, Kotlin, Compose, AndroidX, or test-library version bump, a new dependency, or a new plugin, requires regenerating this file **in the same commit**, or the build will fail verification.
-There is no automated dependency bumper in this repo, so the graph only moves on manual, reviewed version changes.
-The scheduled watcher described under "Noticing when a bump becomes available" below reports that a bump may have become possible; it never performs one.
+There is no automated bumper for the toolchain pins (root `build.gradle.kts`, the Gradle wrapper) in this repo, so that graph only moves on manual, reviewed version changes.
+The scheduled watcher described under "Noticing when a bump becomes available" below reports that a toolchain bump may have become possible; it never performs one.
+Dependabot bumps `app/build.gradle.kts` pins on its own schedule instead, and "Automated regeneration for Dependabot PRs" right below covers how this file stays in sync with those.
 
 Requirements, and why they exist:
 
@@ -49,6 +50,23 @@ Requirements, and why they exist:
 
 Contributors on macOS or Windows who only need a local build can pass `--dependency-verification lenient` to downgrade a verification failure to a warning.
 Never commit that flag into CI, and do not commit a file regenerated on a non-Linux machine.
+
+### Automated regeneration for Dependabot PRs (issue #842)
+
+Dependabot (`.github/dependabot.yml`, issue #819) opens PRs that bump pins in `app/build.gradle.kts`, which moves the dependency graph the same as any other bump above, but Dependabot cannot run `scripts/regenerate-gradle-verification.sh` itself.
+`.github/workflows/dependabot-verification-metadata-regen.yml` and `dependabot-verification-metadata-push.yml` do that for it, regenerating the file and pushing the result back onto the Dependabot branch so its PR can go green without a human running the script by hand.
+
+The two are split across separate workflow files so the half with write access never runs code from a Dependabot bump.
+The first runs on the ordinary `pull_request` trigger, the same read-only, secret-less treatment GitHub already forces on Dependabot's own PRs, and only uploads the regenerated file as a build artifact.
+The second, triggered by `workflow_run` once the first completes, downloads that artifact, treats it as inert data, and is the only one of the two ever granted `contents: write`.
+See the two workflows' header comments for the full rationale, including the confused-deputy attack (`github.actor` versus `github.event.pull_request.user.login`) the generate workflow's PR-author gate defends against.
+
+**One-time setup:** the push workflow pushes with a personal access token, not the default `GITHUB_TOKEN`, because a `GITHUB_TOKEN`-authored push never triggers a new workflow run, which would leave the PR's other checks stuck against the pre-regeneration commit forever.
+Create a fine-grained PAT scoped to just this repository with "Contents: Read and write" permission and nothing else, and add it as a repository secret named `DEPENDABOT_VERIFICATION_PAT`.
+Until that secret exists, the push workflow fails loudly rather than silently no-op'ing; regenerate the file for Dependabot PRs by hand in the meantime, the same as for any other bump above.
+
+This automation only ever runs `scripts/regenerate-gradle-verification.sh` in its normal merge mode; it never deletes the file first, and it never touches the toolchain (root `build.gradle.kts`, the Gradle wrapper).
+It has nothing to do with "Performing a toolchain bump" below, which stays entirely manual.
 
 ## `wrapper/gradle-wrapper.properties` -- distribution pin
 
@@ -78,7 +96,7 @@ Any Kotlin, KGP, or Kotlin-compiler bump must check that ceiling **before** it i
 To check it:
 
 1. Read `cliVersion` from `src/defaults.json` in `github/codeql-action`, at the ref `codeql.yml` actually uses (currently `v4`).
-2. Read the Kotlin row of `docs/codeql/reusables/supported-versions-compilers.rst` in `github/codeql`, at tag `codeql-cli/v<cliVersion>`.
+1. Read the Kotlin row of `docs/codeql/reusables/supported-versions-compilers.rst` in `github/codeql`, at tag `codeql-cli/v<cliVersion>`.
 
 The upper bound uses a trailing-`x` wildcard for the patch digit, so `2.4.0x` means "any 2.4.0 patch", that is, everything below 2.4.10.
 Read `2.4.1x` the same way: up to but not including 2.4.20.
@@ -138,7 +156,7 @@ What it deliberately does not do:
   `verification-metadata.xml` pins the build graph, not what ships in the APK, so a scan over it says nothing about the app; every advisory it finds today arrives transitively through Gradle and AGP build tooling, and none through a declared dependency.
   A weekly report of the same few dozen standing build-tool advisories would train everyone to ignore the job, which is the same failure mode as an open issue that is not really actionable.
   The pinned toolchain coordinates are different: a hit there is directly actionable, and is a reason to bump that overrides the standing lack of urgency.
-  App-runtime CVE coverage would be Dependabot over `app/build.gradle.kts`, which is separate work; there is no `.github/dependabot.yml` here today.
+  App-runtime CVE coverage is Dependabot over `app/build.gradle.kts` (`.github/dependabot.yml`, issue #819), which is separate work from this watcher; see "Automated regeneration for Dependabot PRs" above for how those bumps get their `verification-metadata.xml` pins.
   This is also not the repo's general advisory scan: `.github/workflows/dependency-audit.yml` runs `pip-audit` weekly over every hash-pinned Python lock under `scripts/` (issue #804).
   The two do not overlap, and neither subsumes the other; that one watches what CI's own helper scripts import, this one watches the Maven coordinates tied to the pinned toolchain because a hit against them is an argument for a toolchain bump.
 
@@ -164,7 +182,7 @@ A JDK change has a wider blast radius and is not covered here.
    Do this **before** editing any version, not after a red CI run.
    The watcher's latest comment already carries the ceiling and the newest published KGP, but it does not read the compatibility row, so that part is still yours to do by hand.
 
-2. Edit the versions.
+1. Edit the versions.
    The root `build.gradle.kts` holds the KGP buildscript classpath pin, the AGP plugin version, and the Compose plugin version, which moves in lockstep with KGP.
    For a Gradle bump the surrounding pins are the ones named in the distribution-pin section above.
    Beyond those, a handful of version literals sit in prose and script headers that no guard reads: the docs URL and the toolchain requirement near the top of this file, the header of `scripts/regenerate-gradle-verification.sh`, and the AGP comment in `.claude/hooks/session-start.sh`.
@@ -180,18 +198,18 @@ A JDK change has a wider blast radius and is not covered here.
    > Every version of this inventory has turned out incomplete when checked against the tree.
    > Treat it as a starting point, search deliberately for the rest, and add what you find.
 
-3. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
+1. Commit the step 2 edits and push the branch, then dispatch `.github/workflows/regenerate-gradle-toolchain.yml` against it.
    Do not open the PR yet: `build.yml` runs on pull requests, so opening one now spends a full build on a commit that is still half-migrated by design.
    The workflow checks out the pushed tip, not your working tree, so an uncommitted edit is silently regenerated against the old graph.
    It rebuilds `verification-metadata.xml` from scratch and then the wrapper matched set, an order chosen so the wrapper step runs under enforcement of the fresh pins, and uploads them as `gradle-toolchain-regenerated`.
    A **failed** run instead uploads `gradle-toolchain-partial-DO-NOT-COMMIT`, whose metadata Gradle may have written only partly; never amend that one in.
 
-4. Review the downloaded artifact, then bring the files into the tree, amend them into the step 2 commit, and force-push.
+1. Review the downloaded artifact, then bring the files into the tree, amend them into the step 2 commit, and force-push.
    #774's Step 5 holds the review recipe, but it is written with 9.5.1 literals throughout, so substitute your own version and checksum rather than running its commands as printed.
    Unpack the tarball somewhere outside the working tree: it carries a review-only `metadata-components.txt` whose path inside the archive is the repository root, and which is not gitignored.
    Keep `gradlew` executable, and confirm `git diff` reports no mode change on it; the tarball format exists because `upload-artifact` strips permissions.
 
-5. Open the PR and let `build.yml` validate it end to end.
+1. Open the PR and let `build.yml` validate it end to end.
    `codeql.yml`'s `analyze-kotlin` job is what actually tests the ceiling computed in step 1, but on a pull request it runs only when the diff touches `.kt`, `.kts`, or `.java`, so a Gradle-only bump does not exercise it until the post-merge push to `main`.
    #774 Step 6 also asks for one enforcing run against live registries before merge; note that `build.yml`'s cache falls back through a `restore-keys` prefix, so clearing the branch's own entries is not sufficient on its own to force a cold resolve.
    On a verification failure at this stage, re-dispatch the generator and re-amend rather than reaching for the local merge-mode remedy, for the reason given under "Review the diff" above.
@@ -201,7 +219,7 @@ A JDK change has a wider blast radius and is not covered here.
    > A re-dispatch is deterministic, so it will reproduce the same pin set unless the task list in `scripts/regenerate-gradle-verification.sh` is what needs extending.
    > Diagnose which of the two you are facing before spending a 20-45 minute run on it.
 
-6. Finish what CI cannot check.
+1. Finish what CI cannot check.
    Re-paste `.claude/setup-environment.sh` into the web environment if it changed (see `.claude/environment.md`), and after merge install the `dev-build` APK and exercise the overlay once, because the release variant has no runtime coverage anywhere in CI.
 
 The bump lands as one commit, so the version edits and the regenerated pins are never separated.

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -138,6 +138,23 @@ if [ -f "$PUSH_WF" ]; then
     else
         pass "push workflow does not check out the Dependabot branch"
     fi
+
+    # (i) the push job's permissions block grants actions: read. It downloads
+    # an artifact from the *generate* workflow's run (a different run than
+    # its own, via workflow_run.id), which actions/download-artifact's docs
+    # say requires an actions:read-scoped token. A job-level `permissions:`
+    # block fully replaces the workflow-level one rather than merging with
+    # it, so this job would silently have `actions: none` without an
+    # explicit grant here, even though the workflow-level block above does
+    # not need one. Without it, the download 403s, continue-on-error
+    # swallows that, and the job reports a false "nothing to push" on every
+    # run: the exact silent-failure mode this whole automation exists to
+    # avoid.
+    if awk '/^jobs:/{injobs=1} injobs && /^  push:/{inpush=1} inpush && /^  [a-z]/ && !/^  push:/{inpush=0} inpush' "$PUSH_WF" | grep -qE '^[[:space:]]*actions:[[:space:]]*read'; then
+        pass "push job's permissions block grants actions: read"
+    else
+        fail "push job's permissions block is missing actions: read (actions/download-artifact needs it to pull the generate workflow's cross-run artifact; without it the download 403s and continue-on-error silently reports nothing to push, every time)"
+    fi
 fi
 
 echo

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# test_dependabot_verification_metadata_workflows.sh: guard tests for the
+# Dependabot verification-metadata automation added in issue #842.
+#
+# .github/workflows/dependabot-verification-metadata-regen.yml and
+# dependabot-verification-metadata-push.yml are deliberately split so the
+# half with write access never executes code from a Dependabot PR, and the
+# push half authenticates with a dedicated PAT rather than the default
+# GITHUB_TOKEN so the pushed commit actually re-triggers CI (see both
+# workflows' header comments for the full rationale). Both properties are
+# easy to lose in a well-meaning simplification--folding the two workflows
+# back into one `pull_request_target` workflow, or swapping the PAT for
+# `secrets.GITHUB_TOKEN`--without anything else in the repo noticing, since
+# neither mistake breaks the workflow's own YAML validity or its happy-path
+# behavior on the next Dependabot PR (a GITHUB_TOKEN push still succeeds; it
+# just never shows up as a re-triggered check). These checks assert the
+# security- and correctness-relevant shape of both files, not their runtime
+# behavior, which only a live Dependabot PR can exercise (see the manual
+# test-plan items on the PR that added this).
+#
+# Always exits 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GENERATE_WF="$REPO_ROOT/.github/workflows/dependabot-verification-metadata-regen.yml"
+PUSH_WF="$REPO_ROOT/.github/workflows/dependabot-verification-metadata-push.yml"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# (a) both halves exist.
+for f in "$GENERATE_WF" "$PUSH_WF"; do
+    if [ -f "$f" ]; then
+        pass "$(basename "$f") exists"
+    else
+        fail "$(basename "$f") is missing"
+    fi
+done
+
+if [ -f "$GENERATE_WF" ]; then
+    # (b) the untrusted half uses the unprivileged `pull_request` trigger,
+    # never `pull_request_target`, which would execute a Dependabot bump's
+    # dependency graph (a full Gradle build) under a privileged token.
+    if grep -qE '^[[:space:]]*pull_request:' "$GENERATE_WF"; then
+        pass "generate workflow triggers on pull_request"
+    else
+        fail "generate workflow does not trigger on pull_request"
+    fi
+    if grep -q 'pull_request_target' "$GENERATE_WF"; then
+        fail "generate workflow uses pull_request_target (runs PR code under a privileged token; issue #842's two-workflow split exists specifically to avoid this)"
+    else
+        pass "generate workflow does not use pull_request_target"
+    fi
+
+    # (c) gates on the PR's original author (pull_request.user.login), which
+    # a later event on the same PR cannot change, not on github.actor (who
+    # triggered THIS event), which a "@dependabot recreate" comment can set
+    # to dependabot[bot] on a PR someone else actually opened and controls.
+    # See https://labs.boostsecurity.io/articles/weaponizing-dependabot-pwn-request-at-its-finest.
+    if grep -Eq "pull_request\.user\.login[[:space:]]*==[[:space:]]*'dependabot\[bot\]'" "$GENERATE_WF"; then
+        pass "generate workflow gates on pull_request.user.login"
+    else
+        fail "generate workflow does not gate on pull_request.user.login (see the confused-deputy note in its header comment)"
+    fi
+    if grep -Eq "github\.actor[[:space:]]*==[[:space:]]*'dependabot\[bot\]'" "$GENERATE_WF"; then
+        fail "generate workflow trusts github.actor for its dependabot gate (spoofable on a same-repo PR via '@dependabot recreate'; gate on pull_request.user.login instead)"
+    else
+        pass "generate workflow does not gate on github.actor alone"
+    fi
+
+    # (d) stays read-only. Only the push workflow may hold contents: write.
+    if grep -qE '^[[:space:]]*contents:[[:space:]]*write' "$GENERATE_WF"; then
+        fail "generate workflow declares contents: write (it must stay read-only; only the push workflow may write)"
+    else
+        pass "generate workflow declares no contents: write permission"
+    fi
+fi
+
+if [ -f "$PUSH_WF" ]; then
+    # (e) triggers on workflow_run, naming the generate workflow by its
+    # exact `name:`, so the handoff actually wires up.
+    if grep -q 'workflow_run:' "$PUSH_WF"; then
+        pass "push workflow triggers on workflow_run"
+    else
+        fail "push workflow does not trigger on workflow_run"
+    fi
+    GENERATE_NAME="$(sed -n '1s/^name:[[:space:]]*//p' "$GENERATE_WF")"
+    if [ -n "$GENERATE_NAME" ] && grep -qF "$GENERATE_NAME" "$PUSH_WF"; then
+        pass "push workflow's workflow_run names the generate workflow ($GENERATE_NAME)"
+    else
+        fail "push workflow's workflow_run does not name the generate workflow's exact 'name:' ($GENERATE_NAME)"
+    fi
+
+    # (f) the checkout/push step must authenticate with a dedicated PAT
+    # secret, never the default GITHUB_TOKEN. A GITHUB_TOKEN-authored push
+    # never triggers a new workflow run (GitHub's own anti-recursion rule),
+    # which would leave the PR's other checks stuck against the
+    # pre-regeneration commit forever--defeating issue #842's "go green
+    # without a manual step" goal just as surely as never pushing at all.
+    # Anchored to a bare `token:` key (leading whitespace only) so this does
+    # not also match the unrelated `github-token:` input the artifact-download
+    # step legitimately passes secrets.GITHUB_TOKEN to.
+    if grep -qE '^[[:space:]]*token:[[:space:]]*\$\{\{[[:space:]]*secrets\.GITHUB_TOKEN[[:space:]]*\}\}' "$PUSH_WF"; then
+        fail "push workflow authenticates its checkout with secrets.GITHUB_TOKEN (never retriggers CI on the pushed commit; use a dedicated PAT secret instead)"
+    else
+        pass "push workflow's checkout does not authenticate with secrets.GITHUB_TOKEN"
+    fi
+    if grep -q 'secrets\.DEPENDABOT_VERIFICATION_PAT' "$PUSH_WF"; then
+        pass "push workflow references the DEPENDABOT_VERIFICATION_PAT secret"
+    else
+        fail "push workflow does not reference a dedicated PAT secret for its checkout/push"
+    fi
+
+    # (g) refuses to push over a branch that moved since the file it is
+    # about to apply was generated (see that workflow step's own comment).
+    if grep -q 'head_sha' "$PUSH_WF"; then
+        pass "push workflow compares against workflow_run.head_sha before pushing"
+    else
+        fail "push workflow has no staleness check against workflow_run.head_sha"
+    fi
+fi
+
+echo
+echo "test_dependabot_verification_metadata_workflows.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -79,6 +79,22 @@ if [ -f "$GENERATE_WF" ]; then
     else
         pass "generate workflow declares no contents: write permission"
     fi
+
+    # (j) budgets enough time for the uncached Gradle invocation. The
+    # regenerate job runs the identical uncached build+test invocation as
+    # regenerate-gradle-toolchain.yml (both scripts share the same
+    # always-fresh mktemp GRADLE_USER_HOME), and that sibling workflow
+    # documents a 20-45 minute cold run for it while budgeting 90 minutes.
+    # A too-short timeout here does not fail loudly; it cancels a normal
+    # run, which the push workflow's `if: ... == 'success'` gate correctly
+    # declines to act on, so the PR just never goes green, silently
+    # defeating issue #842's whole purpose.
+    TIMEOUT="$(grep -E '^[[:space:]]*timeout-minutes:' "$GENERATE_WF" | head -1 | grep -oE '[0-9]+')"
+    if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" -ge 90 ]; then
+        pass "generate workflow's timeout-minutes ($TIMEOUT) is at least 90, matching regenerate-gradle-toolchain.yml's budget for the identical uncached Gradle invocation"
+    else
+        fail "generate workflow's timeout-minutes (${TIMEOUT:-unset}) is below 90; regenerate-gradle-toolchain.yml documents a 20-45 minute cold run for the identical script, so anything below that risks cancelling a normal run"
+    fi
 fi
 
 if [ -f "$PUSH_WF" ]; then

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -123,6 +123,21 @@ if [ -f "$PUSH_WF" ]; then
     else
         fail "push workflow has no staleness check against workflow_run.head_sha"
     fi
+
+    # (h) never checks out the Dependabot branch. An earlier revision used
+    # actions/checkout on the branch inside this job, the one job in the
+    # pair holding contents: write, and CodeQL correctly flagged that as
+    # "Checkout of untrusted code in a privileged context": it materialized
+    # the untrusted branch's full tree under the PAT. The fix reads and
+    # writes the single named file through the GitHub Contents API instead,
+    # so nothing here ever checks out PR code. Anchored to a `uses:` step
+    # invocation (leading whitespace only) so this does not also match
+    # prose mentions of actions/checkout, such as this comment's own.
+    if grep -qE '^[[:space:]]*uses:[[:space:]]*actions/checkout' "$PUSH_WF"; then
+        fail "push workflow uses actions/checkout (materializes the untrusted Dependabot branch under the contents:write PAT; write the single file through the Contents API instead)"
+    else
+        pass "push workflow does not check out the Dependabot branch"
+    fi
 fi
 
 echo


### PR DESCRIPTION
🤖 Author

Fixes #842.

Adds a two-workflow pair that runs `scripts/regenerate-gradle-verification.sh` for a Dependabot PR bumping `app/build.gradle.kts` and pushes the result back onto its branch, so the PR can go green without the manual step PR #834's description flagged as follow-on work.

## Design: two workflow files, not one

- `.github/workflows/dependabot-verification-metadata-regen.yml` runs on the ordinary `pull_request` trigger (the same read-only, secret-less treatment GitHub already forces on Dependabot's own PRs), regenerates the file, and uploads it as a build artifact if it changed. It never gets `contents: write`.
- `.github/workflows/dependabot-verification-metadata-push.yml`, triggered by `workflow_run` once the first completes, downloads that artifact, treats it as inert data, and is the only one of the two ever granted `contents: write`.

Splitting them this way means the half with write access never checks out or runs code from the PR: a naive single `pull_request_target` workflow would run a full Gradle build (and any build-time code a bumped dependency ships) under a privileged token. See both files' header comments for the full rationale and links, and https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ for the general pattern.

## Two correctness/security details worth flagging for review

1. **The generate workflow gates on `github.event.pull_request.user.login`, not `github.actor`.** A same-repo `·@·d·ependabot r·ecreate` comment can make `github.actor` read `dependabot[bot]` on a `synchronize` event for a PR someone else actually opened and controls; the PR's original author field cannot be changed that way. See https://labs.boostsecurity.io/articles/weaponizing-dependabot-pwn-request-at-its-finest for the attack this defends against.
2. **The push workflow authenticates with a personal access token, not `GITHUB_TOKEN`.** A `GITHUB_TOKEN`-authored push never triggers a new workflow run (GitHub's own anti-recursion rule), which would leave the PR's other checks (build.yml, lint.yml, ...) stuck against the pre-regeneration commit forever, i.e. the "go green" outcome this issue asks for would never actually happen. A PAT-authenticated push is indistinguishable from an ordinary human push and re-triggers everything normally.

Both points are also encoded as guard checks in the new `scripts/test_dependabot_verification_metadata_workflows.sh`, so a future simplification that reintroduces either mistake fails CI instead of silently regressing.

## Also in this PR

`gradle/README.md` gets a new "Automated regeneration for Dependabot PRs" subsection documenting the one-time PAT setup, plus two small corrections to sentences PR #834's `dependabot.yml` addition left stale ("there is no automated dependency bumper" / "there is no `.github/dependabot.yml` here today").

## Test plan

- [x] `scripts/test_verification_metadata.sh` and the new `scripts/test_dependabot_verification_metadata_workflows.sh` pass locally.
- [x] Both new workflow files parse as valid YAML and pass the repo's hygiene linters (`check-yaml`, `end-of-file-fixer`, `trailing-whitespace-fixer`).
- [ ] **Create a fine-grained personal access token** scoped to just this repository with "Contents: Read and write" permission and nothing else, and add it as a repository secret named `DEPENDABOT_VERIFICATION_PAT`. The push workflow fails loudly (rather than silently no-op'ing) until this exists.
- [ ] After merge, confirm the pair fires correctly against one of the repository's currently-open Dependabot PRs (or the next one opened): the generate workflow runs and uploads an artifact, the push workflow downloads it and pushes a commit, and the PR's other checks re-run and go green on that new commit.

## Follow-up suggestions

- Consider a GitHub App installation token instead of a long-lived PAT, if this pattern gets reused elsewhere; out of scope here since a single fine-grained PAT is proportionate to one repo's one automation.

