### PR TITLE
Document how to re-run the Dependabot verification-metadata pair

### DIFF
--- a/.claude/rules/github-mention-sanitization.md
+++ b/.claude/rules/github-mention-sanitization.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "**/*"
+---
+
+# GitHub mentions posted by an agent are sanitized
+
+## An agent cannot reliably post an `@` mention
+
+Text an agent posts to GitHub is passed through mention-sanitization before it is stored.
+That filter inserts `U+00B7` (middle dot) characters into anything shaped like an `@` mention, so `@example` is stored as a string that is not a mention.
+
+This applies to issue bodies, issue comments, pull request bodies, and pull request comments.
+It has been observed on comments authored as `claude[bot]` and on comments and pull request bodies authored as the repository owner through the GitHub MCP server, so it is not specific to one identity or one posting path.
+
+The consequence worth remembering is not cosmetic.
+Anything that *acts* on a mention will never see one:
+
+- A bot command surface, such as a `@dependabot` command, receives nothing and does nothing.
+- A request for a human's attention does not notify that person.
+
+Nothing reports an error.
+The stored text looks correct at a glance, because a middle dot is easy to miss, so the failure is silent at both ends.
+PR #874 lost about eight hours to a `@dependabot` command that was never delivered.
+
+## What to do instead
+
+- Prefer a mechanism that does not need a mention at all. Re-running a workflow, or a tool call, is unaffected.
+- When a mention is genuinely required, ask a human to post it, and say plainly why you cannot.
+- Never re-post a failed mention verbatim expecting a different result. Each attempt is sanitized the same way.
+
+## Checking whether this still holds
+
+This behavior is external to the repository and can change without notice.
+To check it, post the mention in any GitHub text field, read the stored text back through the API, and compare it byte for byte with what was sent.
+
+Content committed through git is **not** affected, only text posted through the API.
+That difference is itself the cheapest test: commit a line containing a mention, post the same line as a comment, and compare the two.
+The committed copy is intact whenever the posted copy is not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@
 - If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
 - If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.
 - If bumping the Gradle, AGP, KGP, or Compose-plugin version, read `./gradle/README.md`.
+- If working on a Dependabot PR, or on the `gradle/verification-metadata.xml` regeneration workflows, read `./gradle/README.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,4 @@
 - If scanning for outstanding before-merging requirements (unautomated verification steps or changes outside the repo), or planning automation of such steps, read `./agents/verification_planning.md`.
 - If carrying out the before-merging steps from a Verification Planner report on a PR (as a Verification Agent), read `./agents/pr_verify.md`.
 - If a sub-agent that is delegating work to nested sub-agents via the Agent tool, read `./agents/subagent_delegation.md`.
-- If bumping the Gradle, AGP, KGP, or Compose-plugin version, read `./gradle/README.md`.
-- If working on a Dependabot PR, or on the `gradle/verification-metadata.xml` regeneration workflows, read `./gradle/README.md`.
+- If bumping the Gradle, AGP, KGP, or Compose-plugin version, or working on a Dependabot PR or the `gradle/verification-metadata.xml` regeneration workflows, read `./gradle/README.md`.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -71,27 +71,40 @@ It has nothing to do with "Performing a toolchain bump" below, which stays entir
 #### Re-running the pair on an open PR
 
 Fixing one of these workflows does not retroactively help a PR that is already open.
-The pair only runs again when something triggers it, and the regen artifact expires after a day (`retention-days: 1`), so there is usually nothing left to reuse.
-Three levers exist, and they are not equivalent.
+The pair only runs again when something triggers it.
+Four levers exist, and they are not equivalent.
 
 - **Re-run the regen workflow run**, from the Actions tab or the API `rerun` endpoint.
   This is usually the right one.
-  A re-run keeps the original `pull_request` payload, and the `workflow_run` half is always taken from `main`, so a re-run picks up a newly-fixed push workflow rather than the one that failed.
-  It does need a prior run to still exist.
-- **Comment `@dependabot rebase`** on the PR.
+  Its completion fires a fresh `workflow_run` event, and GitHub requires a `workflow_run` workflow to live on the default branch and always runs that copy, so this is the lever that picks up a push workflow fixed since the failure.
+  It needs a prior regen run to still exist, though not its artifact, which the re-run regenerates.
+- **Re-run the failed push run.** This is the obvious move when the push half is the half that failed, and it does not work.
+  A re-run reuses the original event's `GITHUB_SHA` and `GITHUB_REF`, so it re-executes the push workflow as it stood at that commit, carrying whatever defect the re-run was meant to escape.
+  On #874 the failed run was pinned to `f13db5c`, which predates the #876 fix, so re-running it would have failed identically.
+  It is worth knowing this is a dead end, because it looks like the cheap option: the push job budgets `timeout-minutes: 10` against the regen's 20 to 45.
+- **Comment the `@dependabot` rebase command** on the PR.
   This rebuilds the branch from scratch and re-triggers everything.
-  Read the warning below before reaching for it from an agent session.
+  An agent cannot do this; see the warning below.
 - **Push a commit to the branch**, firing `synchronize`.
-  This works, but Dependabot stops maintaining a PR once a non-Dependabot commit lands on it, so it permanently costs that branch its auto-updates.
-  Prefer either of the other two.
+  This works, and costs the branch Dependabot's automatic rebasing (see the note below).
+  In the case that brings you here, the push half has failed, so no automation commit has landed yet and the branch still has that to lose.
+  Prefer the other levers while it does.
+
+If none of these is open to you, say so and stop.
+Adding `workflow_dispatch` (#878) is the intended fix for that dead end.
 
 > [!WARNING]
-> An agent cannot issue `@dependabot` commands.
-> A comment posted by an agent is passed through mention-sanitization before it reaches GitHub, which injects `U+00B7` (middle dot) characters into the mention: `@dependabot rebase` is posted as `·@·d·ependabot r·ebase`.
-> Dependabot never sees a command and does nothing.
-> Nothing reports an error, and the comment looks correct unless its characters are inspected, so the failure is silent at both ends.
-> A worked example is #874's [comment 5260994286](https://github.com/aunger/gallery-button-for-pixel-camera/pull/874#issuecomment-5260994286), which cost about eight hours before anyone noticed it had not worked.
-> Re-run the regen workflow run instead, or ask a human to post the comment.
+> An agent cannot post the `@dependabot` rebase command, or any other `@` mention.
+> Agent-posted GitHub text is sanitized so that mentions are broken, silently and with no error reported anywhere.
+> See `.claude/rules/github-mention-sanitization.md` for the rule, the evidence behind it, and how to check whether it still holds.
+> #874's [comment 5260994286](https://github.com/aunger/gallery-button-for-pixel-camera/pull/874#issuecomment-5260994286) is the worked example, and it cost about eight hours before anyone noticed it had not worked.
+> Re-run the regen workflow run instead, or ask a human to post the command.
+
+> [!NOTE]
+> Dependabot stops rebasing a PR once a commit it did not author lands on the branch, unless that commit's message carries a skip marker.
+> The push workflow's commit carries none, so every PR this automation succeeds on has already lost automatic rebasing.
+> #883 tracks that.
+> An explicit rebase command still works afterwards; it is the automatic rebasing that is gone.
 
 ## `wrapper/gradle-wrapper.properties` -- distribution pin
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -68,6 +68,31 @@ Until that secret exists, the push workflow fails loudly rather than silently no
 This automation only ever runs `scripts/regenerate-gradle-verification.sh` in its normal merge mode; it never deletes the file first, and it never touches the toolchain (root `build.gradle.kts`, the Gradle wrapper).
 It has nothing to do with "Performing a toolchain bump" below, which stays entirely manual.
 
+#### Re-running the pair on an open PR
+
+Fixing one of these workflows does not retroactively help a PR that is already open.
+The pair only runs again when something triggers it, and the regen artifact expires after a day (`retention-days: 1`), so there is usually nothing left to reuse.
+Three levers exist, and they are not equivalent.
+
+- **Re-run the regen workflow run**, from the Actions tab or the API `rerun` endpoint.
+  This is usually the right one.
+  A re-run keeps the original `pull_request` payload, and the `workflow_run` half is always taken from `main`, so a re-run picks up a newly-fixed push workflow rather than the one that failed.
+  It does need a prior run to still exist.
+- **Comment `@dependabot rebase`** on the PR.
+  This rebuilds the branch from scratch and re-triggers everything.
+  Read the warning below before reaching for it from an agent session.
+- **Push a commit to the branch**, firing `synchronize`.
+  This works, but Dependabot stops maintaining a PR once a non-Dependabot commit lands on it, so it permanently costs that branch its auto-updates.
+  Prefer either of the other two.
+
+> [!WARNING]
+> An agent cannot issue `@dependabot` commands.
+> A comment posted by an agent is passed through mention-sanitization before it reaches GitHub, which injects `U+00B7` (middle dot) characters into the mention: `@dependabot rebase` is posted as `·@·d·ependabot r·ebase`.
+> Dependabot never sees a command and does nothing.
+> Nothing reports an error, and the comment looks correct unless its characters are inspected, so the failure is silent at both ends.
+> A worked example is #874's [comment 5260994286](https://github.com/aunger/gallery-button-for-pixel-camera/pull/874#issuecomment-5260994286), which cost about eight hours before anyone noticed it had not worked.
+> Re-run the regen workflow run instead, or ask a human to post the comment.
+
 ## `wrapper/gradle-wrapper.properties` -- distribution pin
 
 `distributionSha256Sum` pins the Gradle 9.5.1 distribution (`gradle-9.5.1-bin.zip`) to its published SHA-256.


### PR DESCRIPTION
## Problem

Fixing one of the regen/push workflows does not retroactively help a Dependabot PR that is already open.
The pair only runs again when something triggers it, and nothing in the repository recorded how to make that happen.

This cost real time on #874.
#876 landed the push-half fix on `main` at 01:25 UTC, and #874 then sat red until 09:43 UTC, because the first re-trigger attempt was a Dependabot rebase command that was silently mangled before it reached GitHub.

## Change

Adds a "Re-running the pair on an open PR" subsection to `gradle/README.md`, inside the existing "Automated regeneration for Dependabot PRs" section, covering four levers and why they are not equivalent:

- **Re-run the regen workflow run.** Usually the right one. Its completion fires a fresh `workflow_run`, and GitHub always serves such a workflow from the default branch, so this is the lever that picks up a push workflow fixed since the failure.
- **Re-run the failed push run.** Listed because it is the obvious move and it does not work: a re-run reuses the original event's `GITHUB_SHA` and `GITHUB_REF`, re-executing the workflow file as it stood at that commit. #874's failed run was pinned to `f13db5c`, predating the #876 fix.
- **The Dependabot rebase command.** Works, but an agent cannot post it.
- **Push a commit to the branch.** Works, and costs the branch Dependabot's automatic rebasing.

Adds `.claude/rules/github-mention-sanitization.md`.
Text an agent posts to GitHub is sanitized so that anything shaped like an `@` mention is broken, silently and with no error.
That is not a Gradle or Dependabot fact, so it lives as a general rule alongside `github-mcp-authenticate.md`, which has the same "this does not work here, do not do it" shape, with `gradle/README.md` citing it.
The rule records the evidence, which is two identities (`claude[bot]` and the repository owner through the MCP server) across three kinds of text field (a PR comment, an issue comment, and a PR body), and a procedure for checking whether it still holds: content committed through git is not sanitized, only text posted through the API, so committing and posting the same line and comparing them is a direct test.

This PR's own description is a live demonstration. Its first revision said `X is posted as Y`, and both sides were mangled at post time, which destroyed the sentence's meaning.

Also merges the two `AGENTS.md` lines pointing at `gradle/README.md` into one.

## Scope

Documentation only.
No workflow behavior changes here.
The defects documented around are filed separately: #877 (push failures invisible on the PR), #878 (generalize the trigger), #879 (redundant second regen run), #883 (the push commit ends Dependabot's automatic rebasing).

## Test plan

- [x] `scripts/lint/lint.sh --check --only markdown --all` passes.
- [x] All three changed files checked for trailing whitespace, final newline, and the characters `.claude/rules/prose-style.md` prohibits. No non-ASCII character is introduced in any of them; the mangled string is described by codepoint rather than spelled out, which the earlier revision did not do.
