### PR TITLE
Raise Dependabot's open-pull-requests-limit and group test-only bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,26 @@
 # Weekly on Monday, offset an hour past dependency-audit.yml's 09:00 UTC
 # Monday cron (which is itself offset from semgrep.yml's 08:00), so the three
 # don't land in the same CI-minute window.
+#
+# open-pull-requests-limit and groups (issue #871): the default limit of 5
+# was fully consumed by test-only bumps (#845 through #849), so no
+# app-runtime bump, the coverage this file exists for, could be proposed
+# until one of those closed. Raising the limit to 10 leaves room for both
+# kinds of bump at once. The test-dependencies group then collapses every
+# test-only bump into a single pull request, so a run of test-only bumps
+# costs one gradle/verification-metadata.xml regeneration instead of one
+# per package; app-runtime dependencies stay ungrouped, so each keeps its
+# own pull request and review.
+#
+# The group patterns cover every testImplementation and
+# androidTestImplementation coordinate in app/build.gradle.kts. The one
+# exception is androidx.compose:compose-bom, declared identically under
+# both androidTestImplementation and the shipping implementation block; it
+# stays ungrouped and travels with the app-runtime Compose bump instead,
+# since grouping it would fold a shipping dependency into the test group.
+# androidx.test* is scoped to the "androidx.test" package prefix, so it
+# does not capture the shipping androidx.core, androidx.lifecycle,
+# androidx.activity, androidx.compose, or androidx.viewpager2 artifacts.
 
 version: 2
 updates:
@@ -41,3 +61,14 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "UTC"
+    open-pull-requests-limit: 10
+    groups:
+      test-dependencies:
+        patterns:
+          - "junit:junit"
+          - "org.mockito*"
+          - "org.robolectric*"
+          - "androidx.test*"
+          - "androidx.compose.ui:ui-test-junit4"
+          - "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+          - "org.json:json"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,25 +32,13 @@
 # Monday cron (which is itself offset from semgrep.yml's 08:00), so the three
 # don't land in the same CI-minute window.
 #
-# open-pull-requests-limit and groups (issue #871): the default limit of 5
-# was fully consumed by test-only bumps (#845 through #849), so no
-# app-runtime bump, the coverage this file exists for, could be proposed
-# until one of those closed. Raising the limit to 10 leaves room for both
-# kinds of bump at once. The test-dependencies group then collapses every
-# test-only bump into a single pull request, so a run of test-only bumps
-# costs one gradle/verification-metadata.xml regeneration instead of one
-# per package; app-runtime dependencies stay ungrouped, so each keeps its
-# own pull request and review.
+# open-pull-requests-limit and groups (issue #871): the default limit of 5 was fully consumed by test-only bumps (#845 through #849), so no app-runtime bump, the coverage this file exists for, could be proposed until one of those closed.
+# Raising the limit to 10 leaves room for both kinds of bump at once.
+# The test-dependencies group then collapses every test-only bump into a single pull request, so a run of test-only bumps costs one gradle/verification-metadata.xml regeneration instead of one per package; app-runtime dependencies stay ungrouped, so each keeps its own pull request and review.
 #
-# The group patterns cover every testImplementation and
-# androidTestImplementation coordinate in app/build.gradle.kts. The one
-# exception is androidx.compose:compose-bom, declared identically under
-# both androidTestImplementation and the shipping implementation block; it
-# stays ungrouped and travels with the app-runtime Compose bump instead,
-# since grouping it would fold a shipping dependency into the test group.
-# androidx.test* is scoped to the "androidx.test" package prefix, so it
-# does not capture the shipping androidx.core, androidx.lifecycle,
-# androidx.activity, androidx.compose, or androidx.viewpager2 artifacts.
+# The group patterns cover every testImplementation and androidTestImplementation coordinate in app/build.gradle.kts.
+# The one exception is androidx.compose:compose-bom, declared identically under both androidTestImplementation and the shipping implementation block; it stays ungrouped and travels with the app-runtime Compose bump instead, since grouping it would fold a shipping dependency into the test group.
+# androidx.test* is scoped to the "androidx.test" package prefix, so it does not capture the shipping androidx.core, androidx.lifecycle, androidx.activity, androidx.compose, or androidx.viewpager2 artifacts.
 
 version: 2
 updates:


### PR DESCRIPTION
Fixes #871.

## Problem

`.github/dependabot.yml` left `open-pull-requests-limit` at its default of 5, and defined no `groups`.
The five open Dependabot PRs (#845-#849) are all test-only bumps, so they fully occupy the default limit and leave no room for any app-runtime bump, the coverage this file exists for.
Ungrouped, each bump also costs its own `gradle/verification-metadata.xml` regeneration run (issue #842, PR #859), and every merge to main re-triggers regeneration on the remaining open branches.

## Change

In the existing `gradle` / `directory: "/app"` entry:

1. Added `open-pull-requests-limit: 10`, leaving room for both test-only and app-runtime bumps at once.
2. Added a `test-dependencies` group covering every `testImplementation` and `androidTestImplementation` coordinate in `app/build.gradle.kts`, so future test-only bumps land as a single PR instead of one per package.
3. Extended the existing header comment to explain both additions, in the file's established style.

## Pattern deviations from the issue's starting point

The issue's suggested patterns are a starting point; two adjustments were needed to satisfy the acceptance criteria (group patterns must match every test coordinate and none of the shipping/debug coordinates):

- Added `"androidx.compose.ui:ui-test-junit4"` as its own exact-match entry. It's an `androidTestImplementation` coordinate the issue's pattern list did not cover; a wildcard like `androidx.compose.ui*` was not an option because that groupId is shared with shipping (`ui`, `ui-graphics`, `ui-tooling-preview` under `implementation`) and debug-only (`ui-tooling`, `ui-test-manifest` under `debugImplementation`) coordinates that must stay out of the group.
- Deliberately left `androidx.compose:compose-bom` out of the group, even though it's also declared under `androidTestImplementation`. The same coordinate, at the same version, is declared under the shipping `implementation` block, so grouping it would fold a shipping dependency into the test-only group. It stays ungrouped and travels with the app-runtime Compose bump instead.

Verified `androidx.test*` does not capture `androidx.core`, `androidx.lifecycle`, `androidx.activity`, `androidx.compose`, or `androidx.viewpager2`, per the issue's explicit constraint.

## Out of scope (per the issue)

- Resolving or dismissing #845-#849 themselves.
- Issue #861 (the `DEPENDABOT_VERIFICATION_PAT` secret), which currently blocks any Dependabot PR from going green.
- Any change to the root `build.gradle.kts` toolchain pins.

## Test plan

- [x] Validated the YAML parses (`yaml.safe_load`) and matches Dependabot v2 shape: `version: 2`, `package-ecosystem: "gradle"`, `directory: "/app"`, and the existing `schedule` block are unchanged.
- [x] Manually cross-checked the group patterns against every dependency coordinate in `app/build.gradle.kts` (see "Pattern deviations" above).
- [ ] Confirm on Dependabot's next scheduled run (Monday 10:00 UTC) that test-only bumps land as a single grouped PR and that the limit increase is honored. This can only be observed once Dependabot actually runs against the new config, which is outside this repo's CI.

