### PR TITLE
Allow the send_later scheduling tool without a permission prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,11 @@
 {
   "effortLevel": "xhigh",
   "alwaysThinkingEnabled": true,
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Problem

`mcp__Claude_Code_Remote__send_later` schedules a message back into the calling session at a future time. Without an allow rule the call prompts, so a session acting without a human in front of it stalls at the prompt rather than doing the thing it scheduled. Nothing reports that it stalled.

This came up while watching #880 on a direct instruction to do so. Every check-in on that PR needed the call, and the re-arm is the only thing that keeps such a loop alive between events.

## What this is, and is not

**It is a harness capability with no in-repo consumer.** A grep of the tree finds no occurrence of `send_later`, `Claude_Code_Remote`, or `claude-code-remote` in any tracked file. Nothing under `agents/` describes self-scheduled check-ins, and this PR does not add anything that does.

**It is not the dev-cycle CI-waiting path, which is documented and routed elsewhere.** `agents/dev_orchestration.md:423` is explicit:

> Do not subscribe to PR events or delay dispatching the Reviewer while waiting for CI; the Monitor loop replaces that pattern.

and `agents/pr_participation.md` tells the Reviewer the same thing from the other side, that the Orchestrator runs the CI Monitor after it exits and it does not need to poll. An earlier revision of this description cited `pr_participation.md` as the justification for project scope. That was wrong: the file says nothing about watching a PR, and its sibling rules the pattern out for the orchestration flow. `scripts/ci_monitor/ci_monitor.py` is how this repository waits on CI, and this permission is not an alternative to it.

What is left is the case that is not the dev cycle at all: a session told directly to watch something and report back later.

## Why project scope rather than `.claude/settings.local.json`

Not because `agents/` calls for it. Because a local rule cannot survive here.

`.claude/settings.local.json` is gitignored (`.gitignore:18`), and these sessions run in ephemeral containers cloned fresh. A rule written there covers exactly one container until it is reclaimed, so the prompt returns on the next session. For a permission whose entire purpose is to stop an unattended session from stalling, a scope that silently lapses on every new session is not a smaller version of the fix, it is the absence of one.

Project scope is also the honest description of the intent: any session in this repository, on any machine, should be able to schedule its own follow-up without a human present to approve it.

If the answer is instead that this behavior should be documented as agent process, that is a different and larger change: something under `agents/` would describe when self-scheduled check-ins are appropriate and how they relate to the Monitor loop, and this permission would then have a real in-tree consumer. This PR does not attempt that, and does not claim to.

## Change

```json
"permissions": {
  "allow": [
    "mcp__Claude_Code_Remote__send_later"
  ]
}
```

One tool, not the whole server. The same server exposes `create_session`, `create_trigger`, and `archive_session`, which are a different risk class and are not granted. `send_later` schedules a message into the session that calls it and does nothing else, so it reaches nothing outside that session. No existing key in the file is touched.

## Scope

Configuration only. No workflow, script, or application change.

## Known limitation

Permission rules match the registered tool name as a literal string. A session that registers the server under a different spelling gets no match, no error, and the prompt back, which is the same silent failure this PR removes arriving by another route. Two spellings for this server have been observed in circulation. Nothing in the repository is the source of truth for the registered name, so a guard test would be circular, and CI cannot check it because CI never runs an agent session.

Filed as #888 rather than left implicit. The unchecked box below is a real gap, not a formality.

## Test plan

- [x] `jq` confirms the file parses and that `effortLevel`, `alwaysThinkingEnabled`, `hooks.SessionStart`, `hooks.PostToolUse`, and `attribution` are present and unmodified.
- [x] `scripts/ci/labels/test_label_by_files.py` passes (56 tests). `AGENTS_PATH_PREFIXES` is `(".claude/",)`, so `.claude/settings.json` self-labels `agents`.
- [x] Trailing whitespace, final newline, conflict markers, and non-ASCII checked on the added lines. The only non-ASCII in the file is the pre-existing `attribution` emoji.
- [x] The tool is registered as exactly `mcp__Claude_Code_Remote__send_later` in two independent sessions.
- [ ] **Not verified:** that the rule actually suppresses the prompt. An agent cannot observe whether a prompt was suppressed, only whether the call succeeded, and it succeeds either way once approved. This needs a human to start a session on this branch and call the tool. See #888.
