### PR TITLE
Keep Dependabot rebasing, regenerate once, and report the push half onto the PR

### DIFF
--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -202,14 +202,23 @@ jobs:
           BODY_FILE="$RUNNER_TEMP/verification-metadata-body.json"
           base64 -w0 "$ARTIFACT_DIR/verification-metadata.xml" | tr -d '\n' > "$B64_FILE"
 
+          # 41898282 is the github-actions[bot] account's own numeric id, and
+          # the ID-prefixed noreply address is what actually links a commit to
+          # that account's profile (issue #864). Without the prefix the commit
+          # renders as an unlinked name and email pair, which defeats the
+          # point of attributing this commit to the automation rather than to
+          # the owner of the PAT it pushes with.
+          BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+
           jq -n \
             --arg message "Regenerate gradle/verification-metadata.xml for this Dependabot bump" \
             --rawfile content "$B64_FILE" \
             --arg sha "$EXISTING_SHA" \
             --arg branch "$HEAD_BRANCH" \
+            --arg bot_email "$BOT_EMAIL" \
             '{message: $message, content: $content, sha: $sha, branch: $branch,
-              committer: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com"},
-              author: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com"}}' \
+              committer: {name: "github-actions[bot]", email: $bot_email},
+              author: {name: "github-actions[bot]", email: $bot_email}}' \
             > "$BODY_FILE"
 
           curl -sf -X PUT -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -274,18 +274,30 @@ jobs:
         # which needs the actions: read already granted above; writing the
         # status needs the statuses: write added alongside it.
         #
-        # Reported when this job did not succeed, and when it acted on an
-        # artifact. A run that found no artifact is the ordinary outcome
+        # Reported whenever this job did not succeed, and whenever the push
+        # step reached a verdict of any kind, which is what a non-empty
+        # `result` means. That covers all four of its outcomes, the two
+        # skips included: #877 names the stale-branch-tip guard among the
+        # modes that must stop being silent, and a skip is exactly the case
+        # where someone is left wondering why no commit arrived.
+        #
+        # The only run that reports nothing is one where the push step never
+        # ran because no artifact was produced. That is the ordinary outcome
         # whenever a bump does not move the dependency graph, and on every
         # non-Dependabot PR touching app/build.gradle.kts, so a status there
-        # would be noise on someone else's PR. The success report is not
+        # would be noise on someone else's PR.
+        #
+        # A skip is reported as success, not failure: nothing went wrong,
+        # and the branch it declined to write to has a fresh pair of runs
+        # coming, or no longer exists. Both may land on a commit the PR no
+        # longer shows, and a deleted branch's commit may be unreachable
+        # altogether; that is handled below and is cheaper than reasoning
+        # here about which SHAs are still visible. The success report is not
         # decoration either: posted to the same context, it clears a failure
         # a previous attempt left on this same commit.
         if: >-
           always()
-          && (job.status != 'success'
-          || steps.push.outputs.result == 'pushed'
-          || steps.push.outputs.result == 'already-current')
+          && (job.status != 'success' || steps.push.outputs.result != '')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -308,11 +320,13 @@ jobs:
 
           if [ "$JOB_STATUS" = "success" ]; then
             STATE="success"
-            if [ "$PUSH_RESULT" = "pushed" ]; then
-              DESCRIPTION="Pushed the regenerated gradle/verification-metadata.xml"
-            else
-              DESCRIPTION="gradle/verification-metadata.xml already matched the regenerated file"
-            fi
+            case "$PUSH_RESULT" in
+              pushed) DESCRIPTION="Pushed the regenerated gradle/verification-metadata.xml" ;;
+              already-current) DESCRIPTION="gradle/verification-metadata.xml already matched the regenerated file" ;;
+              branch-moved) DESCRIPTION="Skipped: the branch moved while the file was being regenerated, so a fresh run follows" ;;
+              branch-gone) DESCRIPTION="Skipped: the branch no longer exists" ;;
+              *) DESCRIPTION="Nothing to push" ;;
+            esac
           else
             STATE="failure"
             # Name the step that actually failed, whichever it was: the
@@ -329,8 +343,12 @@ jobs:
               DESCRIPTION="The regenerated file was not pushed (job $JOB_STATUS)"
             fi
           fi
-          # A commit status description is capped at 140 characters.
-          DESCRIPTION="$(printf '%.140s' "$DESCRIPTION")"
+          # A commit status description is capped at 140 characters. Bash's
+          # substring expansion counts characters rather than bytes under a
+          # UTF-8 locale, so a step name carrying a multi-byte character is
+          # not cut mid-sequence into invalid UTF-8 that jq would then
+          # reject, in the one step whose whole job is to not be silent.
+          DESCRIPTION="${DESCRIPTION:0:140}"
 
           STATUS_BODY="$RUNNER_TEMP/commit-status.json"
           STATUS_RESPONSE="$RUNNER_TEMP/commit-status-response.json"
@@ -353,7 +371,7 @@ jobs:
               echo "::warning::$HEAD_SHA is no longer reachable (HTTP $STATUS_CODE), so the '$STATE' status could not be posted; the pull request or its branch is probably gone."
               ;;
             *)
-              echo "::error::Posting the '$STATE' status on $HEAD_SHA returned HTTP $STATUS_CODE: $(head -c 500 "$STATUS_RESPONSE"). The job's own outcome above is unaffected; only reporting it onto the pull request failed."
+              echo "::error::Posting the '$STATE' status on $HEAD_SHA returned HTTP $STATUS_CODE: $(head -c 500 "$STATUS_RESPONSE"). Whatever the steps above did has already happened, the push included; what failed is reporting it onto the pull request, and this step is what turns the run red."
               exit 1
               ;;
           esac

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -141,8 +141,29 @@ jobs:
           # round of this same automation); abandon this round rather than
           # overwrite work the stale artifact knows nothing about. Whatever
           # moved the branch triggers a fresh pair of runs on its own.
-          CURRENT_SHA="$(curl -sf -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
-            "$API/git/ref/heads/$HEAD_BRANCH" | jq -r '.object.sha')"
+          #
+          # The branch can also be gone by the time this runs: the PR was
+          # closed, or Dependabot recreated the branch mid-flight (issue
+          # #863). That is the same "nothing to push here" situation as a
+          # moved tip, not a fault, so read the status code rather than
+          # running this lookup under `curl -sf`, which would abort the job
+          # under `set -e` and leave a red run carrying no real signal. Any
+          # other non-200 is a genuine API failure and still fails loudly:
+          # treating it as "the branch is gone" would silently drop a
+          # regeneration the PR is waiting on.
+          REF_BODY="$RUNNER_TEMP/branch-ref.json"
+          REF_STATUS="$(curl -s -o "$REF_BODY" -w '%{http_code}' \
+            -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+            "$API/git/ref/heads/$HEAD_BRANCH")"
+          if [ "$REF_STATUS" = "404" ]; then
+            echo "::warning::$HEAD_BRANCH no longer exists (the pull request was closed, or Dependabot recreated the branch) since the file was generated; skipping this regeneration."
+            exit 0
+          fi
+          if [ "$REF_STATUS" != "200" ]; then
+            echo "::error::Looking up $HEAD_BRANCH's tip returned HTTP $REF_STATUS: $(head -c 500 "$REF_BODY")"
+            exit 1
+          fi
+          CURRENT_SHA="$(jq -r '.object.sha' < "$REF_BODY")"
           if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
             echo "::warning::$HEAD_BRANCH moved (was $EXPECTED_SHA, now $CURRENT_SHA) since the file was generated; skipping this stale regeneration."
             exit 0

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -17,6 +17,13 @@ name: Push regenerated verification metadata (Dependabot)
 # base branch to run at all, so what actually executes here is always this
 # reviewed file on main, never anything from a Dependabot branch.
 #
+# The last step writes one more thing through the API: a commit status on
+# the PR's head commit, mirroring this job's outcome onto the PR that
+# triggered it (issue #877). Running on workflow_run means this job's own
+# check runs attach to the base branch, where the PR never shows them, so
+# without that status a failure here is invisible exactly where someone
+# would look for it. It needs no checkout either.
+#
 # The push authenticates with a personal access token
 # (secrets.DEPENDABOT_VERIFICATION_PAT), not the default GITHUB_TOKEN. A
 # GITHUB_TOKEN-authored push never triggers a new workflow run--that is
@@ -60,6 +67,13 @@ jobs:
       # with it, so this must be listed explicitly even though the
       # workflow-level block above does not have it.
       actions: read
+      # "Report this job's outcome onto the pull request" below mirrors the
+      # job's result onto the PR's head commit as a commit status, because
+      # this job's own check run attaches to the base branch where the PR
+      # never shows it (issue #877). Writing a commit status needs no
+      # checkout and no PR code, so it costs this job nothing that the split
+      # in the header comment is protecting.
+      statuses: write
     steps:
       - name: Download the regenerated file, if one was produced
         id: download
@@ -119,6 +133,7 @@ jobs:
           fi
 
       - name: Push the regenerated file through the Contents API
+        id: push
         if: steps.gate.outputs.has_artifact == 'true'
         env:
           PAT: ${{ secrets.DEPENDABOT_VERIFICATION_PAT }}
@@ -156,6 +171,7 @@ jobs:
             -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
             "$API/git/ref/heads/$HEAD_BRANCH")"
           if [ "$REF_STATUS" = "404" ]; then
+            echo "result=branch-gone" >> "$GITHUB_OUTPUT"
             echo "::warning::$HEAD_BRANCH no longer exists (the pull request was closed, or Dependabot recreated the branch) since the file was generated; skipping this regeneration."
             exit 0
           fi
@@ -165,6 +181,7 @@ jobs:
           fi
           CURRENT_SHA="$(jq -r '.object.sha' < "$REF_BODY")"
           if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+            echo "result=branch-moved" >> "$GITHUB_OUTPUT"
             echo "::warning::$HEAD_BRANCH moved (was $EXPECTED_SHA, now $CURRENT_SHA) since the file was generated; skipping this stale regeneration."
             exit 0
           fi
@@ -178,6 +195,7 @@ jobs:
           EXISTING_SHA="$(echo "$EXISTING" | jq -r '.sha')"
 
           if echo "$EXISTING" | jq -r '.content' | base64 -d | cmp -s - "$ARTIFACT_DIR/verification-metadata.xml"; then
+            echo "result=already-current" >> "$GITHUB_OUTPUT"
             echo "$FILE_PATH already matches the regenerated file; nothing to commit."
             exit 0
           fi
@@ -236,3 +254,106 @@ jobs:
 
           curl -sf -X PUT -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
             --data-binary @"$BODY_FILE" "$API/contents/$FILE_PATH" >/dev/null
+
+          echo "result=pushed" >> "$GITHUB_OUTPUT"
+
+      - name: Report this job's outcome onto the pull request
+        # This workflow runs on workflow_run, so it executes in the base
+        # branch's context and its check runs attach to that branch, not to
+        # the PR's head SHA. The PR therefore shows no trace of this job at
+        # all: when the push half fails, the PR looks exactly as it would if
+        # the automation had never been wired up, and #875 went fourteen
+        # hours before anyone thought to look in the Actions tab (issue
+        # #877). Mirror the outcome onto the head commit as a commit status,
+        # which the PR does display, naming the step that failed and linking
+        # this run.
+        #
+        # workflow_run.head_sha is the PR branch's tip, already relied on by
+        # the push step above, so nothing is checked out and no PR code runs
+        # to obtain it. Naming the failed step reads this run's own jobs,
+        # which needs the actions: read already granted above; writing the
+        # status needs the statuses: write added alongside it.
+        #
+        # Reported when this job did not succeed, and when it acted on an
+        # artifact. A run that found no artifact is the ordinary outcome
+        # whenever a bump does not move the dependency graph, and on every
+        # non-Dependabot PR touching app/build.gradle.kts, so a status there
+        # would be noise on someone else's PR. The success report is not
+        # decoration either: posted to the same context, it clears a failure
+        # a previous attempt left on this same commit.
+        if: >-
+          always()
+          && (job.status != 'success'
+          || steps.push.outputs.result == 'pushed'
+          || steps.push.outputs.result == 'already-current')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          JOB_STATUS: ${{ job.status }}
+          PUSH_RESULT: ${{ steps.push.outputs.result }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # No `set -e`: every failure below is handled explicitly, so that
+          # reporting cannot itself turn a completed push into a red run
+          # without saying why.
+          set -uo pipefail
+
+          AUTH_HEADER="Authorization: Bearer $GH_TOKEN"
+          ACCEPT_HEADER="Accept: application/vnd.github+json"
+          VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
+          API="https://api.github.com/repos/$REPO"
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            STATE="success"
+            if [ "$PUSH_RESULT" = "pushed" ]; then
+              DESCRIPTION="Pushed the regenerated gradle/verification-metadata.xml"
+            else
+              DESCRIPTION="gradle/verification-metadata.xml already matched the regenerated file"
+            fi
+          else
+            STATE="failure"
+            # Name the step that actually failed, whichever it was: the
+            # missing-PAT guard, the artifact confirmation, the push itself,
+            # or a cancellation. Reading it from the run's own jobs keeps
+            # this out of the business of enumerating failure modes, so a
+            # step added later is covered without touching this one.
+            FAILED_STEP="$(curl -sf -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+              "$API/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
+              | jq -r 'first(.jobs[]?.steps[]? | select(.conclusion == "failure") | .name) // empty')"
+            if [ -n "$FAILED_STEP" ]; then
+              DESCRIPTION="Failed at: $FAILED_STEP"
+            else
+              DESCRIPTION="The regenerated file was not pushed (job $JOB_STATUS)"
+            fi
+          fi
+          # A commit status description is capped at 140 characters.
+          DESCRIPTION="$(printf '%.140s' "$DESCRIPTION")"
+
+          STATUS_BODY="$RUNNER_TEMP/commit-status.json"
+          STATUS_RESPONSE="$RUNNER_TEMP/commit-status-response.json"
+          jq -n \
+            --arg state "$STATE" \
+            --arg description "$DESCRIPTION" \
+            --arg target_url "$RUN_URL" \
+            '{state: $state, description: $description, target_url: $target_url,
+              context: "Dependabot verification-metadata push"}' \
+            > "$STATUS_BODY"
+
+          STATUS_CODE="$(curl -s -o "$STATUS_RESPONSE" -w '%{http_code}' -X POST \
+            -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" -H "$VERSION_HEADER" \
+            --data-binary @"$STATUS_BODY" "$API/statuses/$HEAD_SHA")"
+          case "$STATUS_CODE" in
+            2*)
+              echo "Reported $STATE on $HEAD_SHA: $DESCRIPTION"
+              ;;
+            404 | 422)
+              echo "::warning::$HEAD_SHA is no longer reachable (HTTP $STATUS_CODE), so the '$STATE' status could not be posted; the pull request or its branch is probably gone."
+              ;;
+            *)
+              echo "::error::Posting the '$STATE' status on $HEAD_SHA returned HTTP $STATUS_CODE: $(head -c 500 "$STATUS_RESPONSE"). The job's own outcome above is unaffected; only reporting it onto the pull request failed."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/dependabot-verification-metadata-push.yml
+++ b/.github/workflows/dependabot-verification-metadata-push.yml
@@ -210,8 +210,21 @@ jobs:
           # the owner of the PAT it pushes with.
           BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Dependabot stops rebasing a pull request once a commit it did not
+          # author lands on the branch, unless that commit's message carries
+          # one of its skip markers ([dependabot skip], [skip dependabot],
+          # [dependabot-skip] or [skip-dependabot], in either case). Without
+          # one, this automation silently ends Dependabot's maintenance of
+          # every branch it succeeds on, which matters most for a grouped bump
+          # left open across other merges: exactly the pull request most
+          # likely to need a rebase (issue #883). Keep the marker on its own
+          # trailer line; deleting it is not a cosmetic edit to the message.
+          COMMIT_MESSAGE="$(printf '%s\n\n%s\n' \
+            "Regenerate gradle/verification-metadata.xml for this Dependabot bump" \
+            "[dependabot skip]")"
+
           jq -n \
-            --arg message "Regenerate gradle/verification-metadata.xml for this Dependabot bump" \
+            --arg message "$COMMIT_MESSAGE" \
             --rawfile content "$B64_FILE" \
             --arg sha "$EXISTING_SHA" \
             --arg branch "$HEAD_BRANCH" \

--- a/.github/workflows/dependabot-verification-metadata-regen.yml
+++ b/.github/workflows/dependabot-verification-metadata-regen.yml
@@ -42,8 +42,85 @@ permissions:
   contents: read
 
 jobs:
-  regenerate:
+  # A cheap gate in front of the expensive job below (issue #879).
+  #
+  # The push half's metadata commit is itself a push to the PR head, so it
+  # fires `synchronize` and matches the path filter above, which GitHub
+  # evaluates against the PR's whole base-to-head diff rather than against
+  # the new commit alone. Ungated, every Dependabot PR therefore pays a
+  # second full regeneration whose result cannot differ from the first: the
+  # file it would regenerate is the one that commit just landed, generated
+  # against that commit's own parent. On #874 that was 7.5 wasted minutes on
+  # a warm cache, and this job is uncached by design (see the timeout note
+  # below), so a cold one costs proportionally more.
+  #
+  # The discriminator is what the head commit *does*, not who it claims to be
+  # from: a commit whose entire diff is gradle/verification-metadata.xml
+  # cannot have moved the dependency graph, so regenerating against it
+  # reproduces the file already on the branch. Keying on the committer
+  # identity instead would have tied this gate to the exact email string the
+  # push half writes, which issue #864 was changing in the same breath.
+  #
+  # Skipping wrongly costs far more than the run it saves: it leaves a
+  # Dependabot PR red with stale metadata and no automated way back. So every
+  # uncertain answer regenerates, and the only state that still reaches a
+  # wrong skip is a commit pushed by hand whose entire diff is
+  # gradle/verification-metadata.xml and whose contents were not generated
+  # from this branch's graph. Nothing in this repository produces it,
+  # Dependabot's own pushes always carry app/build.gradle.kts, and the way
+  # out is the by-hand regeneration gradle/README.md already documents.
+  triage:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      needs_regen: ${{ steps.head_commit.outputs.needs_regen }}
+    steps:
+      - name: Check whether the head commit only carries regenerated metadata
+        id: head_commit
+        # Asks the API what the head commit changed rather than checking the
+        # branch out, so this job runs no code from the PR either.
+        #
+        # Every uncertain answer regenerates. This gate is an optimization,
+        # and the behavior it optimizes away was correct, so an unreachable
+        # API or a payload without a usable file list falls back to it rather
+        # than blocking the PR on a transient error or, worse, guessing that
+        # nothing needs doing.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FILE_PATH: gradle/verification-metadata.xml
+        run: |
+          set -uo pipefail
+          COMMIT_BODY="$RUNNER_TEMP/head-commit.json"
+          if ! curl -sf -o "$COMMIT_BODY" -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPO/commits/$HEAD_SHA"; then
+            echo "needs_regen=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not read $HEAD_SHA from the commits API, so what it changes is unknown; regenerating rather than assuming there is nothing to do."
+            exit 0
+          fi
+          # An absent or unusable file list yields an empty string, which
+          # never equals $FILE_PATH and so regenerates.
+          CHANGED="$(jq -r 'if (.files | type) == "array" then (.files | map(.filename) | sort | join("\n")) else "" end' \
+            "$COMMIT_BODY")"
+          if [ "$CHANGED" = "$FILE_PATH" ]; then
+            echo "needs_regen=false" >> "$GITHUB_OUTPUT"
+            echo "$HEAD_SHA changes $FILE_PATH and nothing else, so it is this automation's own metadata commit; regenerating against it would reproduce the file it already carries. Skipping."
+          else
+            echo "needs_regen=true" >> "$GITHUB_OUTPUT"
+            echo "$HEAD_SHA changes more than $FILE_PATH, so the dependency graph may have moved; regenerating."
+          fi
+
+  regenerate:
+    needs: [triage]
+    # The author gate is repeated here rather than left to `needs` alone: it
+    # is the confused-deputy defense described in this file's header, and it
+    # should not be one edit to the job graph away from disappearing.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && needs.triage.outputs.needs_regen == 'true'
     runs-on: ubuntu-latest
     # scripts/regenerate-gradle-verification.sh always sets a fresh mktemp
     # GRADLE_USER_HOME (so no previously-cached artifact is silently omitted

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -79,6 +79,10 @@ It asks the API what the head commit changed, and skips the regeneration when th
 The discriminator is what the commit does rather than who it says it is from: a commit with that diff cannot have moved the dependency graph, and keying on the committer identity would have tied the gate to the exact email string the push half writes.
 Triage checks nothing out, so the regen half's read-only, no-secrets posture is unchanged.
 
+"Once per push" is the claim, not "once per PR".
+A Dependabot rebase force-pushes the branch, which discards the metadata commit and earns a fresh full regeneration, and the `[dependabot skip]` marker in the section below is what keeps those rebases happening.
+That is the intended trade (a branch that rebases and regenerates beats one that silently goes stale), but it does mean a long-lived PR can regenerate several times.
+
 A regen wrongly skipped is much worse than the run it saves, since it leaves a PR red with stale metadata.
 Every uncertain answer therefore regenerates: an unreachable commits API, or a payload with no usable file list, warns and falls back to the behavior this gate optimizes away, which was correct all along.
 The one state that still reaches a wrong skip is a commit pushed by hand whose entire diff is `gradle/verification-metadata.xml`, carrying contents not generated from that branch's graph.
@@ -128,6 +132,9 @@ Four levers exist, and they are not equivalent.
   This is usually the right one.
   Its completion fires a fresh `workflow_run` event, and GitHub requires a `workflow_run` workflow to live on the default branch and always runs that copy, so this is the lever that picks up a push workflow fixed since the failure.
   It needs a prior regen run to still exist, though not its artifact, which the re-run regenerates.
+  It does nothing, however, when the PR's head is already a metadata commit, because triage skips it (see "Regenerating once per Dependabot push" above).
+  That is the case where the push half already succeeded and you want a *fresh* regeneration, rather than the case where it failed and never landed anything.
+  Reach for the last lever below then, and give the commit a real change in it.
 - **Re-run the failed push run.** This is the obvious move when the push half is the half that failed, and it does not work.
   A re-run reuses the original event's `GITHUB_SHA` and `GITHUB_REF`, so it re-executes the push workflow as it stood at that commit, carrying whatever defect the re-run was meant to escape.
   On #874 the failed run was pinned to `f13db5c`, which predates the #876 fix, so re-running it would have failed identically.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -68,6 +68,20 @@ Until that secret exists, the push workflow fails loudly rather than silently no
 This automation only ever runs `scripts/regenerate-gradle-verification.sh` in its normal merge mode; it never deletes the file first, and it never touches the toolchain (root `build.gradle.kts`, the Gradle wrapper).
 It has nothing to do with "Performing a toolchain bump" below, which stays entirely manual.
 
+#### Keeping Dependabot rebasing the branch (issue #883)
+
+Dependabot stops rebasing a pull request once a commit it did not author lands on the branch, unless that commit's message carries one of its skip markers.
+[GitHub's documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates) names four, in either case: `[dependabot skip]`, `[skip dependabot]`, `[dependabot-skip]` and `[skip-dependabot]`.
+
+The push workflow's commit message therefore ends with a `[dependabot skip]` trailer.
+Without it, the automation built to help these pull requests would silently end Dependabot's maintenance of every branch it succeeds on.
+What that costs is automatic rebasing in the window between the metadata commit landing and the pull request merging, which is worst for a grouped bump left open across other merges: exactly the pull request most likely to need a rebase.
+An explicit rebase command still works either way; it is the automatic rebasing that is lost.
+
+That trailer is not a cosmetic part of the message.
+`scripts/test_dependabot_verification_metadata_workflows.sh` asserts a marker is present in the request body the push step assembles, so dropping it fails the `shell-tests` job rather than going unnoticed until a branch quietly goes stale.
+Any commit pushed onto a Dependabot branch by hand needs the same marker for the same reason.
+
 #### Re-running the pair on an open PR
 
 Fixing one of these workflows does not retroactively help a PR that is already open.
@@ -86,9 +100,8 @@ Four levers exist, and they are not equivalent.
   This rebuilds the branch from scratch and re-triggers everything.
   An agent cannot do this; see the warning below.
 - **Push a commit to the branch**, firing `synchronize`.
-  This works, and costs the branch Dependabot's automatic rebasing (see the note below).
-  In the case that brings you here, the push half has failed, so no automation commit has landed yet and the branch still has that to lose.
-  Prefer the other levers while it does.
+  This works.
+  Give the commit message a `[dependabot skip]` trailer, or the branch loses Dependabot's automatic rebasing (see "Keeping Dependabot rebasing the branch" above).
 
 If none of these is open to you, say so and stop.
 Adding `workflow_dispatch` (#878) is the intended fix for that dead end.
@@ -99,12 +112,6 @@ Adding `workflow_dispatch` (#878) is the intended fix for that dead end.
 > See `.claude/rules/github-mention-sanitization.md` for the rule, the evidence behind it, and how to check whether it still holds.
 > #874's [comment 5260994286](https://github.com/aunger/gallery-button-for-pixel-camera/pull/874#issuecomment-5260994286) is the worked example, and it cost about eight hours before anyone noticed it had not worked.
 > Re-run the regen workflow run instead, or ask a human to post the command.
-
-> [!NOTE]
-> Dependabot stops rebasing a PR once a commit it did not author lands on the branch, unless that commit's message carries a skip marker.
-> The push workflow's commit carries none, so every PR this automation succeeds on has already lost automatic rebasing.
-> #883 tracks that.
-> An explicit rebase command still works afterwards; it is the automatic rebasing that is gone.
 
 ## `wrapper/gradle-wrapper.properties` -- distribution pin
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -68,6 +68,19 @@ Until that secret exists, the push workflow fails loudly rather than silently no
 This automation only ever runs `scripts/regenerate-gradle-verification.sh` in its normal merge mode; it never deletes the file first, and it never touches the toolchain (root `build.gradle.kts`, the Gradle wrapper).
 It has nothing to do with "Performing a toolchain bump" below, which stays entirely manual.
 
+#### Where the pair reports (issue #877)
+
+The regen half runs on `pull_request`, so its `regenerate` job appears in the PR's own checks list.
+The push half runs on `workflow_run`, which executes in the base branch's context, so its check runs attach to `main` and the PR shows no trace of them.
+That asymmetry once cost fourteen hours on #874: `build-and-test` was red for dependency verification and nothing on the PR pointed at the workflow that was supposed to have fixed it.
+
+The push job's last step therefore writes a commit status onto the PR's head SHA, named "Dependabot verification-metadata push", whose description names the step that failed and whose link goes to the run.
+It reports every unsuccessful outcome, cancellations included, because it reads which step failed from the run's own jobs rather than enumerating failure modes one by one.
+It also reports success, to the same status context, which is what clears a failure an earlier attempt left on that same commit.
+A run that found no artifact to push reports nothing at all: that is the ordinary outcome whenever a bump does not move the dependency graph, and on any non-Dependabot PR touching `app/build.gradle.kts`, where a status would just be noise on someone else's PR.
+
+Writing a commit status needs `statuses: write` and no checkout, so the property the two-workflow split exists for is untouched: the half holding write credentials still never materializes the Dependabot branch.
+
 #### Keeping Dependabot rebasing the branch (issue #883)
 
 Dependabot stops rebasing a pull request once a commit it did not author lands on the branch, unless that commit's message carries one of its skip markers.

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -91,10 +91,16 @@ The regen half runs on `pull_request`, so its `regenerate` job appears in the PR
 The push half runs on `workflow_run`, which executes in the base branch's context, so its check runs attach to `main` and the PR shows no trace of them.
 That asymmetry once cost fourteen hours on #874: `build-and-test` was red for dependency verification and nothing on the PR pointed at the workflow that was supposed to have fixed it.
 
-The push job's last step therefore writes a commit status onto the PR's head SHA, named "Dependabot verification-metadata push", whose description names the step that failed and whose link goes to the run.
+The push job's last step therefore writes a commit status onto the PR's head SHA, named "Dependabot verification-metadata push", whose description names the outcome and whose link goes to the run.
 It reports every unsuccessful outcome, cancellations included, because it reads which step failed from the run's own jobs rather than enumerating failure modes one by one.
-It also reports success, to the same status context, which is what clears a failure an earlier attempt left on that same commit.
-A run that found no artifact to push reports nothing at all: that is the ordinary outcome whenever a bump does not move the dependency graph, and on any non-Dependabot PR touching `app/build.gradle.kts`, where a status would just be noise on someone else's PR.
+It reports the successful ones too, to the same status context, which is also what clears a failure an earlier attempt left on that same commit: the file was pushed, it already matched, the branch moved during regeneration, or the branch is gone.
+The last two are skips rather than failures, so they are reported green, saying which skip it was.
+
+One run reports nothing: the one where no artifact was produced, so the push step never ran and reached no verdict.
+That is the ordinary outcome whenever a bump does not move the dependency graph, and on any non-Dependabot PR touching `app/build.gradle.kts`, where a status would just be noise on someone else's PR.
+
+A status can land on a commit the PR no longer displays, since both skips mean the head has moved on, and a deleted branch's commit may be unreachable altogether.
+The step treats a 404 or 422 from the status API as a warning rather than an error for that reason, instead of trying to work out in advance which SHAs are still visible.
 
 Writing a commit status needs `statuses: write` and no checkout, so the property the two-workflow split exists for is untouched: the half holding write credentials still never materializes the Dependabot branch.
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -68,6 +68,23 @@ Until that secret exists, the push workflow fails loudly rather than silently no
 This automation only ever runs `scripts/regenerate-gradle-verification.sh` in its normal merge mode; it never deletes the file first, and it never touches the toolchain (root `build.gradle.kts`, the Gradle wrapper).
 It has nothing to do with "Performing a toolchain bump" below, which stays entirely manual.
 
+#### Regenerating once per Dependabot push (issue #879)
+
+The push half's metadata commit is a push to the PR head, so it fires `synchronize` and re-triggers the regen half.
+The path filter does not stop it: GitHub evaluates `paths` against the PR's whole base-to-head diff, and `app/build.gradle.kts` is still in it.
+Left alone, that bought a second full regeneration on every Dependabot PR whose result could not differ from the first, since the file it regenerates is the one that commit just landed, generated against that commit's own parent.
+
+The regen workflow's `triage` job cuts it off.
+It asks the API what the head commit changed, and skips the regeneration when the answer is `gradle/verification-metadata.xml` and nothing else.
+The discriminator is what the commit does rather than who it says it is from: a commit with that diff cannot have moved the dependency graph, and keying on the committer identity would have tied the gate to the exact email string the push half writes.
+Triage checks nothing out, so the regen half's read-only, no-secrets posture is unchanged.
+
+A regen wrongly skipped is much worse than the run it saves, since it leaves a PR red with stale metadata.
+Every uncertain answer therefore regenerates: an unreachable commits API, or a payload with no usable file list, warns and falls back to the behavior this gate optimizes away, which was correct all along.
+The one state that still reaches a wrong skip is a commit pushed by hand whose entire diff is `gradle/verification-metadata.xml`, carrying contents not generated from that branch's graph.
+Nothing here produces that: Dependabot's own pushes always carry `app/build.gradle.kts`, and the push half only ever commits a file it generated against the very commit it is committing onto.
+If you do hit it, regenerate by hand as for any other bump; re-running the regen workflow will take the same skip.
+
 #### Where the pair reports (issue #877)
 
 The regen half runs on `pull_request`, so its `regenerate` job appears in the PR's own checks list.
@@ -115,6 +132,7 @@ Four levers exist, and they are not equivalent.
 - **Push a commit to the branch**, firing `synchronize`.
   This works.
   Give the commit message a `[dependabot skip]` trailer, or the branch loses Dependabot's automatic rebasing (see "Keeping Dependabot rebasing the branch" above).
+  Change something other than `gradle/verification-metadata.xml` too, or the triage job takes the commit for this automation's own and skips the regeneration (see "Regenerating once per Dependabot push" above).
 
 If none of these is open to you, say so and stop.
 Adding `workflow_dispatch` (#878) is the intended fix for that dead end.

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -258,7 +258,12 @@ run_text = step["run"]
 # scripts/test_dependabot_verification_metadata_workflows.sh (issue #875).
 # Records every invocation's argv so the test can inspect the real push
 # request, and answers the two GET calls the push step makes before it,
-# without any real network access.
+# without any real network access. It honours -o (write the body to a file
+# instead of stdout), -w (append the write-out format, with %{http_code}
+# substituted) and the -f family (exit 22 on a >=400 status), so a step that
+# reads the status code itself is exercised the same way curl would exercise
+# it. MOCK_REF_STATUS drives the branch-tip lookup's status code (issue
+# #863).
 MOCK_CURL = textwrap.dedent(
     """\
     #!/usr/bin/env python3
@@ -273,19 +278,46 @@ MOCK_CURL = textwrap.dedent(
     with open(call_path, "w") as f:
         json.dump(args, f)
 
+    out_path = None
+    write_out = None
+    for i, a in enumerate(args):
+        if a == "-o" and i + 1 < len(args):
+            out_path = args[i + 1]
+        elif a == "-w" and i + 1 < len(args):
+            write_out = args[i + 1]
+
     url = args[-1] if args else ""
+    status = "200"
     if "/git/ref/heads/" in url:
-        print(json.dumps({"object": {"sha": os.environ["MOCK_EXPECTED_SHA"]}}))
+        status = os.environ.get("MOCK_REF_STATUS", "200")
+        if status == "200":
+            body = json.dumps({"object": {"sha": os.environ["MOCK_EXPECTED_SHA"]}})
+        else:
+            body = json.dumps({"message": "mock curl: answering HTTP " + status})
     elif "?ref=" in url:
-        print(json.dumps({
+        body = json.dumps({
             "sha": os.environ["MOCK_EXISTING_BLOB_SHA"],
             "content": os.environ["MOCK_EXISTING_CONTENT_B64"],
-        }))
+        })
     elif "/contents/" in url:
-        print(json.dumps({"content": {"sha": "0" * 40}}))
+        body = json.dumps({"content": {"sha": "0" * 40}})
     else:
         sys.stderr.write("mock curl: unrecognized URL: {}\\n".format(url))
         sys.exit(99)
+
+    if out_path:
+        with open(out_path, "w") as f:
+            f.write(body)
+    else:
+        sys.stdout.write(body + "\\n")
+    if write_out:
+        sys.stdout.write(write_out.replace("%{http_code}", status))
+
+    fail_fast = any(
+        a.startswith("-") and not a.startswith("--") and "f" in a for a in args
+    )
+    if fail_fast and int(status) >= 400:
+        sys.exit(22)
     """
 )
 
@@ -463,6 +495,44 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
             pushed_bytes == artifact_bytes,
             "pushed content, once base64-decoded, is byte-identical to the regenerated artifact",
         )
+
+    # (n) behavioral: the Dependabot branch was deleted between generation and
+    # this run, so the branch-tip lookup 404s (issue #863). That is a "nothing
+    # to push" outcome, not a fault: the step must skip cleanly rather than
+    # hard-fail under `set -e` and leave a red run carrying no real signal.
+    gone, gone_calls, _ = run_push_step(MOCK_REF_STATUS="404")
+    check(
+        gone.returncode == 0,
+        "push step exits 0 when the Dependabot branch no longer exists (exit %d; stderr: %s)"
+        % (gone.returncode, gone.stderr.strip()[-400:]),
+    )
+    check(
+        put_call_of(gone_calls) is None,
+        "push step makes no Contents API PUT when the Dependabot branch no longer exists",
+    )
+    check(
+        "::warning::" in gone.stdout,
+        "push step warns, rather than staying silent, when the Dependabot branch no longer exists",
+    )
+
+    # (o) behavioral: any other failure on that same lookup is a genuine API
+    # error, not a deleted branch, and must still fail loudly. Treating it as
+    # "the branch is gone" would silently drop a regeneration the pull request
+    # is waiting on.
+    broken, broken_calls, _ = run_push_step(MOCK_REF_STATUS="500")
+    check(
+        broken.returncode != 0,
+        "push step fails when the branch-tip lookup returns an unexpected status (exit %d)"
+        % broken.returncode,
+    )
+    check(
+        put_call_of(broken_calls) is None,
+        "push step makes no Contents API PUT when the branch-tip lookup returns an unexpected status",
+    )
+    check(
+        "::error::" in broken.stdout,
+        "push step reports an error annotation when the branch-tip lookup returns an unexpected status",
+    )
 
 sys.exit(0 if all(results) else 1)
 PY

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -202,6 +202,19 @@ if [ -f "$PUSH_WF" ]; then
         pass "push workflow does not pass the assembled body to curl via -d \"\$BODY\""
     fi
 
+    # (m) the push job can write commit statuses. Running on workflow_run
+    # attaches this job's own check runs to the base branch, so the affected
+    # PR shows no trace of a failure here (issue #877); the outcome is
+    # mirrored onto the PR's head commit as a commit status instead, which
+    # needs statuses: write in this job's permissions block. As with (i),
+    # a job-level block fully replaces the workflow-level one, so the grant
+    # has to be listed here.
+    if awk '/^jobs:/{injobs=1} injobs && /^  push:/{inpush=1} inpush && /^  [a-z]/ && !/^  push:/{inpush=0} inpush' "$PUSH_WF" | grep -qE '^[[:space:]]*statuses:[[:space:]]*write'; then
+        pass "push job's permissions block grants statuses: write"
+    else
+        fail "push job's permissions block is missing statuses: write (without it the push half cannot report its outcome onto the pull request, and a failure leaves no signal there at all; see issue #877)"
+    fi
+
     # (m) behavioral: run the push step's real "Push the regenerated file
     # through the Contents API" script against a realistic-size artifact
     # (issue #875's file was 266562 bytes, base64ing to about 2.7 times the
@@ -244,15 +257,19 @@ with open(push_wf_path) as f:
     doc = yaml.safe_load(f)
 
 steps = doc["jobs"]["push"]["steps"]
-step = next(
-    (s for s in steps if s.get("name") == "Push the regenerated file through the Contents API"),
-    None,
-)
-if step is None:
-    check(False, "could not find the 'Push the regenerated file through the Contents API' step to extract for the behavioral test")
-    sys.exit(1)
 
-run_text = step["run"]
+
+def extract_step(name):
+    """Return the named step, or report a failure and stop the whole block."""
+    found = next((s for s in steps if s.get("name") == name), None)
+    if found is None:
+        check(False, "could not find the %r step to extract for the behavioral test" % name)
+        sys.exit(1)
+    return found
+
+
+push_step = extract_step("Push the regenerated file through the Contents API")
+report_step = extract_step("Report this job's outcome onto the pull request")
 
 # Mock curl for the behavioral checks in
 # scripts/test_dependabot_verification_metadata_workflows.sh (issue #875).
@@ -288,16 +305,25 @@ MOCK_CURL = textwrap.dedent(
 
     url = args[-1] if args else ""
     status = "200"
-    if "/git/ref/heads/" in url:
+    if url.endswith("/jobs"):
+        body = os.environ.get("MOCK_JOBS_JSON", '{"jobs": []}')
+    elif "/statuses/" in url:
+        status = os.environ.get("MOCK_STATUS_POST_CODE", "201")
+        body = json.dumps({"state": "recorded"})
+    elif "/git/ref/heads/" in url:
         status = os.environ.get("MOCK_REF_STATUS", "200")
         if status == "200":
             body = json.dumps({"object": {"sha": os.environ["MOCK_EXPECTED_SHA"]}})
         else:
             body = json.dumps({"message": "mock curl: answering HTTP " + status})
     elif "?ref=" in url:
+        # Read through a file: the committed file's base64 is far past
+        # MAX_ARG_STRLEN, which applies to environment strings too.
+        with open(os.environ["MOCK_EXISTING_CONTENT_B64_FILE"]) as f:
+            existing_content = f.read()
         body = json.dumps({
             "sha": os.environ["MOCK_EXISTING_BLOB_SHA"],
-            "content": os.environ["MOCK_EXISTING_CONTENT_B64"],
+            "content": existing_content,
         })
     elif "/contents/" in url:
         body = json.dumps({"content": {"sha": "0" * 40}})
@@ -332,9 +358,12 @@ def put_call_of(calls):
 
 
 with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
-    script_path = os.path.join(tmp, "push_step.sh")
-    with open(script_path, "w") as f:
-        f.write(run_text)
+    push_script = os.path.join(tmp, "push_step.sh")
+    with open(push_script, "w") as f:
+        f.write(push_step["run"])
+    report_script = os.path.join(tmp, "report_step.sh")
+    with open(report_script, "w") as f:
+        f.write(report_step["run"])
 
     artifact_dir = os.path.join(tmp, "artifact")
     os.makedirs(artifact_dir)
@@ -370,14 +399,20 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     st = os.stat(mock_curl_path)
     os.chmod(mock_curl_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
-    existing_content_b64 = base64.b64encode(
-        b"stale placeholder content, not the regenerated artifact"
-    ).decode()
+    # The mock reads the committed file's base64 from a file rather than an
+    # environment variable: at this file's real size it is past
+    # MAX_ARG_STRLEN, which bounds environment strings just as it bounds argv.
+    stale_b64_path = os.path.join(tmp, "committed-stale.b64")
+    with open(stale_b64_path, "w") as f:
+        f.write(base64.b64encode(b"stale placeholder content, not the regenerated artifact").decode())
+    current_b64_path = os.path.join(tmp, "committed-current.b64")
+    with open(current_b64_path, "w") as f:
+        f.write(base64.b64encode(artifact_bytes).decode())
 
     runs = [0]
 
-    def run_push_step(**mock_overrides):
-        """Run the extracted push step once, in its own scratch directories.
+    def run_step(script, step_env):
+        """Run one extracted step, in its own scratch directories.
 
         Returns the completed process, the argv of every curl invocation it
         made in order, and the step outputs it wrote to $GITHUB_OUTPUT.
@@ -393,22 +428,13 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
 
         env = dict(os.environ)
         env["PATH"] = bin_dir + os.pathsep + env["PATH"]
-        env["PAT"] = "test-pat-not-a-real-secret"
-        env["REPO"] = "octocat/example-repo"
-        env["HEAD_BRANCH"] = "dependabot/gradle/app/some-dependency-1.2.3"
-        env["EXPECTED_SHA"] = "1" * 40
-        env["ARTIFACT_DIR"] = artifact_dir
-        env["FILE_PATH"] = "gradle/verification-metadata.xml"
         env["RUNNER_TEMP"] = runner_temp
         env["GITHUB_OUTPUT"] = github_output
         env["MOCK_CALLS_DIR"] = calls_dir
-        env["MOCK_EXPECTED_SHA"] = env["EXPECTED_SHA"]
-        env["MOCK_EXISTING_BLOB_SHA"] = "d" * 40
-        env["MOCK_EXISTING_CONTENT_B64"] = existing_content_b64
-        env.update(mock_overrides)
+        env.update(step_env)
 
         proc = subprocess.run(
-            ["bash", script_path],
+            ["bash", script],
             env=env,
             capture_output=True,
             text=True,
@@ -428,6 +454,49 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
             )
 
         return proc, calls, outputs
+
+    def run_push_step(**overrides):
+        """Run the push step with the workflow's own env, as GitHub sets it."""
+        step_env = {
+            "PAT": "test-pat-not-a-real-secret",
+            "REPO": "octocat/example-repo",
+            "HEAD_BRANCH": "dependabot/gradle/app/some-dependency-1.2.3",
+            "EXPECTED_SHA": "1" * 40,
+            "ARTIFACT_DIR": artifact_dir,
+            "FILE_PATH": "gradle/verification-metadata.xml",
+            "MOCK_EXPECTED_SHA": "1" * 40,
+            "MOCK_EXISTING_BLOB_SHA": "d" * 40,
+            "MOCK_EXISTING_CONTENT_B64_FILE": stale_b64_path,
+        }
+        step_env.update(overrides)
+        return run_step(push_script, step_env)
+
+    def run_report_step(**overrides):
+        """Run the outcome-reporting step with the workflow's own env."""
+        step_env = {
+            "GH_TOKEN": "test-token-not-a-real-secret",
+            "REPO": "octocat/example-repo",
+            "HEAD_SHA": "1" * 40,
+            "JOB_STATUS": "success",
+            "PUSH_RESULT": "pushed",
+            "RUN_ID": "31584288707",
+            "RUN_ATTEMPT": "1",
+            "RUN_URL": "https://github.com/octocat/example-repo/actions/runs/31584288707",
+        }
+        step_env.update(overrides)
+        return run_step(report_script, step_env)
+
+    def posted_status(calls):
+        """Return the body of the commit-status POST, or None if never made."""
+        for args in calls:
+            url = args[-1] if args else ""
+            if "/statuses/" not in url:
+                continue
+            for i, a in enumerate(args):
+                if a == "--data-binary" and i + 1 < len(args):
+                    with open(args[i + 1].lstrip("@")) as f:
+                        return url, json.load(f)
+        return None, None
 
     result, calls, outputs = run_push_step()
 
@@ -525,11 +594,20 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
             "pushed content, once base64-decoded, is byte-identical to the regenerated artifact",
         )
 
+    # The step's `result` output is what the reporting step below keys on to
+    # tell the outcomes apart, so each path has to declare the right one
+    # (issue #877).
+    check(
+        outputs.get("result") == "pushed",
+        "push step reports result=pushed after a successful push (got %r)"
+        % outputs.get("result"),
+    )
+
     # (n) behavioral: the Dependabot branch was deleted between generation and
     # this run, so the branch-tip lookup 404s (issue #863). That is a "nothing
     # to push" outcome, not a fault: the step must skip cleanly rather than
     # hard-fail under `set -e` and leave a red run carrying no real signal.
-    gone, gone_calls, _ = run_push_step(MOCK_REF_STATUS="404")
+    gone, gone_calls, gone_outputs = run_push_step(MOCK_REF_STATUS="404")
     check(
         gone.returncode == 0,
         "push step exits 0 when the Dependabot branch no longer exists (exit %d; stderr: %s)"
@@ -542,6 +620,11 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     check(
         "::warning::" in gone.stdout,
         "push step warns, rather than staying silent, when the Dependabot branch no longer exists",
+    )
+    check(
+        gone_outputs.get("result") == "branch-gone",
+        "push step reports result=branch-gone when the Dependabot branch no longer exists (got %r)"
+        % gone_outputs.get("result"),
     )
 
     # (o) behavioral: any other failure on that same lookup is a genuine API
@@ -562,6 +645,157 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         "::error::" in broken.stdout,
         "push step reports an error annotation when the branch-tip lookup returns an unexpected status",
     )
+
+    # (p) behavioral: the two remaining no-op paths. Both are successes with
+    # nothing to push, and the reporting step tells them apart by `result`.
+    moved, moved_calls, moved_outputs = run_push_step(MOCK_EXPECTED_SHA="9" * 40)
+    check(
+        moved.returncode == 0 and put_call_of(moved_calls) is None,
+        "push step skips without pushing when the branch tip moved during regeneration",
+    )
+    check(
+        moved_outputs.get("result") == "branch-moved",
+        "push step reports result=branch-moved when the branch tip moved during regeneration (got %r)"
+        % moved_outputs.get("result"),
+    )
+
+    current, current_calls, current_outputs = run_push_step(
+        MOCK_EXISTING_CONTENT_B64_FILE=current_b64_path
+    )
+    check(
+        current.returncode == 0 and put_call_of(current_calls) is None,
+        "push step commits nothing when the committed file already matches the regenerated one",
+    )
+    check(
+        current_outputs.get("result") == "already-current",
+        "push step reports result=already-current when the committed file already matches (got %r)"
+        % current_outputs.get("result"),
+    )
+
+    # (q) behavioral: the outcome-reporting step (issue #877). Running on
+    # workflow_run puts this job's own check runs on the base branch, so the
+    # commit status it writes onto the head SHA is the only trace the pull
+    # request ever sees.
+    failed_jobs_json = json.dumps(
+        {
+            "jobs": [
+                {
+                    "steps": [
+                        {"name": "Download the regenerated file, if one was produced", "conclusion": "success"},
+                        {"name": "Confirm the push token is configured", "conclusion": "failure"},
+                    ]
+                }
+            ]
+        }
+    )
+    failed, failed_calls, _ = run_report_step(
+        JOB_STATUS="failure", PUSH_RESULT="", MOCK_JOBS_JSON=failed_jobs_json
+    )
+    check(
+        failed.returncode == 0,
+        "reporting step exits 0 after reporting a failure (exit %d; stderr: %s)"
+        % (failed.returncode, failed.stderr.strip()[-400:]),
+    )
+    status_url, status_body = posted_status(failed_calls)
+    if not check(
+        status_body is not None,
+        "reporting step posts a commit status when the job failed",
+    ):
+        sys.exit(1)
+    check(
+        status_url.endswith("/statuses/" + "1" * 40),
+        "the failure status is posted against the pull request's head SHA (got %r)" % status_url,
+    )
+    check(
+        status_body.get("state") == "failure",
+        "the reported state is 'failure' (got %r)" % status_body.get("state"),
+    )
+    check(
+        "Confirm the push token is configured" in status_body.get("description", ""),
+        "the failure status names the step that failed (got %r)" % status_body.get("description"),
+    )
+    check(
+        status_body.get("target_url", "").endswith("/actions/runs/31584288707"),
+        "the failure status links this workflow run (got %r)" % status_body.get("target_url"),
+    )
+    check(
+        bool(status_body.get("context")),
+        "the failure status carries a context, so a later run replaces it rather than piling up",
+    )
+
+    # A failure the jobs API cannot attribute to a named step, such as a
+    # cancelled job, still has to reach the pull request.
+    cancelled, cancelled_calls, _ = run_report_step(JOB_STATUS="cancelled", PUSH_RESULT="")
+    _, cancelled_body = posted_status(cancelled_calls)
+    check(
+        cancelled.returncode == 0
+        and cancelled_body is not None
+        and cancelled_body.get("state") == "failure"
+        and bool(cancelled_body.get("description")),
+        "an unattributable failure is still reported, with a description (got %r)" % cancelled_body,
+    )
+
+    # A commit status description is capped at 140 characters; a long step
+    # name must be truncated rather than rejected by the API.
+    long_name = "Confirm " + ("a very long step name " * 12)
+    long_jobs_json = json.dumps(
+        {"jobs": [{"steps": [{"name": long_name, "conclusion": "failure"}]}]}
+    )
+    long_run, long_calls, _ = run_report_step(
+        JOB_STATUS="failure", PUSH_RESULT="", MOCK_JOBS_JSON=long_jobs_json
+    )
+    _, long_body = posted_status(long_calls)
+    check(
+        long_body is not None and len(long_body.get("description", "")) <= 140,
+        "a long failed-step name is truncated to the 140-character status description cap",
+    )
+
+    # The success report is not decoration: posted to the same context, it is
+    # what clears a failure a previous attempt left on this same commit.
+    for push_result, label in (("pushed", "a push"), ("already-current", "a no-op")):
+        ok_run, ok_calls, _ = run_report_step(JOB_STATUS="success", PUSH_RESULT=push_result)
+        _, ok_body = posted_status(ok_calls)
+        check(
+            ok_run.returncode == 0
+            and ok_body is not None
+            and ok_body.get("state") == "success",
+            "the reporting step posts a success status after %s (got %r)" % (label, ok_body),
+        )
+
+    # The commit can be gone by the time the status is written (the branch was
+    # deleted, the pull request closed). That is not worth failing over, and
+    # it must not mask the job's real outcome.
+    unreachable, _, _ = run_report_step(MOCK_STATUS_POST_CODE="422")
+    check(
+        unreachable.returncode == 0 and "::warning::" in unreachable.stdout,
+        "the reporting step warns, rather than failing, when the head commit is unreachable",
+    )
+
+    # Any other API failure means the pull request silently lost its only
+    # signal, which is the whole defect this step exists to fix, so it fails
+    # loudly and says the job's own outcome is unaffected.
+    unreported, _, _ = run_report_step(MOCK_STATUS_POST_CODE="500")
+    check(
+        unreported.returncode != 0 and "::error::" in unreported.stdout,
+        "the reporting step fails loudly when the commit status cannot be posted at all",
+    )
+
+# The reporting step's own `if` decides which runs report at all: every
+# unsuccessful one, plus the successful ones that acted on an artifact. A run
+# that found no artifact is the ordinary outcome on any pull request that does
+# not move the dependency graph, including a non-Dependabot one, and must
+# leave no status behind.
+report_if = str(report_step.get("if", ""))
+check(
+    "always()" in report_if and "job.status" in report_if,
+    "the reporting step runs on every unsuccessful outcome, cancellations included (if: %r)"
+    % report_if,
+)
+check(
+    "steps.push.outputs.result" in report_if,
+    "the reporting step's success path is gated on the push step's result, so a run with no "
+    "artifact reports nothing (if: %r)" % report_if,
+)
 
 sys.exit(0 if all(results) else 1)
 PY

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -483,6 +483,17 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         "pushed body's commit message names the regenerated file",
     )
 
+    # The ID-prefixed noreply address is what links the commit to the
+    # github-actions[bot] account's profile; the bare form renders as an
+    # unlinked name and email pair instead (issue #864).
+    bot_email = "41898282+github-actions[bot]@users.noreply.github.com"
+    for role in ("author", "committer"):
+        check(
+            pushed_body.get(role, {}).get("email") == bot_email,
+            "pushed body's %s email is the ID-prefixed github-actions[bot] noreply address "
+            "(got %r)" % (role, pushed_body.get(role, {}).get("email")),
+        )
+
     pushed_content_b64 = pushed_body.get("content", "")
     pushed_bytes = None
     try:

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -33,6 +33,36 @@ FAIL=0
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
+# Print the YAML block of one top-level job, so a check can assert against
+# that job alone rather than the whole file. Job-level `permissions:` fully
+# replaces the workflow-level block, so "does this job grant X" is the only
+# question worth asking, and it cannot be asked with a plain grep.
+#
+# Every caller below captures this output and matches it with a reader that
+# consumes all of its input. The obvious `awk '...' "$WF" | grep -q ...`
+# instead is a race: `grep -q` exits at its first match and closes the pipe,
+# `awk` dies of SIGPIPE (141), and `set -o pipefail` above turns that into a
+# failed pipeline, so a pattern that IS present is reported missing. The
+# window opens only once awk's output no longer fits a single buffered
+# write, which is why the pattern survived here until the push job grew past
+# that size and CI run 31978297339 reported "statuses: write" missing from a
+# job that declares it. `head -1` closes a pipe the same way, and in a
+# `VAR="$(...)"` assignment a 141 aborts the whole script under `set -e`.
+# Nothing here may depend on a workflow file staying under a buffer size.
+job_block() {
+    awk -v job="$2" '
+        /^jobs:/ { in_jobs = 1 }
+        in_jobs && $0 == "  " job ":" { in_job = 1 }
+        in_job && /^  [A-Za-z_]/ && $0 != "  " job ":" { in_job = 0 }
+        in_job
+    ' "$1"
+}
+
+# Whether $1 (a captured block) has a line matching the ERE $2. Plain grep,
+# not `grep -q`: it reads to end of input, so there is no early close and no
+# writer to kill. The block arrives by here-string, not by pipe.
+block_has() { grep -E "$2" <<<"$1" >/dev/null; }
+
 # (a) both halves exist.
 for f in "$GENERATE_WF" "$PUSH_WF"; do
     if [ -f "$f" ]; then
@@ -89,8 +119,12 @@ if [ -f "$GENERATE_WF" ]; then
     # run, which the push workflow's `if: ... == 'success'` gate correctly
     # declines to act on, so the PR just never goes green, silently
     # defeating issue #842's whole purpose.
-    TIMEOUT="$(awk '/^jobs:/{injobs=1} injobs && /^  regenerate:/{injob=1} injob && /^  [a-z]/ && !/^  regenerate:/{injob=0} injob' "$GENERATE_WF" \
-        | grep -E '^[[:space:]]*timeout-minutes:' | head -1 | grep -oE '[0-9]+')"
+    # Read the regenerate job's own budget, not the first timeout-minutes in
+    # the file, which belongs to the triage job in front of it. One awk over
+    # the captured block, rather than a `grep | head -1` pipeline: see the
+    # SIGPIPE note on job_block above.
+    TIMEOUT="$(awk '!seen && /^[[:space:]]*timeout-minutes:/ { gsub(/[^0-9]/, "", $0); print; seen = 1 }' \
+        <<<"$(job_block "$GENERATE_WF" regenerate)")"
     if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" -ge 90 ]; then
         pass "generate workflow's timeout-minutes ($TIMEOUT) is at least 90, matching regenerate-gradle-toolchain.yml's budget for the identical uncached Gradle invocation"
     else
@@ -368,7 +402,8 @@ if [ -f "$PUSH_WF" ]; then
     # swallows that, and the job reports a false "nothing to push" on every
     # run: the exact silent-failure mode this whole automation exists to
     # avoid.
-    if awk '/^jobs:/{injobs=1} injobs && /^  push:/{inpush=1} inpush && /^  [a-z]/ && !/^  push:/{inpush=0} inpush' "$PUSH_WF" | grep -qE '^[[:space:]]*actions:[[:space:]]*read'; then
+    PUSH_JOB="$(job_block "$PUSH_WF" push)"
+    if block_has "$PUSH_JOB" '^[[:space:]]*actions:[[:space:]]*read'; then
         pass "push job's permissions block grants actions: read"
     else
         fail "push job's permissions block is missing actions: read (actions/download-artifact needs it to pull the generate workflow's cross-run artifact; without it the download 403s and continue-on-error silently reports nothing to push, every time)"
@@ -411,7 +446,7 @@ if [ -f "$PUSH_WF" ]; then
     # needs statuses: write in this job's permissions block. As with (i),
     # a job-level block fully replaces the workflow-level one, so the grant
     # has to be listed here.
-    if awk '/^jobs:/{injobs=1} injobs && /^  push:/{inpush=1} inpush && /^  [a-z]/ && !/^  push:/{inpush=0} inpush' "$PUSH_WF" | grep -qE '^[[:space:]]*statuses:[[:space:]]*write'; then
+    if block_has "$PUSH_JOB" '^[[:space:]]*statuses:[[:space:]]*write'; then
         pass "push job's permissions block grants statuses: write"
     else
         fail "push job's permissions block is missing statuses: write (without it the push half cannot report its outcome onto the pull request, and a failure leaves no signal there at all; see issue #877)"

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -89,11 +89,213 @@ if [ -f "$GENERATE_WF" ]; then
     # run, which the push workflow's `if: ... == 'success'` gate correctly
     # declines to act on, so the PR just never goes green, silently
     # defeating issue #842's whole purpose.
-    TIMEOUT="$(grep -E '^[[:space:]]*timeout-minutes:' "$GENERATE_WF" | head -1 | grep -oE '[0-9]+')"
+    TIMEOUT="$(awk '/^jobs:/{injobs=1} injobs && /^  regenerate:/{injob=1} injob && /^  [a-z]/ && !/^  regenerate:/{injob=0} injob' "$GENERATE_WF" \
+        | grep -E '^[[:space:]]*timeout-minutes:' | head -1 | grep -oE '[0-9]+')"
     if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" -ge 90 ]; then
         pass "generate workflow's timeout-minutes ($TIMEOUT) is at least 90, matching regenerate-gradle-toolchain.yml's budget for the identical uncached Gradle invocation"
     else
         fail "generate workflow's timeout-minutes (${TIMEOUT:-unset}) is below 90; regenerate-gradle-toolchain.yml documents a 20-45 minute cold run for the identical script, so anything below that risks cancelling a normal run"
+    fi
+
+    # (n) behavioral: the triage gate that keeps the push half's own metadata
+    # commit from buying a second, identical regeneration (issue #879). Runs
+    # the real extracted step against a mocked commits API, so what is tested
+    # is the shell the workflow actually executes. The skip must stay
+    # conservative: a regen wrongly skipped leaves a Dependabot PR red with
+    # stale metadata, which is far worse than the wasted run this saves.
+    set +e
+    N_OUTPUT="$(python3 - "$GENERATE_WF" <<'PY'
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+generate_wf_path = sys.argv[1]
+
+try:
+    import yaml
+except ImportError:
+    print("  FAIL: PyYAML is not installed (see scripts/requirements.txt); cannot run the behavioral triage test")
+    sys.exit(1)
+
+results = []
+
+
+def check(ok, msg):
+    results.append(ok)
+    print(("  PASS: " if ok else "  FAIL: ") + msg)
+    return ok
+
+
+with open(generate_wf_path) as f:
+    doc = yaml.safe_load(f)
+
+jobs = doc["jobs"]
+
+if not check("triage" in jobs, "generate workflow has a triage job in front of the regeneration"):
+    sys.exit(1)
+
+regenerate_if = str(jobs.get("regenerate", {}).get("if", ""))
+check(
+    "needs.triage.outputs.needs_regen" in regenerate_if,
+    "the regenerate job is gated on the triage job's verdict (if: %r)" % regenerate_if,
+)
+check(
+    "pull_request.user.login" in regenerate_if,
+    "the regenerate job still carries the dependabot author gate itself, not only through "
+    "`needs` (if: %r)" % regenerate_if,
+)
+
+step = next(
+    (
+        s
+        for s in jobs["triage"]["steps"]
+        if s.get("name") == "Check whether the head commit only carries regenerated metadata"
+    ),
+    None,
+)
+if step is None:
+    check(False, "could not find the triage job's head-commit step to extract for the behavioral test")
+    sys.exit(1)
+
+MOCK_CURL = textwrap.dedent(
+    """\
+    #!/usr/bin/env python3
+    import os
+    import sys
+
+    if os.environ.get("MOCK_COMMIT_FAILS") == "1":
+        sys.stderr.write("mock curl: the commits API is unavailable\\n")
+        sys.exit(22)
+    out_path = None
+    args = sys.argv[1:]
+    for i, a in enumerate(args):
+        if a == "-o" and i + 1 < len(args):
+            out_path = args[i + 1]
+    body = os.environ["MOCK_COMMIT_JSON"]
+    if out_path:
+        with open(out_path, "w") as f:
+            f.write(body)
+    else:
+        sys.stdout.write(body)
+    """
+)
+
+
+def files_payload(*filenames):
+    return json.dumps({"files": [{"filename": n} for n in filenames]})
+
+
+with tempfile.TemporaryDirectory(prefix="dependabot-triage-test-") as tmp:
+    script_path = os.path.join(tmp, "triage_step.sh")
+    with open(script_path, "w") as f:
+        f.write(step["run"])
+
+    bin_dir = os.path.join(tmp, "bin")
+    os.makedirs(bin_dir)
+    mock_curl_path = os.path.join(bin_dir, "curl")
+    with open(mock_curl_path, "w") as f:
+        f.write(MOCK_CURL)
+    st = os.stat(mock_curl_path)
+    os.chmod(mock_curl_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    runs = [0]
+
+    def run_triage_step(commit_json, **overrides):
+        runs[0] += 1
+        run_dir = os.path.join(tmp, "run_%d" % runs[0])
+        os.makedirs(run_dir)
+        github_output = os.path.join(run_dir, "github_output")
+        open(github_output, "w").close()
+
+        env = dict(os.environ)
+        env["PATH"] = bin_dir + os.pathsep + env["PATH"]
+        env["GH_TOKEN"] = "test-token-not-a-real-secret"
+        env["REPO"] = "octocat/example-repo"
+        env["HEAD_SHA"] = "a" * 40
+        env["FILE_PATH"] = "gradle/verification-metadata.xml"
+        env["RUNNER_TEMP"] = run_dir
+        env["GITHUB_OUTPUT"] = github_output
+        env["MOCK_COMMIT_JSON"] = commit_json
+        env.update(overrides)
+
+        proc = subprocess.run(
+            ["bash", script_path], env=env, capture_output=True, text=True, timeout=60
+        )
+        with open(github_output) as f:
+            outputs = dict(
+                line.split("=", 1) for line in f.read().splitlines() if "=" in line
+            )
+        return proc, outputs
+
+    cases = [
+        (
+            files_payload("gradle/verification-metadata.xml"),
+            "false",
+            "a head commit whose entire diff is gradle/verification-metadata.xml is recognized as "
+            "this automation's own commit and skipped",
+        ),
+        (
+            files_payload("app/build.gradle.kts"),
+            "true",
+            "a Dependabot bump of app/build.gradle.kts is regenerated",
+        ),
+        (
+            files_payload("app/build.gradle.kts", "gradle/verification-metadata.xml"),
+            "true",
+            "a head commit that touches the metadata file alongside a real bump is still "
+            "regenerated",
+        ),
+        (
+            files_payload("gradle/libs.versions.toml"),
+            "true",
+            "a head commit that touches neither file is regenerated rather than skipped",
+        ),
+    ]
+    for commit_json, expected, description in cases:
+        proc, outputs = run_triage_step(commit_json)
+        check(
+            proc.returncode == 0 and outputs.get("needs_regen") == expected,
+            "%s (needs_regen=%r, exit %d)" % (description, outputs.get("needs_regen"), proc.returncode),
+        )
+
+    # Every uncertain answer regenerates: this gate is an optimization over
+    # behavior that was already correct, so an unreachable API or a payload
+    # with no usable file list must fall back to it rather than block the
+    # pull request or, worse, decide there is nothing to do.
+    broken, broken_outputs = run_triage_step(
+        files_payload("app/build.gradle.kts"), MOCK_COMMIT_FAILS="1"
+    )
+    check(
+        broken.returncode == 0
+        and broken_outputs.get("needs_regen") == "true"
+        and "::warning::" in broken.stdout,
+        "an unreachable commits API regenerates, with a warning, rather than skipping or failing "
+        "(exit %d, outputs %r)" % (broken.returncode, broken_outputs),
+    )
+
+    malformed, malformed_outputs = run_triage_step('{"sha": "aaa"}')
+    check(
+        malformed.returncode == 0 and malformed_outputs.get("needs_regen") == "true",
+        "a commits payload carrying no file list regenerates rather than skipping (exit %d, "
+        "outputs %r)" % (malformed.returncode, malformed_outputs),
+    )
+
+sys.exit(0 if all(results) else 1)
+PY
+)"
+    N_STATUS=$?
+    set -e
+    echo "$N_OUTPUT"
+    N_PASS=$(grep -c '^  PASS:' <<<"$N_OUTPUT" || true)
+    N_FAIL=$(grep -c '^  FAIL:' <<<"$N_OUTPUT" || true)
+    PASS=$((PASS + N_PASS))
+    FAIL=$((FAIL + N_FAIL))
+    if [ "$N_STATUS" -ne 0 ] && [ "$N_FAIL" -eq 0 ]; then
+        fail "triage-gate behavioral test errored before reporting individual checks (exit $N_STATUS)"
     fi
 fi
 

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -483,6 +483,24 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         "pushed body's commit message names the regenerated file",
     )
 
+    # Dependabot stops rebasing a pull request once a commit it did not author
+    # lands on the branch, unless the message carries one of its skip markers
+    # (issue #883). Without one, the automation built to help these pull
+    # requests silently ends Dependabot's maintenance of every branch it
+    # succeeds on.
+    skip_markers = (
+        "[dependabot skip]",
+        "[skip dependabot]",
+        "[dependabot-skip]",
+        "[skip-dependabot]",
+    )
+    message = pushed_body.get("message", "")
+    check(
+        any(m in message.lower() for m in skip_markers),
+        "pushed body's commit message carries a Dependabot skip marker, so the branch keeps "
+        "being rebased automatically (got %r)" % message,
+    )
+
     # The ID-prefixed noreply address is what links the commit to the
     # github-actions[bot] account's profile; the bare form renders as an
     # unlinked name and email pair instead (issue #864).

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -254,6 +254,51 @@ if step is None:
 
 run_text = step["run"]
 
+# Mock curl for the behavioral checks in
+# scripts/test_dependabot_verification_metadata_workflows.sh (issue #875).
+# Records every invocation's argv so the test can inspect the real push
+# request, and answers the two GET calls the push step makes before it,
+# without any real network access.
+MOCK_CURL = textwrap.dedent(
+    """\
+    #!/usr/bin/env python3
+    import json
+    import os
+    import sys
+
+    args = sys.argv[1:]
+    calls_dir = os.environ["MOCK_CALLS_DIR"]
+    existing = [n for n in os.listdir(calls_dir) if n.startswith("call_")]
+    call_path = os.path.join(calls_dir, "call_{}.json".format(len(existing) + 1))
+    with open(call_path, "w") as f:
+        json.dump(args, f)
+
+    url = args[-1] if args else ""
+    if "/git/ref/heads/" in url:
+        print(json.dumps({"object": {"sha": os.environ["MOCK_EXPECTED_SHA"]}}))
+    elif "?ref=" in url:
+        print(json.dumps({
+            "sha": os.environ["MOCK_EXISTING_BLOB_SHA"],
+            "content": os.environ["MOCK_EXISTING_CONTENT_B64"],
+        }))
+    elif "/contents/" in url:
+        print(json.dumps({"content": {"sha": "0" * 40}}))
+    else:
+        sys.stderr.write("mock curl: unrecognized URL: {}\\n".format(url))
+        sys.exit(99)
+    """
+)
+
+
+def put_call_of(calls):
+    """Return the argv of the Contents API PUT, or None if it never ran."""
+    for args in calls:
+        url = args[-1] if args else ""
+        if "/git/ref/heads/" not in url and "?ref=" not in url and "/contents/" in url:
+            return args
+    return None
+
+
 with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     script_path = os.path.join(tmp, "push_step.sh")
     with open(script_path, "w") as f:
@@ -285,52 +330,11 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     ):
         sys.exit(1)
 
-    runner_temp = os.path.join(tmp, "runner_temp")
-    os.makedirs(runner_temp)
-
-    calls_dir = os.path.join(tmp, "calls")
-    os.makedirs(calls_dir)
-
     bin_dir = os.path.join(tmp, "bin")
     os.makedirs(bin_dir)
     mock_curl_path = os.path.join(bin_dir, "curl")
     with open(mock_curl_path, "w") as f:
-        f.write(
-            textwrap.dedent(
-                """\
-                #!/usr/bin/env python3
-                # Mock curl for the behavioral check in
-                # scripts/test_dependabot_verification_metadata_workflows.sh (issue #875).
-                # Records every invocation's argv so the test can inspect the real push
-                # request, and answers the two GET calls the push step makes before it,
-                # without any real network access.
-                import json
-                import os
-                import sys
-
-                args = sys.argv[1:]
-                calls_dir = os.environ["MOCK_CALLS_DIR"]
-                existing = [n for n in os.listdir(calls_dir) if n.startswith("call_")]
-                call_path = os.path.join(calls_dir, "call_{}.json".format(len(existing) + 1))
-                with open(call_path, "w") as f:
-                    json.dump(args, f)
-
-                url = args[-1] if args else ""
-                if "/git/ref/heads/" in url:
-                    print(json.dumps({"object": {"sha": os.environ["MOCK_EXPECTED_SHA"]}}))
-                elif "?ref=" in url:
-                    print(json.dumps({
-                        "sha": os.environ["MOCK_EXISTING_BLOB_SHA"],
-                        "content": os.environ["MOCK_EXISTING_CONTENT_B64"],
-                    }))
-                elif "/contents/" in url:
-                    print(json.dumps({"content": {"sha": "0" * 40}}))
-                else:
-                    sys.stderr.write("mock curl: unrecognized URL: {}\\n".format(url))
-                    sys.exit(99)
-                """
-            )
-        )
+        f.write(MOCK_CURL)
     st = os.stat(mock_curl_path)
     os.chmod(mock_curl_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
@@ -338,27 +342,62 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         b"stale placeholder content, not the regenerated artifact"
     ).decode()
 
-    env = dict(os.environ)
-    env["PATH"] = bin_dir + os.pathsep + env["PATH"]
-    env["PAT"] = "test-pat-not-a-real-secret"
-    env["REPO"] = "octocat/example-repo"
-    env["HEAD_BRANCH"] = "dependabot/gradle/app/some-dependency-1.2.3"
-    env["EXPECTED_SHA"] = "1" * 40
-    env["ARTIFACT_DIR"] = artifact_dir
-    env["FILE_PATH"] = "gradle/verification-metadata.xml"
-    env["RUNNER_TEMP"] = runner_temp
-    env["MOCK_CALLS_DIR"] = calls_dir
-    env["MOCK_EXPECTED_SHA"] = env["EXPECTED_SHA"]
-    env["MOCK_EXISTING_BLOB_SHA"] = "d" * 40
-    env["MOCK_EXISTING_CONTENT_B64"] = existing_content_b64
+    runs = [0]
 
-    result = subprocess.run(
-        ["bash", script_path],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    def run_push_step(**mock_overrides):
+        """Run the extracted push step once, in its own scratch directories.
+
+        Returns the completed process, the argv of every curl invocation it
+        made in order, and the step outputs it wrote to $GITHUB_OUTPUT.
+        """
+        runs[0] += 1
+        run_dir = os.path.join(tmp, "run_%d" % runs[0])
+        calls_dir = os.path.join(run_dir, "calls")
+        runner_temp = os.path.join(run_dir, "runner_temp")
+        os.makedirs(calls_dir)
+        os.makedirs(runner_temp)
+        github_output = os.path.join(run_dir, "github_output")
+        open(github_output, "w").close()
+
+        env = dict(os.environ)
+        env["PATH"] = bin_dir + os.pathsep + env["PATH"]
+        env["PAT"] = "test-pat-not-a-real-secret"
+        env["REPO"] = "octocat/example-repo"
+        env["HEAD_BRANCH"] = "dependabot/gradle/app/some-dependency-1.2.3"
+        env["EXPECTED_SHA"] = "1" * 40
+        env["ARTIFACT_DIR"] = artifact_dir
+        env["FILE_PATH"] = "gradle/verification-metadata.xml"
+        env["RUNNER_TEMP"] = runner_temp
+        env["GITHUB_OUTPUT"] = github_output
+        env["MOCK_CALLS_DIR"] = calls_dir
+        env["MOCK_EXPECTED_SHA"] = env["EXPECTED_SHA"]
+        env["MOCK_EXISTING_BLOB_SHA"] = "d" * 40
+        env["MOCK_EXISTING_CONTENT_B64"] = existing_content_b64
+        env.update(mock_overrides)
+
+        proc = subprocess.run(
+            ["bash", script_path],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        calls = []
+        for name in sorted(
+            os.listdir(calls_dir), key=lambda n: int(n.split("_")[1].split(".")[0])
+        ):
+            with open(os.path.join(calls_dir, name)) as f:
+                calls.append(json.load(f))
+
+        with open(github_output) as f:
+            outputs = dict(
+                line.split("=", 1) for line in f.read().splitlines() if "=" in line
+            )
+
+        return proc, calls, outputs
+
+    result, calls, outputs = run_push_step()
 
     ok = check(
         result.returncode == 0,
@@ -368,14 +407,7 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     if not ok:
         sys.exit(1)
 
-    put_call = None
-    for name in sorted(os.listdir(calls_dir)):
-        with open(os.path.join(calls_dir, name)) as f:
-            args = json.load(f)
-        url = args[-1] if args else ""
-        if "/git/ref/heads/" not in url and "?ref=" not in url and "/contents/" in url:
-            put_call = args
-            break
+    put_call = put_call_of(calls)
 
     if not check(put_call is not None, "the push step made a PUT request to the Contents API"):
         sys.exit(1)
@@ -407,11 +439,11 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         pushed_body = json.load(f)
 
     check(
-        pushed_body.get("branch") == env["HEAD_BRANCH"],
+        pushed_body.get("branch") == "dependabot/gradle/app/some-dependency-1.2.3",
         "pushed body's branch matches the workflow_run's head branch",
     )
     check(
-        pushed_body.get("sha") == env["MOCK_EXISTING_BLOB_SHA"],
+        pushed_body.get("sha") == "d" * 40,
         "pushed body's sha matches the existing file's blob sha",
     )
     check(

--- a/scripts/test_dependabot_verification_metadata_workflows.sh
+++ b/scripts/test_dependabot_verification_metadata_workflows.sh
@@ -987,16 +987,27 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
         "a long failed-step name is truncated to the 140-character status description cap",
     )
 
-    # The success report is not decoration: posted to the same context, it is
-    # what clears a failure a previous attempt left on this same commit.
-    for push_result, label in (("pushed", "a push"), ("already-current", "a no-op")):
+    # Every verdict the push step can reach is reported, the two skips
+    # included: #877 names the stale-branch-tip guard among the modes that
+    # must stop being silent. A skip is a success, since nothing went wrong,
+    # and each description has to say which outcome it was rather than
+    # falling through to a generic one.
+    verdicts = (
+        ("pushed", "Pushed"),
+        ("already-current", "already matched"),
+        ("branch-moved", "the branch moved"),
+        ("branch-gone", "no longer exists"),
+    )
+    for push_result, expected_phrase in verdicts:
         ok_run, ok_calls, _ = run_report_step(JOB_STATUS="success", PUSH_RESULT=push_result)
         _, ok_body = posted_status(ok_calls)
         check(
             ok_run.returncode == 0
             and ok_body is not None
-            and ok_body.get("state") == "success",
-            "the reporting step posts a success status after %s (got %r)" % (label, ok_body),
+            and ok_body.get("state") == "success"
+            and expected_phrase in ok_body.get("description", ""),
+            "result=%s is reported as a success naming that outcome (got %r)"
+            % (push_result, ok_body),
         )
 
     # The commit can be gone by the time the status is written (the branch was
@@ -1018,20 +1029,20 @@ with tempfile.TemporaryDirectory(prefix="dependabot-push-body-test-") as tmp:
     )
 
 # The reporting step's own `if` decides which runs report at all: every
-# unsuccessful one, plus the successful ones that acted on an artifact. A run
-# that found no artifact is the ordinary outcome on any pull request that does
-# not move the dependency graph, including a non-Dependabot one, and must
-# leave no status behind.
-report_if = str(report_step.get("if", ""))
+# unsuccessful one, plus every one where the push step reached a verdict. A
+# run that found no artifact never sets `result`, and it is the ordinary
+# outcome on any pull request that does not move the dependency graph,
+# including a non-Dependabot one, so it must leave no status behind.
+report_if = " ".join(str(report_step.get("if", "")).split())
 check(
-    "always()" in report_if and "job.status" in report_if,
+    "always()" in report_if and "job.status != 'success'" in report_if,
     "the reporting step runs on every unsuccessful outcome, cancellations included (if: %r)"
     % report_if,
 )
 check(
-    "steps.push.outputs.result" in report_if,
-    "the reporting step's success path is gated on the push step's result, so a run with no "
-    "artifact reports nothing (if: %r)" % report_if,
+    "steps.push.outputs.result != ''" in report_if,
+    "the reporting step reports on any push verdict, and only a run that never reached one "
+    "(no artifact) is excluded (if: %r)" % report_if,
 )
 
 sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Fixes #890.
Fixes #883. Fixes #879. Fixes #877. Fixes #864. Fixes #863.

All five children of #890 are fixed here, none dropped. Each is its own commit; the first commit is a pure refactor of the guard test's behavioral harness so it can drive an extracted step more than once, and the last three are the review round.

## #883: the commit message carries no Dependabot skip marker

The push workflow's commit message now ends with a `[dependabot skip]` trailer, so a pull request this automation succeeds on keeps Dependabot's automatic rebasing instead of silently losing it.

GitHub's current documentation was re-read rather than trusted from the issue, as the issue asked: it names four markers, in either case (`[dependabot skip]`, `[skip dependabot]`, `[dependabot-skip]`, `[skip-dependabot]`).

`gradle/README.md` records the marker and what dropping it costs, its earlier NOTE flagging the missing marker is gone, and the guard test asserts a marker is present in the request body the step assembles.

## #879: two full regenerations per pull request

A `triage` job now stands in front of the regeneration and skips it when the head commit's entire diff is `gradle/verification-metadata.xml`, which is what the push half's own commit looks like and cannot have moved the dependency graph.

The discriminator is the commit's diff, not its committer identity, as #879 preferred, so it is unaffected by the email change #864 makes in this same branch. Triage checks nothing out, so the regen half stays the read-only, secret-less half.

On the reachability question the issue asks to answer explicitly: every uncertain answer regenerates (an unreachable commits API, or a payload with no usable file list, warns and falls back to regenerating), so the only state that still reaches a wrong skip is a commit pushed by hand whose entire diff is that file and whose contents were not generated from the branch's graph. Nothing in this repository produces it: Dependabot's own pushes always carry `app/build.gradle.kts`, and the push half only ever commits a file generated against the very commit it commits onto. The recovery is the by-hand regeneration `gradle/README.md` already documents.

A genuine second bump still regenerates, because a Dependabot rebase or follow-up push does not have that diff. The claim is one regeneration per Dependabot *push*, not per pull request: a rebase discards the metadata commit and earns a fresh one, which is the trade the `[dependabot skip]` marker buys, and the README now says so.

## #877: push-half failures leave no signal on the pull request

The push job's last step mirrors the job's outcome onto `workflow_run.head_sha` as a commit status, which the pull request does display.

- It covers every failure mode rather than an enumerated list, because it reads the failed step's name from the run's own jobs: missing PAT, artifact confirmation, an error on the branch-tip lookup, the push itself, and a cancelled job all report.
- It reports the four verdicts the push step can reach, too: pushed, already current, and the two skips (the branch moved during regeneration, the branch is gone). The skips are green and say which skip it was, since nothing went wrong in either.
- Success is reported to the same status context, which is what clears a failure an earlier attempt left on that commit.
- Only a run that produced no artifact, and so never ran the push step, reports nothing. That keeps an ordinary no-change bump, and any non-Dependabot pull request touching `app/build.gradle.kts`, free of a spurious check.
- A skip can land a status on a commit the pull request no longer displays, and a deleted branch's commit may be unreachable outright; the step treats 404 and 422 from the status API as a warning for that reason.
- It needs `statuses: write` and no checkout, so the half holding write credentials still never materializes the Dependabot branch.

The push step declares a `result` output at each of its exits, which is what tells those four verdicts apart.

## #864: unprefixed bot email

Author and committer email are now `41898282+github-actions[bot]@users.noreply.github.com`, from one shell variable so the two cannot drift apart. The account id was re-read from the API rather than taken from the issue.

## #863: branch-tip lookup under `set -e`

The lookup now reads the status code: 404 (the branch was deleted or recreated mid-flight) skips with a warning, like the moved-tip case immediately below it, and any other non-200 still fails loudly, since treating an API error as a deleted branch would silently drop a regeneration the pull request is waiting on.

## Tests

`scripts/test_dependabot_verification_metadata_workflows.sh` goes from 30 checks to 72, run by the `shell-tests` job. The new ones are mostly behavioral: they extract the real `run` scripts from the workflow and execute them against a mocked GitHub API, so what is tested is the shell that actually runs.

- Push step: skip marker present, ID-prefixed emails, `result` at every exit, a deleted branch (404), an API error (500), a moved branch tip, and a file that already matches.
- Reporting step: a named failure, an unattributable failure (cancellation), a description longer than the 140-character cap, all four push verdicts, an unreachable head commit, and a status API error.
- Triage step: a metadata-only commit, a bump, a mixed commit, an unrelated commit, an unreachable API, and a payload with no file list.
- The regenerate job's `timeout-minutes` check reads that job's own budget rather than the first one in the file, which is triage's.

The job-block checks no longer pipe `awk` into `grep -q` or `head -1`, which was a SIGPIPE race under `pipefail` that turned a present grant into a reported-missing one once the push job outgrew a single buffered write. That is what reddened this PR's first CI run.

## Before merging

- [ ] #883 asks for confirmation on a live Dependabot pull request that Dependabot still updates the branch after the metadata commit lands. That needs a real Dependabot pull request and cannot be asserted from the commit message alone.
- [ ] #877's verification note asks for a deliberately induced push failure on a live Dependabot pull request (for example, unsetting the PAT for one run) to confirm the commit status appears where the pull request shows it.
- [ ] Confirm on that same run that the *success* status also appears, since that is the path that clears a stale failure and it has never executed against the real API.
- [ ] Confirm on the first real run that the metadata commit renders as attributed to the `github-actions[bot]` account (#864), which is only observable on a commit GitHub has rendered.
- [ ] Confirm on the first real Dependabot pull request that exactly one regeneration run occurs per Dependabot push (#879).
